### PR TITLE
SFX-245: Integrate show/hide functionality for SAYT

### DIFF
--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -11,6 +11,6 @@ export function getDisplayCode(code: string): string {
         }
       </style>
       <h3>The code</h3>
-      <pre class="code-output"><code>${entities.encode(code)}</code></pre>
+      <pre class="code-output"><code>${ entities.encode(code) }</code></pre>
     `
   }

--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -1,0 +1,16 @@
+import { XmlEntities } from 'html-entities';
+
+const entities = new XmlEntities();
+
+export function getDisplayCode(code: string): string {
+    return `
+      <style>
+        pre.code-output {
+          padding: 15px;
+          background-color: #EEEEEE;
+        }
+      </style>
+      <h3>The code</h3>
+      <pre class="code-output"><code>${entities.encode(code)}</code></pre>
+    `
+  }

--- a/packages/web-components/@sfx/sayt/package.json
+++ b/packages/web-components/@sfx/sayt/package.json
@@ -18,5 +18,8 @@
     "directory": "packages/web-components/@sfx/sayt"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "html-entities": "^1.2.1"
+  }
 }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -66,6 +66,7 @@ export default class Sayt extends LitElement {
     super.disconnectedCallback();
 
     window.removeEventListener(SAYT_EVENT.SAYT_SHOW, this.showCorrectSayt);
+    window.removeEventListener(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, this.showCorrectSayt);
     window.removeEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.removeEventListener('click', this.processClick);
     window.removeEventListener('keypress', this.processKeyPress);

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -185,9 +185,9 @@ export default class Sayt extends LitElement {
   render() {
     return html`
       ${ this.showCloseButton ?
-        html`<a href="#" aria-label="Close" .onclick=${ this.clickCloseSayt }>
+        html`<button aria-label="Close" .onclick=${ this.clickCloseSayt }>
           ${ this.closeText }
-        </a>`
+        </button>`
         : ``
       }
       ${ this.hideAutocomplete ? '' : html`<sfx-autocomplete></sfx-autocomplete>` }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -165,7 +165,7 @@ export default class Sayt extends LitElement {
    */
   nodeInSearchBar(node: Node): boolean {
     if (!this.searchbox) return false;
-    const searchBar = document.querySelector('#' + this.searchbox);
+    const searchBar = document.getElementById(this.searchbox);
     return !!searchBar && searchBar.contains(node);
   }
 

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -95,7 +95,7 @@ export default class Sayt extends LitElement {
 
   /**
    * Makes SAYT visible if the event refers to the correct SAYT component.
-   * See isCorrectSayt().
+   * @see [[isCorrectSayt]]
    *
    * @param event An event that can contain a searchbox ID.
    */

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -19,6 +19,10 @@ export default class Sayt extends LitElement {
    * Stores the ID of the relevant search element.
    */
   @property({ type: String, reflect: true }) searchbar = '';
+  /**
+   * Customizes the text in the close button.
+   */
+  @property({ type: String }) closeText = 'Close';
 
   /**
    * Calls superclass constructor and bind methods.
@@ -174,7 +178,7 @@ export default class Sayt extends LitElement {
   render() {
     return html`
       ${ this.hideAutocomplete ? '' : html`<sfx-autocomplete></sfx-autocomplete>` }
-      <a href="#" .onclick=${this.clickCloseSayt}>Close</a>
+      <a href="#" aria-label="Close" .onclick=${this.clickCloseSayt}>${this.closeText}</a>
     `;
   }
 }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -82,6 +82,11 @@ export default class Sayt extends LitElement {
     this.visible = true;
   }
 
+  /**
+   * Makes SAYT visible if the event refers to the correct SAYT component.
+   *
+   * @param event An event that can contain a searchbar ID.
+   */
   showCorrectSayt(event: CustomEvent) {
     if (this.isCorrectSayt(event)) {
       this.showSayt();
@@ -95,12 +100,24 @@ export default class Sayt extends LitElement {
     this.visible = false;
   }
 
+  /**
+   * Hides SAYT if the event refers to the correct SAYT component.
+   *
+   * @param event An event that can contain a searchbar ID.
+   */
   hideCorrectSayt(event: CustomEvent) {
     if (this.isCorrectSayt(event)) {
       this.hideSayt();
     }
   }
 
+  /**
+   * Determines whether an event refers to the correct SAYT. This is true if
+   * either a matching `searchbar` ID is specified, or if no `searchbar` ID
+   * is specified at all.
+   *
+   * @param event An event that can contain a searchbar ID for comparison.
+   */
   isCorrectSayt(event: CustomEvent) {
     const searchbar = event.detail.searchbar;
     return searchbar === this.searchbar || searchbar === undefined;

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -1,5 +1,6 @@
 import { LitElement, customElement, html, property, PropertyValues } from 'lit-element';
 import { SAYT_EVENT } from './events';
+import { AUTOCOMPLETE_RECEIVED_RESULTS_EVENT } from '../../autocomplete/src/events';
 
 /**
  * The `sfx-sayt` component is responsible for displaying and hiding the
@@ -52,6 +53,7 @@ export default class Sayt extends LitElement {
     super.connectedCallback();
 
     window.addEventListener(SAYT_EVENT.SAYT_SHOW, this.showCorrectSayt);
+    window.addEventListener(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, this.showCorrectSayt);
     window.addEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.addEventListener('click', this.processClick);
     window.addEventListener('keypress', this.processKeyPress);

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -149,7 +149,7 @@ export default class Sayt extends LitElement {
   }
 
   /**
-   * Handles hiding SAYT on click on a close link/button (or other event).
+   * Handles hiding SAYT on click of a close link/button (or other event).
    *
    * @param event An event with a default action to be prevented.
    */

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -42,7 +42,7 @@ export default class Sayt extends LitElement {
   connectedCallback() {
     super.connectedCallback();
 
-    window.addEventListener(SAYT_EVENT.SAYT_SHOW, this.showSayt);
+    window.addEventListener(SAYT_EVENT.SAYT_SHOW, this.showCorrectSayt);
     window.addEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.addEventListener('click', this.processClick);
     window.addEventListener('keypress', this.processKeyPress);
@@ -54,7 +54,7 @@ export default class Sayt extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
 
-    window.removeEventListener(SAYT_EVENT.SAYT_SHOW, this.showSayt);
+    window.removeEventListener(SAYT_EVENT.SAYT_SHOW, this.showCorrectSayt);
     window.removeEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.removeEventListener('click', this.processClick);
     window.removeEventListener('keypress', this.processKeyPress);

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -43,7 +43,6 @@ export default class Sayt extends LitElement {
     this.hideCorrectSayt = this.hideCorrectSayt.bind(this);
     this.showCorrectSayt = this.showCorrectSayt.bind(this);
     this.isCorrectSayt = this.isCorrectSayt.bind(this);
-    this.clickCloseSayt = this.clickCloseSayt.bind(this);
   }
 
   /**
@@ -185,7 +184,7 @@ export default class Sayt extends LitElement {
   render() {
     return html`
       ${ this.showCloseButton ?
-        html`<button aria-label="Close" .onclick=${ this.clickCloseSayt }>
+        html`<button aria-label="Close" @click=${ this.clickCloseSayt }>
           ${ this.closeText }
         </button>`
         : ``

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -131,7 +131,7 @@ export default class Sayt extends LitElement {
    *
    * @param event An event that can contain a searchbox ID for comparison.
    */
-  isCorrectSayt(event: CustomEvent) {
+  isCorrectSayt(event: CustomEvent): boolean {
     const searchbox = event.detail && event.detail.searchbox;
     return this.searchbox === undefined ||
       searchbox === this.searchbox ||
@@ -165,7 +165,7 @@ export default class Sayt extends LitElement {
    * 
    * @param node The node to check for containment.
    */
-  nodeInSearchBar(node: Node) {
+  nodeInSearchBar(node: Node): boolean {
     if (!this.searchbox) return false;
     const searchBar = document.querySelector('#' + this.searchbox);
     return !!searchBar && searchBar.contains(node);

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -34,6 +34,7 @@ export default class Sayt extends LitElement {
     this.hideCorrectSayt = this.hideCorrectSayt.bind(this);
     this.showCorrectSayt = this.showCorrectSayt.bind(this);
     this.isCorrectSayt = this.isCorrectSayt.bind(this);
+    this.clickCloseSayt = this.clickCloseSayt.bind(this);
   }
 
   /**
@@ -138,6 +139,16 @@ export default class Sayt extends LitElement {
   }
 
   /**
+   * Handles hiding SAYT on click on a close link/button (or other event).
+   *
+   * @param event An event with a default action to be prevented.
+   */
+  clickCloseSayt(event: Event) {
+    event.preventDefault();
+    this.hideSayt();
+  }
+
+  /**
    * Checks whether a given node is inside of SAYT's identified search bar.
    * 
    * @param node The node to check for containment.
@@ -163,6 +174,7 @@ export default class Sayt extends LitElement {
   render() {
     return html`
       ${ this.hideAutocomplete ? '' : html`<sfx-autocomplete></sfx-autocomplete>` }
+      <a href="#" .onclick=${this.clickCloseSayt}>Close</a>
     `;
   }
 }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -119,7 +119,7 @@ export default class Sayt extends LitElement {
    * @param event An event that can contain a searchbar ID for comparison.
    */
   isCorrectSayt(event: CustomEvent) {
-    const searchbar = event.detail.searchbar;
+    const searchbar = event.detail && event.detail.searchbar;
     return this.searchbar === undefined ||
       searchbar === this.searchbar ||
       searchbar === undefined;

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -158,7 +158,7 @@ export default class Sayt extends LitElement {
   }
 
   /**
-   * Checks whether a given node is inside of SAYT's identified search bar.
+   * Checks whether a given node is inside of SAYT's identified search box.
    * 
    * @param node The node to check for containment.
    */

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -23,6 +23,10 @@ export default class Sayt extends LitElement {
    * Customizes the text in the close button.
    */
   @property({ type: String }) closeText = 'Close';
+  /**
+   * Shows a button to allow for closing SAYT manually.
+   */
+  @property({ type: Boolean }) showCloseButton = false;
 
   /**
    * Calls superclass constructor and bind methods.
@@ -177,8 +181,13 @@ export default class Sayt extends LitElement {
    */
   render() {
     return html`
+      ${ this.showCloseButton ?
+        html`<a href="#" aria-label="Close" .onclick=${this.clickCloseSayt}>
+          ${this.closeText}
+        </a>`
+        : ``
+      }
       ${ this.hideAutocomplete ? '' : html`<sfx-autocomplete></sfx-autocomplete>` }
-      <a href="#" aria-label="Close" .onclick=${this.clickCloseSayt}>${this.closeText}</a>
     `;
   }
 }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -19,7 +19,7 @@ export default class Sayt extends LitElement {
   /**
    * Stores the ID of the relevant search element.
    */
-  @property({ type: String, reflect: true }) searchbar = '';
+  @property({ type: String, reflect: true }) searchbox = '';
   /**
    * Customizes the text in the close button.
    */
@@ -97,7 +97,7 @@ export default class Sayt extends LitElement {
   /**
    * Makes SAYT visible if the event refers to the correct SAYT component.
    *
-   * @param event An event that can contain a searchbar ID.
+   * @param event An event that can contain a searchbox ID.
    */
   showCorrectSayt(event: CustomEvent) {
     if (this.isCorrectSayt(event)) {
@@ -115,7 +115,7 @@ export default class Sayt extends LitElement {
   /**
    * Hides SAYT if the event refers to the correct SAYT component.
    *
-   * @param event An event that can contain a searchbar ID.
+   * @param event An event that can contain a searchbox ID.
    */
   hideCorrectSayt(event: CustomEvent) {
     if (this.isCorrectSayt(event)) {
@@ -125,16 +125,16 @@ export default class Sayt extends LitElement {
 
   /**
    * Determines whether an event refers to the correct SAYT. This is true if
-   * a matching `searchbar` ID is specified, if the event has no `searchbar`
-   * ID specified, or if SAYT has no `searchbar` ID specified.
+   * a matching `searchbox` ID is specified, if the event has no `searchbox`
+   * ID specified, or if SAYT has no `searchbox` ID specified.
    *
-   * @param event An event that can contain a searchbar ID for comparison.
+   * @param event An event that can contain a searchbox ID for comparison.
    */
   isCorrectSayt(event: CustomEvent) {
-    const searchbar = event.detail && event.detail.searchbar;
-    return this.searchbar === undefined ||
-      searchbar === this.searchbar ||
-      searchbar === undefined;
+    const searchbox = event.detail && event.detail.searchbox;
+    return this.searchbox === undefined ||
+      searchbox === this.searchbox ||
+      searchbox === undefined;
   }
 
   /**
@@ -165,8 +165,8 @@ export default class Sayt extends LitElement {
    * @param node The node to check for containment.
    */
   nodeInSearchBar(node: Node) {
-    if (!this.searchbar) return false;
-    const searchBar = document.querySelector('#' + this.searchbar);
+    if (!this.searchbox) return false;
+    const searchBar = document.querySelector('#' + this.searchbox);
     return !!searchBar && searchBar.contains(node);
   }
 

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -38,7 +38,7 @@ export default class Sayt extends LitElement {
     this.showSayt = this.showSayt.bind(this);
     this.hideSayt = this.hideSayt.bind(this);
     this.processClick = this.processClick.bind(this);
-    this.processKeyPress = this.processKeyPress.bind(this);
+    this.processKeyEvent = this.processKeyEvent.bind(this);
     this.nodeInSearchbox = this.nodeInSearchbox.bind(this);
     this.hideCorrectSayt = this.hideCorrectSayt.bind(this);
     this.showCorrectSayt = this.showCorrectSayt.bind(this);
@@ -55,7 +55,7 @@ export default class Sayt extends LitElement {
     window.addEventListener(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, this.showCorrectSayt);
     window.addEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.addEventListener('click', this.processClick);
-    window.addEventListener('keydown', this.processKeyPress);
+    window.addEventListener('keydown', this.processKeyEvent);
   }
 
   /**
@@ -68,7 +68,7 @@ export default class Sayt extends LitElement {
     window.removeEventListener(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, this.showCorrectSayt);
     window.removeEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.removeEventListener('click', this.processClick);
-    window.removeEventListener('keydown', this.processKeyPress);
+    window.removeEventListener('keydown', this.processKeyEvent);
   }
 
   createRenderRoot() {
@@ -175,7 +175,7 @@ export default class Sayt extends LitElement {
    *
    * @param event A keyboard event used for checking which key has been pressed.
    */
-  processKeyPress(event: KeyboardEvent) {
+  processKeyEvent(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       this.hideSayt();
     }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -186,8 +186,8 @@ export default class Sayt extends LitElement {
   render() {
     return html`
       ${ this.showCloseButton ?
-        html`<a href="#" aria-label="Close" .onclick=${this.clickCloseSayt}>
-          ${this.closeText}
+        html`<a href="#" aria-label="Close" .onclick=${ this.clickCloseSayt }>
+          ${ this.closeText }
         </a>`
         : ``
       }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -162,6 +162,7 @@ export default class Sayt extends LitElement {
    * @param node The node to check for containment.
    */
   nodeInSearchBar(node: Node) {
+    if (!this.searchbar) return false;
     const searchBar = document.querySelector('#' + this.searchbar);
     return !!searchBar && searchBar.contains(node);
   }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -23,11 +23,11 @@ export default class Sayt extends LitElement {
   /**
    * Customizes the text in the close button.
    */
-  @property({ type: String }) closeText = 'Close';
+  @property({ type: String, reflect: true }) closeText = 'Close';
   /**
    * Shows a button to allow for closing SAYT manually.
    */
-  @property({ type: Boolean }) showCloseButton = false;
+  @property({ type: Boolean, reflect: true }) showCloseButton = false;
 
   /**
    * Calls superclass constructor and bind methods.

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -133,9 +133,7 @@ export default class Sayt extends LitElement {
    */
   isCorrectSayt(event: CustomEvent): boolean {
     const searchbox = event.detail && event.detail.searchbox;
-    return this.searchbox === undefined ||
-      searchbox === this.searchbox ||
-      searchbox === undefined;
+    return !searchbox || !this.searchbox || searchbox === this.searchbox;
   }
 
   /**

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -55,7 +55,7 @@ export default class Sayt extends LitElement {
     window.addEventListener(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, this.showCorrectSayt);
     window.addEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.addEventListener('click', this.processClick);
-    window.addEventListener('keypress', this.processKeyPress);
+    window.addEventListener('keydown', this.processKeyPress);
   }
 
   /**
@@ -68,7 +68,7 @@ export default class Sayt extends LitElement {
     window.removeEventListener(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, this.showCorrectSayt);
     window.removeEventListener(SAYT_EVENT.SAYT_HIDE, this.hideCorrectSayt);
     window.removeEventListener('click', this.processClick);
-    window.removeEventListener('keypress', this.processKeyPress);
+    window.removeEventListener('keydown', this.processKeyPress);
   }
 
   createRenderRoot() {

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -113,14 +113,16 @@ export default class Sayt extends LitElement {
 
   /**
    * Determines whether an event refers to the correct SAYT. This is true if
-   * either a matching `searchbar` ID is specified, or if no `searchbar` ID
-   * is specified at all.
+   * a matching `searchbar` ID is specified, if the event has no `searchbar`
+   * ID specified, or if SAYT has no `searchbar` ID specified.
    *
    * @param event An event that can contain a searchbar ID for comparison.
    */
   isCorrectSayt(event: CustomEvent) {
     const searchbar = event.detail.searchbar;
-    return searchbar === this.searchbar || searchbar === undefined;
+    return this.searchbar === undefined ||
+      searchbar === this.searchbar ||
+      searchbar === undefined;
   }
 
   /**

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -39,7 +39,7 @@ export default class Sayt extends LitElement {
     this.hideSayt = this.hideSayt.bind(this);
     this.processClick = this.processClick.bind(this);
     this.processKeyPress = this.processKeyPress.bind(this);
-    this.nodeInSearchBar = this.nodeInSearchBar.bind(this);
+    this.nodeInSearchbox = this.nodeInSearchbox.bind(this);
     this.hideCorrectSayt = this.hideCorrectSayt.bind(this);
     this.showCorrectSayt = this.showCorrectSayt.bind(this);
     this.isCorrectSayt = this.isCorrectSayt.bind(this);
@@ -140,9 +140,9 @@ export default class Sayt extends LitElement {
    * 
    * @param event The click event.
    */
-  processClick(event: Event) {
+  processClick(event: MouseEvent) {
     const target = event.target as Node;
-    if (this.contains(target) || this.nodeInSearchBar(target)) return;
+    if (this.contains(target) || this.nodeInSearchbox(target)) return;
 
     this.hideSayt();
   }
@@ -162,15 +162,18 @@ export default class Sayt extends LitElement {
    * 
    * @param node The node to check for containment.
    */
-  nodeInSearchBar(node: Node): boolean {
+  nodeInSearchbox(node: Node): boolean {
     if (!this.searchbox) return false;
-    const searchBar = document.getElementById(this.searchbox);
-    return !!searchBar && searchBar.contains(node);
+    const searchbox = document.getElementById(this.searchbox);
+    return !!searchbox && searchbox.contains(node);
   }
 
   /**
-   * Processes a keypress event in order to close SAYT under the right conditions.
-   * @param event 
+   * Processes a keyboard event in order to close SAYT when certain keys are pressed.
+   * Namely:
+   *   - Escape
+   *
+   * @param event A keyboard event used for checking which key has been pressed.
    */
   processKeyPress(event: KeyboardEvent) {
     if (event.key === 'Escape') {
@@ -187,7 +190,7 @@ export default class Sayt extends LitElement {
         html`<button aria-label="Close" @click=${ this.clickCloseSayt }>
           ${ this.closeText }
         </button>`
-        : ``
+        : ''
       }
       ${ this.hideAutocomplete ? '' : html`<sfx-autocomplete></sfx-autocomplete>` }
     `;

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -96,6 +96,7 @@ export default class Sayt extends LitElement {
 
   /**
    * Makes SAYT visible if the event refers to the correct SAYT component.
+   * See isCorrectSayt().
    *
    * @param event An event that can contain a searchbox ID.
    */

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -173,7 +173,7 @@ export default class Sayt extends LitElement {
    * @param event 
    */
   processKeyPress(event: KeyboardEvent) {
-    if (event.key === "Escape") {
+    if (event.key === 'Escape') {
       this.hideSayt();
     }
   }

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -6,6 +6,8 @@ import '../src/index.ts';
 
 const entities = new XmlEntities();
 
+// @TODO allow for sending event with searchbar ID. This should allow for one 
+// story's events to not affect another story.
 const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_received_results',
   { detail: [
       { "title": "Brands", "items": [{ "label": "Cats" }, { "label": "Dogs" }] },
@@ -68,10 +70,10 @@ storiesOf('Components|SAYT', module)
     } 
   })
   // @TODO Remove these setTimeouts when opening a new story
-  .add('Responding to Events - sayt_show & sayt_hide ', () => {
+  .add('Responding to Events - sayt_hide & sayt_show ', () => {
     emitEventInFuture(autocompleteDataReceivedEvent, 100);
-    emitEventInFuture(new Event('sfx::sayt_show'), 2000);
-    emitEventInFuture(new Event('sfx::sayt_hide'), 4000);
+    emitEventInFuture(new Event('sfx::sayt_hide'), 2000);
+    emitEventInFuture(new Event('sfx::sayt_show'), 4000);
 
     const sayt = getSayt('', false);
     return `
@@ -82,8 +84,9 @@ storiesOf('Components|SAYT', module)
     notes: {
       markdown:`
         # Search As You Type (SAYT)
-        - Receiving sayt_show event after 2 seconds.
-        - Receiving sayt_hide event after 4 seconds.
+        - Show automatically once sub-component Autocomplete receives results.
+        - Receiving sayt_hide event after 2 seconds.
+        - Receiving sayt_show event after 4 seconds.
       `
     }
   })

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -78,7 +78,7 @@ storiesOf('Components|SAYT', module)
     emitEventInFuture(autocompleteDataReceivedEvent, 100);
 
     const input = `<input type="text" id="search-box" placeholder="Search here" />`;
-    const sayt = getSayt();
+    const sayt = getSayt('search-box');
     return `
       ${ input }
       <br />

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -18,11 +18,12 @@ function getSayt(searchbox = '', showSayt = true): string {
   const closeText = text('Close link text', 'Close');
   const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
 
-  return `<sfx-sayt${ searchbox ? ` searchbox="${ searchbox }"` : '' }
-  closetext="${ closeText }"${ showCloseButton ? `
-  ${ showCloseButton }` : ''}${ showAttribute ? `
-  ${ showAttribute }` : ''}
-></sfx-sayt>`;
+  return '<sfx-sayt\n'
+    + (searchbox ? `  searchbox="${searchbox}"\n` : '')
+    + `  closetext="${closeText}"\n`
+    + (showCloseButton ? `  ${showCloseButton}\n` : '')
+    + (showAttribute ? `  ${showAttribute}\n` : '')
+    + '></sfx-sayt>';
 }
 
 function emitEventInFuture(event, timeout = 100) {
@@ -76,14 +77,13 @@ storiesOf('Components|SAYT', module)
   .add('SAYT with simple search input', () => {
     emitEventInFuture(autocompleteDataReceivedEvent, 100);
 
-    const input = `<input type="text" id="search-bar" placeholder="Search here" />`;
+    const input = `<input type="text" id="search-box" placeholder="Search here" />`;
     const sayt = getSayt();
     return `
       ${ input }
       <br />
       ${ sayt }
-      ${ getDisplayCode(`${ input }
-${ sayt }`) }
+      ${ getDisplayCode(`${ input }\n${ sayt }`) }
     `
   }, {
     notes: {
@@ -97,10 +97,10 @@ ${ sayt }`) }
   .add('SAYT with multiple search inputs', () => {
     emitEventInFuture(autocompleteDataReceivedEvent, 100);
 
-    const input1 = `<input type="text" id="search-bar1" placeholder="Search here" />`;
-    const input2 = `<input type="text" id="search-bar2" placeholder="Or search here" />`;
-    const sayt1 = getSayt('search-bar1');
-    const sayt2 = getSayt('search-bar2');
+    const input1 = `<input type="text" id="search-box1" placeholder="Search here" />`;
+    const input2 = `<input type="text" id="search-box2" placeholder="Or search here" />`;
+    const sayt1 = getSayt('search-box1');
+    const sayt2 = getSayt('search-box2');
 
     return `${ input1 }<br />
 ${ sayt1 }

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -1,8 +1,7 @@
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
-
-import '../src/index.ts';
-import { getDisplayCode } from '../../../../../.storybook/common';
+import { getDisplayCode } from '../test/utils';
+import '../src/index';
 
 // @TODO allow for sending event with searchbox ID. This should allow for one
 // story's events to not affect another story.

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -14,13 +14,18 @@ storiesOf('Components|SAYT', module)
   .addDecorator(withKnobs)
   .add('Default', () => {
     const showAttribute = boolean('visible', true) ? 'visible' : '';
-    const closeText = text('Close link text', 'Close');
+    const closeText = text('Close button text', 'Close');
+    const showCloseButton = boolean('Show Close button', false) ? 'showclosebutton' : '';
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
     }, 100);
 
-    return `<sfx-sayt ${ showAttribute } closetext="${closeText}"></sfx-sayt>`
+    return `<sfx-sayt
+      closetext="${closeText}"
+      ${ showCloseButton }
+      ${ showAttribute }
+    ></sfx-sayt>`
   }, {
     notes: {
       markdown: `
@@ -60,6 +65,7 @@ storiesOf('Components|SAYT', module)
   .add('SAYT with simple search input', () => {
     const showAttribute = boolean('visible', true) ? 'visible' : '';
     const closeText = text('Close link text', 'Close');
+    const showCloseButton = boolean('Show Close button', false) ? 'showclosebutton' : '';
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
@@ -69,8 +75,8 @@ storiesOf('Components|SAYT', module)
       <input type="text" id="search-bar" placeholder="Search here" />
       <br />
       <sfx-sayt
-        searchbar="search-bar"
         closetext="${closeText}"
+        ${ showCloseButton }
         ${ showAttribute }
       ></sfx-sayt>
     `

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -15,7 +15,7 @@ storiesOf('Components|SAYT', module)
   .add('Default', () => {
     const showAttribute = boolean('visible', true) ? 'visible' : '';
     const closeText = text('Close button text', 'Close');
-    const showCloseButton = boolean('Show Close button', false) ? 'showclosebutton' : '';
+    const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
@@ -65,7 +65,7 @@ storiesOf('Components|SAYT', module)
   .add('SAYT with simple search input', () => {
     const showAttribute = boolean('visible', true) ? 'visible' : '';
     const closeText = text('Close link text', 'Close');
-    const showCloseButton = boolean('Show Close button', false) ? 'showclosebutton' : '';
+    const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
@@ -91,6 +91,10 @@ storiesOf('Components|SAYT', module)
   .add('SAYT with multiple search inputs', () => {
     const showAttribute1 = boolean('visible (first)', true) ? 'visible' : '';
     const showAttribute2 = boolean('visible (second)', true) ? 'visible' : '';
+    const closeText1 = text('Close link text (first)', 'Close');
+    const closeText2 = text('Close link text (second)', 'Close');
+    const showCloseButton1 = boolean('Show Close button (first)', true) ? 'showclosebutton' : '';
+    const showCloseButton2 = boolean('Show Close button (second)', true) ? 'showclosebutton' : '';
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
@@ -99,11 +103,21 @@ storiesOf('Components|SAYT', module)
     return `
       <input type="text" id="search-bar1" placeholder="Search here" />
       <br />
-      <sfx-sayt searchbar="search-bar1" ${ showAttribute1 }></sfx-sayt>
+      <sfx-sayt
+        searchbar="search-bar1"
+        closetext="${closeText1}"
+        ${ showCloseButton1 }
+        ${ showAttribute1 }
+      ></sfx-sayt>
       <hr />
       <input type="text" id="search-bar2" placeholder="Or search here" />
       <br />
-      <sfx-sayt searchbar="search-bar2" ${ showAttribute2 }></sfx-sayt>
+      <sfx-sayt
+        searchbar="search-bar2"
+        closetext="${closeText2}"
+        ${ showCloseButton2 }
+        ${ showAttribute2 }
+      ></sfx-sayt>
     `
   }, {
     notes: {

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -90,7 +90,8 @@ ${ sayt }`) }
     notes: {
       markdown:`
         #Search As You Type (SAYT)
-        Demonstrating initially visible SAYT for showing/hiding.
+        Demonstrating SAYT working with a standard input element,
+        rather than our Seach component.
       `
     }
   })
@@ -118,7 +119,20 @@ ${ sayt2 }`) }
     notes: {
       markdown:`
         #Search As You Type (SAYT)
-        Demonstrating multiple SAYT components. This proves that each Search/SAYT pair acts independently.
-      `
-    }
+        Demonstrating multiple SAYT components.This proves that eachSearch/SAYT
+        pair acts independently.
+
+        Note that it is virtually impossible to open two SAYT windows simultaneously.
+        Nevertheless, this proves two open SAYT components are acting independently.
+
+        * Clicking anywhere but either of the SAYT components should result in both
+        being closed due to lost focus.
+        * Clicking on a given SAYT component should leave that component
+        open, and any other SAYT component would be closed.
+        * Clicking \`Close\` on a given SAYT will close both SAYTs because:
+
+          * You have closed the SAYT for which you have clicked Close.
+          * The other SAYT has closed due to lost focus.
+      `,
+    },
   });

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -19,9 +19,9 @@ function getSayt(searchbar='', showSayt=true): string {
   const closeText = text('Close link text', 'Close');
   const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
 
-  return `<sfx-sayt${searchbar ? ` searchbar="${searchbar}"` : ''}
-  closetext="${closeText}"${showCloseButton ? `
-  ${ showCloseButton }` : ''}${showAttribute ? `
+  return `<sfx-sayt${ searchbar ? ` searchbar="${ searchbar }"` : '' }
+  closetext="${ closeText }"${ showCloseButton ? `
+  ${ showCloseButton }` : ''}${ showAttribute ? `
   ${ showAttribute }` : ''}
 ></sfx-sayt>`;
 }
@@ -39,9 +39,9 @@ storiesOf('Components|SAYT', module)
 
     const sayt = getSayt();
     return `
-      ${sayt}
+      ${ sayt }
 
-      ${getDisplayCode(sayt)}
+      ${ getDisplayCode(sayt) }
     `;
   }, {
     notes: {
@@ -61,8 +61,8 @@ storiesOf('Components|SAYT', module)
 
     const sayt = getSayt('', false);
     return `
-      ${sayt}
-      ${getDisplayCode(sayt)}
+      ${ sayt }
+      ${ getDisplayCode(sayt) }
     `;
   }, {
     notes: {
@@ -80,11 +80,11 @@ storiesOf('Components|SAYT', module)
     const input = `<input type="text" id="search-bar" placeholder="Search here" />`;
     const sayt = getSayt();
     return `
-      ${input}
+      ${ input }
       <br />
-      ${sayt}
-      ${getDisplayCode(`${input}
-${sayt}`)}
+      ${ sayt }
+      ${ getDisplayCode(`${ input }
+${ sayt }`) }
     `
   }, {
     notes: {
@@ -102,18 +102,18 @@ ${sayt}`)}
     const sayt1 = getSayt('search-bar1');
     const sayt2 = getSayt('search-bar2');
 
-    return `${input1}<br />
-${sayt1}
+    return `${ input1 }<br />
+${ sayt1 }
 <hr />
-${input2}<br />
-${sayt2}
+${ input2 }<br />
+${ sayt2 }
 
-${getDisplayCode(`${input1}
-${sayt1}
+${ getDisplayCode(`${ input1 }
+${ sayt1 }
 
-${input2}
-${sayt2}`)}
-    `
+${ input2 }
+${ sayt2 }`) }
+    `;
   }, {
     notes: {
       markdown:`

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -13,13 +13,14 @@ const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_receive
 storiesOf('Components|SAYT', module)
   .addDecorator(withKnobs)
   .add('Default', () => {
-    const showAttribute = boolean('visible', false) ? 'visible' : '';
+    const showAttribute = boolean('visible', true) ? 'visible' : '';
+    const closeText = text('Close link text', 'Close');
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
     }, 100);
 
-    return `<sfx-sayt ${ showAttribute }></sfx-sayt>`
+    return `<sfx-sayt ${ showAttribute } closetext="${closeText}"></sfx-sayt>`
   }, {
     notes: {
       markdown: `

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -6,7 +6,7 @@ import '../src/index.ts';
 
 const entities = new XmlEntities();
 
-// @TODO allow for sending event with searchbar ID. This should allow for one 
+// @TODO allow for sending event with searchbar ID. This should allow for one
 // story's events to not affect another story.
 const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_received_results',
   { detail: [

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -8,7 +8,7 @@ import '../src/index';
 const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_received_results',
   { detail: [
       { "title": "Brands", "items": [{ "label": "Cats" }, { "label": "Dogs" }] },
-      { "title": "default", "items": [{ "label": "Cars" }, { "label": "Bikes" }] }
+      { "title": "", "items": [{ "label": "Cars" }, { "label": "Bikes" }] }
     ],
     bubbles: true }
 );

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -13,7 +13,7 @@ const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_receive
     bubbles: true }
 );
 
-function getSayt(searchbox='', showSayt=true): string {
+function getSayt(searchbox = '', showSayt = true): string {
   const showAttribute = boolean('visible', showSayt) ? 'visible' : '';
   const closeText = text('Close link text', 'Close');
   const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
@@ -25,7 +25,7 @@ function getSayt(searchbox='', showSayt=true): string {
 ></sfx-sayt>`;
 }
 
-function emitEventInFuture(event, timeout=100) {
+function emitEventInFuture(event, timeout = 100) {
   setTimeout(() => {
     window.dispatchEvent(event);
   }, timeout);

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -4,7 +4,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import '../src/index.ts';
 import { getDisplayCode } from '../../../../../.storybook/common';
 
-// @TODO allow for sending event with searchbar ID. This should allow for one
+// @TODO allow for sending event with searchbox ID. This should allow for one
 // story's events to not affect another story.
 const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_received_results',
   { detail: [
@@ -14,12 +14,12 @@ const autocompleteDataReceivedEvent = new CustomEvent('sfx::autocomplete_receive
     bubbles: true }
 );
 
-function getSayt(searchbar='', showSayt=true): string {
+function getSayt(searchbox='', showSayt=true): string {
   const showAttribute = boolean('visible', showSayt) ? 'visible' : '';
   const closeText = text('Close link text', 'Close');
   const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
 
-  return `<sfx-sayt${ searchbar ? ` searchbar="${ searchbar }"` : '' }
+  return `<sfx-sayt${ searchbox ? ` searchbox="${ searchbox }"` : '' }
   closetext="${ closeText }"${ showCloseButton ? `
   ${ showCloseButton }` : ''}${ showAttribute ? `
   ${ showAttribute }` : ''}

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -118,7 +118,7 @@ ${ sayt2 }`) }
     notes: {
       markdown:`
         #Search As You Type (SAYT)
-        Demonstrating multiple SAYT components.This proves that eachSearch/SAYT
+        Demonstrating multiple SAYT components.This proves that each Search/SAYT
         pair acts independently.
 
         Note that it is virtually impossible to open two SAYT windows simultaneously.

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -59,6 +59,7 @@ storiesOf('Components|SAYT', module)
   })
   .add('SAYT with simple search input', () => {
     const showAttribute = boolean('visible', true) ? 'visible' : '';
+    const closeText = text('Close link text', 'Close');
 
     setTimeout(() => {
       window.dispatchEvent(autocompleteDataReceivedEvent);
@@ -67,7 +68,11 @@ storiesOf('Components|SAYT', module)
     return `
       <input type="text" id="search-bar" placeholder="Search here" />
       <br />
-      <sfx-sayt searchbar="search-bar" ${ showAttribute }></sfx-sayt>
+      <sfx-sayt
+        searchbar="search-bar"
+        closetext="${closeText}"
+        ${ showAttribute }
+      ></sfx-sayt>
     `
   }, {
     notes: {

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
-import { XmlEntities } from 'html-entities';
 
 import '../src/index.ts';
-
-const entities = new XmlEntities();
+import { getDisplayCode } from '../../../../../.storybook/common';
 
 // @TODO allow for sending event with searchbar ID. This should allow for one
 // story's events to not affect another story.
@@ -26,20 +24,6 @@ function getSayt(searchbar='', showSayt=true): string {
   ${ showCloseButton }` : ''}${showAttribute ? `
   ${ showAttribute }` : ''}
 ></sfx-sayt>`;
-}
-
-// @TODO Move this CSS elsewhere. Should be loaded globally.
-function getDisplayCode(code: string): string {
-  return `
-    <style>
-      pre.code-output {
-        padding: 15px;
-        background-color: #EEEEEE;
-      }
-    </style>
-    <h3>The code</h3>
-    <pre class="code-output"><code>${entities.encode(code)}</code></pre>
-  `
 }
 
 function emitEventInFuture(event, timeout=100) {

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -1,4 +1,4 @@
-import { expect, spy, stub } from './utils';
+import { expect, sinon, spy, stub } from './utils';
 import { TemplateResult } from 'lit-element';
 import Sayt from '../src/sayt';
 import { SAYT_EVENT } from '../src/events';
@@ -181,7 +181,7 @@ describe('Sayt Component', () => {
 
       sayt.processClick(event);
 
-      expect(sayt.contains).to.be.calledWith(node);
+      expect(sayt.contains).to.be.calledWith(sinon.match.same(node));
       expect(sayt.hideSayt).to.be.called;
     });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -144,6 +144,15 @@ describe('Sayt Component', () => {
 
       expect(result).to.be.false;
     });
+
+    it('should return true if event specifies a searchbar but SAYT has none specified', () => {
+      sayt.searchbar = undefined;
+      const event = { detail: { searchbar: 'some-searchbar-id' } };
+
+      const result = sayt.isCorrectSayt(event);
+
+      expect(result).to.be.true;
+    });
   });
 
   describe('render()', () => {

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -240,7 +240,7 @@ describe('Sayt Component', () => {
 
       expect(getElementById).to.be.calledWith('searchbox-id');
       expect(searchbox.contains).to.be.calledWith('node');
-      expect(result).to.equal(true);
+      expect(result).to.be.true;
     });
 
     it('should return false if given node is not contained in the search bar', () => {
@@ -254,7 +254,7 @@ describe('Sayt Component', () => {
 
       expect(getElementById).to.be.calledWith('searchbox-id');
       expect(searchbox.contains).to.be.calledWith('node');
-      expect(result).to.equal(false);
+      expect(result).to.be.false;
     });
 
     it('should return false if there is no search bar on the page', () => {
@@ -267,12 +267,13 @@ describe('Sayt Component', () => {
       expect(getElementById).to.be.calledWith('searchbox-id');
     });
 
-    it('should not query for searchbox if this.searchbox is not set', () => {
+    it('should return false and avoid querying for searchbox if this.searchbox is not set', () => {
       sayt.searchbox = undefined;
       const getElementById = stub(document, 'getElementById');
 
-      sayt.nodeInSearchBar('node');
+      const result = sayt.nodeInSearchBar('node');
 
+      expect(result).to.be.false;
       expect(getElementById).to.not.be.called;
     });
   });

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -69,30 +69,6 @@ describe('Sayt Component', () => {
     });
   });
 
-  describe('hideCorrectSayt()', () => {
-    it('should call hideSayt() when event specifies correct searchbar ID ', () => {
-      const hideSayt = stub(sayt, 'hideSayt');
-      const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(true);
-      const event = {};
-
-      sayt.hideCorrectSayt(event);
-
-      expect(isCorrectSayt).to.be.calledOnceWith(event);
-      expect(hideSayt).to.be.calledOnce;
-    });
-
-    it('should not call hideSayt() when event specifies wrong searchbar ID', () => {
-      const hideSayt = stub(sayt, 'hideSayt');
-      const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(false);
-      const event = {};
-
-      sayt.hideCorrectSayt(event);
-
-      expect(isCorrectSayt).to.be.calledOnceWith(event);
-      expect(hideSayt).to.not.be.called;
-    });
-  });
-
   describe('showCorrectSayt()', () => {
     it('should call showSayt() when event specifies correct searchbar ID ', () => {
       const showSayt = stub(sayt, 'showSayt');
@@ -114,6 +90,30 @@ describe('Sayt Component', () => {
 
       expect(isCorrectSayt).to.be.calledOnceWith(event);
       expect(showSayt).to.not.be.called;
+    });
+  });
+
+  describe('hideCorrectSayt()', () => {
+    it('should call hideSayt() when event specifies correct searchbar ID ', () => {
+      const hideSayt = stub(sayt, 'hideSayt');
+      const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(true);
+      const event = {};
+
+      sayt.hideCorrectSayt(event);
+
+      expect(isCorrectSayt).to.be.calledOnceWith(event);
+      expect(hideSayt).to.be.calledOnce;
+    });
+
+    it('should not call hideSayt() when event specifies wrong searchbar ID', () => {
+      const hideSayt = stub(sayt, 'hideSayt');
+      const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(false);
+      const event = {};
+
+      sayt.hideCorrectSayt(event);
+
+      expect(isCorrectSayt).to.be.calledOnceWith(event);
+      expect(hideSayt).to.not.be.called;
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -171,11 +171,11 @@ describe('Sayt Component', () => {
 
     beforeEach(() => {
       event = { target: node };
-      sayt.nodeInSearchBar = () => false;
     });
 
     it('should hide SAYT if the event target is nowhere relevant', () => {
-      sayt.contains = stub().returns(false);
+      stub(sayt, 'contains').returns(false);
+      stub(sayt, 'nodeInSearchBar').returns(false);
       sayt.hideSayt = spy();
 
       sayt.processClick(event);
@@ -185,7 +185,7 @@ describe('Sayt Component', () => {
     });
 
     it('should not SAYT if the event target is contained by SAYT', () => {
-      sayt.contains = stub().returns(true);
+      stub(sayt, 'contains').returns(true);
       sayt.hideSayt = spy();
 
       sayt.processClick(event);
@@ -195,8 +195,8 @@ describe('Sayt Component', () => {
     });
 
     it('should not hide SAYT if the event target is the provided search box', () => {
-      sayt.contains = stub().returns(false);
-      sayt.nodeInSearchBar = stub().returns(true);
+      stub(sayt, 'contains').returns(false);
+      stub(sayt, 'nodeInSearchBar').returns(true);
       sayt.hideSayt = spy();
 
       sayt.processClick(event);

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -267,13 +267,13 @@ describe('Sayt Component', () => {
       expect(getElementById).to.be.calledWith('searchbox-id');
     });
 
-    it('should not call document.querySelector() if this.searchbox is not set', () => {
+    it('should not query for searchbox if this.searchbox is not set', () => {
       sayt.searchbox = undefined;
-      const querySelector = stub(document, 'querySelector');
+      const getElementById = stub(document, 'getElementById');
 
       sayt.nodeInSearchBar('node');
 
-      expect(querySelector).to.not.be.called;
+      expect(getElementById).to.not.be.called;
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -16,7 +16,7 @@ describe('Sayt Component', () => {
 
       sayt.connectedCallback();
 
-      expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showSayt);
+      expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showCorrectSayt);
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(addEventListener).to.be.calledWith('click', sayt.processClick);
       expect(addEventListener).to.be.calledWith('keypress', sayt.processKeyPress);
@@ -30,7 +30,7 @@ describe('Sayt Component', () => {
 
       sayt.disconnectedCallback();
 
-      expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showSayt);
+      expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showCorrectSayt);
       expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(removeEventListener).to.be.calledWith('click', sayt.processClick);
       expect(removeEventListener).to.be.calledWith('keypress', sayt.processKeyPress);

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -222,12 +222,12 @@ describe('Sayt Component', () => {
       const searchbox = {
         contains: stub().returns(true),
       };
-      const querySelector = stub(document, 'querySelector').callsFake(() => searchbox);
+      const getElementById = stub(document, 'getElementById').callsFake(() => searchbox);
       sayt.searchbox = 'searchbox-id';
 
       const result = sayt.nodeInSearchBar('node');
 
-      expect(querySelector).to.be.calledWith('#searchbox-id');
+      expect(getElementById).to.be.calledWith('searchbox-id');
       expect(searchbox.contains).to.be.calledWith('node');
       expect(result).to.equal(true);
     });
@@ -236,12 +236,12 @@ describe('Sayt Component', () => {
       const searchbox = {
         contains: stub().returns(false),
       };
-      const querySelector = stub(document, 'querySelector').callsFake(() => searchbox);
+      const getElementById = stub(document, 'getElementById').callsFake(() => searchbox);
       sayt.searchbox = 'searchbox-id';
 
       const result = sayt.nodeInSearchBar('node');
 
-      expect(querySelector).to.be.calledWith('#searchbox-id');
+      expect(getElementById).to.be.calledWith('searchbox-id');
       expect(searchbox.contains).to.be.calledWith('node');
       expect(result).to.equal(false);
     });

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -131,7 +131,7 @@ describe('Sayt Component', () => {
     });
 
     it('should return true if event does not provide a searchbox ID', () => {
-      const searchbox = sayt.searchbox = 'some-searchbox-id';
+      sayt.searchbox = 'some-searchbox-id';
       const event = { detail: {} };
 
       const result = sayt.isCorrectSayt(event);
@@ -279,24 +279,24 @@ describe('Sayt Component', () => {
   describe('processKeyPress()', () => {
     it('should hide SAYT when pressing escape', () => {
       const event: any = { key: "Escape" };
-      sayt.hideSayt = spy();
+      const hideSayt = stub(sayt, 'hideSayt');
 
       sayt.processKeyPress(event);
 
-      expect(sayt.hideSayt).to.be.called;
+      expect(hideSayt).to.be.called;
     });
 
     it('should not hide SAYT when pressing any character other than escape', () => {
       const event: any = { key: "j" };
       const event2: any = { key: "Enter" };
       const event3: any = { key: "Space" };
-      sayt.hideSayt = spy();
+      const hideSayt = stub(sayt, 'hideSayt');
 
       sayt.processKeyPress(event);
       sayt.processKeyPress(event2);
       sayt.processKeyPress(event3);
 
-      expect(sayt.hideSayt).to.not.be.called;
+      expect(hideSayt).to.not.be.called;
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -176,7 +176,7 @@ describe('Sayt Component', () => {
     it('should hide SAYT if the event target is nowhere relevant', () => {
       stub(sayt, 'contains').returns(false);
       stub(sayt, 'nodeInSearchBar').returns(false);
-      sayt.hideSayt = spy();
+      stub(sayt, 'hideSayt');
 
       sayt.processClick(event);
 
@@ -186,7 +186,7 @@ describe('Sayt Component', () => {
 
     it('should not SAYT if the event target is contained by SAYT', () => {
       stub(sayt, 'contains').returns(true);
-      sayt.hideSayt = spy();
+      stub(sayt, 'hideSayt');
 
       sayt.processClick(event);
 
@@ -197,7 +197,7 @@ describe('Sayt Component', () => {
     it('should not hide SAYT if the event target is the provided search box', () => {
       stub(sayt, 'contains').returns(false);
       stub(sayt, 'nodeInSearchBar').returns(true);
-      sayt.hideSayt = spy();
+      stub(sayt, 'hideSayt');
 
       sayt.processClick(event);
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -249,6 +249,15 @@ describe('Sayt Component', () => {
 
       expect(result).to.be.false;
     });
+
+    it('should not call document.querySelector() if this.searchbar is not set', () => {
+      sayt.searchbar = undefined;
+      const querySelector = stub(document, 'querySelector');
+
+      sayt.nodeInSearchBar('node');
+
+      expect(querySelector).to.not.be.called;
+    });
   });
 
   describe('processKeyPress()', () => {

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -230,7 +230,7 @@ describe('Sayt Component', () => {
   });
 
   describe('nodeInSearchbox()', () => {
-    it('should return true if given node is contained in the search bar', () => {
+    it('should return true if given node is contained in the search box', () => {
       const searchbox = {
         contains: spy(() => true),
       };
@@ -244,7 +244,7 @@ describe('Sayt Component', () => {
       expect(result).to.be.true;
     });
 
-    it('should return false if given node is not contained in the search bar', () => {
+    it('should return false if given node is not contained in the search box', () => {
       const searchbox = {
         contains: stub().returns(false),
       };
@@ -258,7 +258,7 @@ describe('Sayt Component', () => {
       expect(result).to.be.false;
     });
 
-    it('should return false if there is no search bar on the page', () => {
+    it('should return false if there is no search box on the page', () => {
       const getElementById = stub(document, 'getElementById').returns(null);
       sayt.searchbox = 'searchbox-id';
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -278,4 +278,25 @@ describe('Sayt Component', () => {
       expect(sayt.hideSayt).to.not.be.called;
     });
   });
+
+  describe('clickCloseSayt()', () => {
+    it('should close SAYT when activated', () => {
+      const hideSayt = stub(sayt, 'hideSayt');
+      const event = { preventDefault: () => null };
+
+      sayt.clickCloseSayt(event);
+
+      expect(hideSayt).to.be.calledOnce;
+    });
+
+    it('should prevent the default event action when activated', () => {
+      stub(sayt, 'hideSayt');
+      const preventDefault = spy();
+      const event = { preventDefault };
+
+      sayt.clickCloseSayt(event);
+
+      expect(preventDefault).to.be.calledOnce;
+    });
+  });
 });

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -21,7 +21,7 @@ describe('Sayt Component', () => {
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(addEventListener).to.be.calledWith('click', sayt.processClick);
       expect(addEventListener).to.be.calledWith('keypress', sayt.processKeyPress);
-      expect(addEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT);
+      expect(addEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, sayt.showCorrectSayt);
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -208,7 +208,7 @@ describe('Sayt Component', () => {
   });
 
   describe('clickCloseSayt()', () => {
-    it('should close SAYT when activated', () => {
+    it('should close SAYT', () => {
       const hideSayt = stub(sayt, 'hideSayt');
       const event = { preventDefault: () => null };
 
@@ -217,10 +217,10 @@ describe('Sayt Component', () => {
       expect(hideSayt).to.be.calledOnce;
     });
 
-    it('should prevent the default event action when activated', () => {
-      stub(sayt, 'hideSayt');
+    it('should prevent the default event action', () => {
       const preventDefault = spy();
       const event = { preventDefault };
+      stub(sayt, 'hideSayt');
 
       sayt.clickCloseSayt(event);
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -20,7 +20,7 @@ describe('Sayt Component', () => {
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showCorrectSayt);
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(addEventListener).to.be.calledWith('click', sayt.processClick);
-      expect(addEventListener).to.be.calledWith('keydown', sayt.processKeyPress);
+      expect(addEventListener).to.be.calledWith('keydown', sayt.processKeyEvent);
       expect(addEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, sayt.showCorrectSayt);
     });
   });
@@ -36,7 +36,7 @@ describe('Sayt Component', () => {
       expect(removeEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, sayt.showCorrectSayt);
       expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(removeEventListener).to.be.calledWith('click', sayt.processClick);
-      expect(removeEventListener).to.be.calledWith('keydown', sayt.processKeyPress);
+      expect(removeEventListener).to.be.calledWith('keydown', sayt.processKeyEvent);
     });
   });
 
@@ -185,7 +185,7 @@ describe('Sayt Component', () => {
       expect(sayt.hideSayt).to.be.called;
     });
 
-    it('should not SAYT if the event target is contained by SAYT', () => {
+    it('should not hide SAYT if the event target is contained by SAYT', () => {
       stub(sayt, 'contains').returns(true);
       stub(sayt, 'hideSayt');
 
@@ -277,12 +277,12 @@ describe('Sayt Component', () => {
     });
   });
 
-  describe('processKeyPress()', () => {
+  describe('processKeyEvent()', () => {
     it('should hide SAYT when pressing escape', () => {
       const event: any = { key: "Escape" };
       const hideSayt = stub(sayt, 'hideSayt');
 
-      sayt.processKeyPress(event);
+      sayt.processKeyEvent(event);
 
       expect(hideSayt).to.be.called;
     });
@@ -293,9 +293,9 @@ describe('Sayt Component', () => {
       const event3: any = { key: "Space" };
       const hideSayt = stub(sayt, 'hideSayt');
 
-      sayt.processKeyPress(event);
-      sayt.processKeyPress(event2);
-      sayt.processKeyPress(event3);
+      sayt.processKeyEvent(event);
+      sayt.processKeyEvent(event2);
+      sayt.processKeyEvent(event3);
 
       expect(hideSayt).to.not.be.called;
     });

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -159,8 +159,9 @@ describe('Sayt Component', () => {
 
     it('should not error if passed an event without a detail attribute', () => {
       const event = {};
+      const callback = () => sayt.isCorrectSayt(event);
 
-      expect(() => sayt.isCorrectSayt(event)).to.not.throw();
+      expect(callback).to.not.throw();
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -267,24 +267,18 @@ describe('Sayt Component', () => {
       expect(getElementById).to.be.calledWith('searchbox-id');
     });
 
-    it('should return false and avoid querying for searchbox if this.searchbox is not set', () => {
+    it('should return false if this.searchbox is not set', () => {
       sayt.searchbox = undefined;
-      const getElementById = stub(document, 'getElementById');
 
       const result = sayt.nodeInSearchBar('node');
 
       expect(result).to.be.false;
-      expect(getElementById).to.not.be.called;
     });
   });
 
   describe('processKeyPress()', () => {
-    it('should exist as a function', () => {
-      expect(sayt.processKeyPress).to.be.a('function');
-    });
-
     it('should hide SAYT when pressing escape', () => {
-      const event = { key: "Escape" } as KeyboardEvent;
+      const event: any = { key: "Escape" };
       sayt.hideSayt = spy();
 
       sayt.processKeyPress(event);
@@ -293,9 +287,9 @@ describe('Sayt Component', () => {
     });
 
     it('should not hide SAYT when pressing any character other than escape', () => {
-      const event = { key: "j" } as KeyboardEvent;
-      const event2 = { key: "Enter" } as KeyboardEvent;
-      const event3 = { key: "Space" } as KeyboardEvent;
+      const event: any = { key: "j" };
+      const event2: any = { key: "Enter" };
+      const event3: any = { key: "Space" };
       sayt.hideSayt = spy();
 
       sayt.processKeyPress(event);

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -2,6 +2,7 @@ import { expect, spy, stub } from './utils';
 import { TemplateResult } from 'lit-element';
 import Sayt from '../src/sayt';
 import { SAYT_EVENT } from '../src/events';
+import { AUTOCOMPLETE_RECEIVED_RESULTS_EVENT } from '../../autocomplete/src/events';
 
 describe('Sayt Component', () => {
   let sayt;
@@ -20,6 +21,7 @@ describe('Sayt Component', () => {
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(addEventListener).to.be.calledWith('click', sayt.processClick);
       expect(addEventListener).to.be.calledWith('keypress', sayt.processKeyPress);
+      expect(addEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT);
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -153,6 +153,12 @@ describe('Sayt Component', () => {
 
       expect(result).to.be.true;
     });
+
+    it('should not error if passed an event without a detail attribute', () => {
+      const event = {};
+
+      expect(() => sayt.isCorrectSayt(event)).to.not.throw();
+    });
   });
 
   describe('render()', () => {

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -167,12 +167,10 @@ describe('Sayt Component', () => {
 
   describe('processClick()', () => {
     let node: any = 'some-node';
-    let event: Event;
+    let event: any;
 
     beforeEach(() => {
-      event = {
-        target: node,
-      } as Event;
+      event = { target: node };
       sayt.nodeInSearchBar = () => false;
     });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -33,6 +33,7 @@ describe('Sayt Component', () => {
       sayt.disconnectedCallback();
 
       expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showCorrectSayt);
+      expect(removeEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, sayt.showCorrectSayt);
       expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(removeEventListener).to.be.calledWith('click', sayt.processClick);
       expect(removeEventListener).to.be.calledWith('keypress', sayt.processKeyPress);

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -73,7 +73,7 @@ describe('Sayt Component', () => {
   });
 
   describe('showCorrectSayt()', () => {
-    it('should call showSayt() when event specifies correct searchbar ID ', () => {
+    it('should call showSayt() when event specifies correct searchbox ID ', () => {
       const showSayt = stub(sayt, 'showSayt');
       const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(true);
       const event = {};
@@ -84,7 +84,7 @@ describe('Sayt Component', () => {
       expect(showSayt).to.be.calledOnce;
     });
 
-    it('should not call showSayt() when event specifies wrong searchbar ID', () => {
+    it('should not call showSayt() when event specifies wrong searchbox ID', () => {
       const showSayt = stub(sayt, 'showSayt');
       const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(false);
       const event = {};
@@ -97,7 +97,7 @@ describe('Sayt Component', () => {
   });
 
   describe('hideCorrectSayt()', () => {
-    it('should call hideSayt() when event specifies correct searchbar ID ', () => {
+    it('should call hideSayt() when event specifies correct searchbox ID ', () => {
       const hideSayt = stub(sayt, 'hideSayt');
       const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(true);
       const event = {};
@@ -108,7 +108,7 @@ describe('Sayt Component', () => {
       expect(hideSayt).to.be.calledOnce;
     });
 
-    it('should not call hideSayt() when event specifies wrong searchbar ID', () => {
+    it('should not call hideSayt() when event specifies wrong searchbox ID', () => {
       const hideSayt = stub(sayt, 'hideSayt');
       const isCorrectSayt = stub(sayt, 'isCorrectSayt').returns(false);
       const event = {};
@@ -121,17 +121,17 @@ describe('Sayt Component', () => {
   });
 
   describe('isCorrectSayt()', () => {
-    it('should return true if event provides the correct searchbar ID', () => {
-      const searchbar = sayt.searchbar = 'some-searchbar-id';
-      const event = { detail: { searchbar } };
+    it('should return true if event provides the correct searchbox ID', () => {
+      const searchbox = sayt.searchbox = 'some-searchbox-id';
+      const event = { detail: { searchbox } };
 
       const result = sayt.isCorrectSayt(event);
 
       expect(result).to.be.true;
     });
 
-    it('should return true if event does not provide a searchbar ID', () => {
-      const searchbar = sayt.searchbar = 'some-searchbar-id';
+    it('should return true if event does not provide a searchbox ID', () => {
+      const searchbox = sayt.searchbox = 'some-searchbox-id';
       const event = { detail: {} };
 
       const result = sayt.isCorrectSayt(event);
@@ -139,18 +139,18 @@ describe('Sayt Component', () => {
       expect(result).to.be.true;
     });
 
-    it('should return false if event provides the wrong searchbar ID', () => {
-      sayt.searchbar = 'correct-searchbar-id';
-      const event = { detail: { searchbar: 'wrong-searchbar-id' } };
+    it('should return false if event provides the wrong searchbox ID', () => {
+      sayt.searchbox = 'correct-searchbox-id';
+      const event = { detail: { searchbox: 'wrong-searchbox-id' } };
 
       const result = sayt.isCorrectSayt(event);
 
       expect(result).to.be.false;
     });
 
-    it('should return true if event specifies a searchbar but SAYT has none specified', () => {
-      sayt.searchbar = undefined;
-      const event = { detail: { searchbar: 'some-searchbar-id' } };
+    it('should return true if event specifies a searchbox but SAYT has none specified', () => {
+      sayt.searchbox = undefined;
+      const event = { detail: { searchbox: 'some-searchbox-id' } };
 
       const result = sayt.isCorrectSayt(event);
 
@@ -219,30 +219,30 @@ describe('Sayt Component', () => {
 
   describe('nodeInSearchBar()', () => {
     it('should return true if given node is contained in the search bar', () => {
-      const searchbar = {
+      const searchbox = {
         contains: stub().returns(true),
       };
-      const querySelector = stub(document, 'querySelector').callsFake(() => searchbar);
-      sayt.searchbar = 'searchbar-id';
+      const querySelector = stub(document, 'querySelector').callsFake(() => searchbox);
+      sayt.searchbox = 'searchbox-id';
 
       const result = sayt.nodeInSearchBar('node');
 
-      expect(querySelector).to.be.calledWith('#searchbar-id');
-      expect(searchbar.contains).to.be.calledWith('node');
+      expect(querySelector).to.be.calledWith('#searchbox-id');
+      expect(searchbox.contains).to.be.calledWith('node');
       expect(result).to.equal(true);
     });
 
     it('should return false if given node is not contained in the search bar', () => {
-      const searchbar = {
+      const searchbox = {
         contains: stub().returns(false),
       };
-      const querySelector = stub(document, 'querySelector').callsFake(() => searchbar);
-      sayt.searchbar = 'searchbar-id';
+      const querySelector = stub(document, 'querySelector').callsFake(() => searchbox);
+      sayt.searchbox = 'searchbox-id';
 
       const result = sayt.nodeInSearchBar('node');
 
-      expect(querySelector).to.be.calledWith('#searchbar-id');
-      expect(searchbar.contains).to.be.calledWith('node');
+      expect(querySelector).to.be.calledWith('#searchbox-id');
+      expect(searchbox.contains).to.be.calledWith('node');
       expect(result).to.equal(false);
     });
 
@@ -254,8 +254,8 @@ describe('Sayt Component', () => {
       expect(result).to.be.false;
     });
 
-    it('should not call document.querySelector() if this.searchbar is not set', () => {
-      sayt.searchbar = undefined;
+    it('should not call document.querySelector() if this.searchbox is not set', () => {
+      sayt.searchbox = undefined;
       const querySelector = stub(document, 'querySelector');
 
       sayt.nodeInSearchBar('node');

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -242,7 +242,7 @@ describe('Sayt Component', () => {
       expect(result).to.equal(false);
     });
 
-    it('should return false if there is no search bar can be found', () => {
+    it('should return false if there is no search bar on the page', () => {
       const querySelector = stub(document, 'querySelector').returns(null);
 
       const result = sayt.nodeInSearchBar('node');

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -131,8 +131,8 @@ describe('Sayt Component', () => {
     });
 
     it('should return true if event does not provide a searchbox ID', () => {
-      sayt.searchbox = 'some-searchbox-id';
       const event = { detail: {} };
+      sayt.searchbox = 'some-searchbox-id';
 
       const result = sayt.isCorrectSayt(event);
 
@@ -166,16 +166,17 @@ describe('Sayt Component', () => {
   });
 
   describe('processClick()', () => {
-    let node: any = 'some-node';
+    let node: any;
     let event: any;
 
     beforeEach(() => {
+      node = {};
       event = { target: node };
     });
 
     it('should hide SAYT if the event target is nowhere relevant', () => {
       stub(sayt, 'contains').returns(false);
-      stub(sayt, 'nodeInSearchBar').returns(false);
+      stub(sayt, 'nodeInSearchbox').returns(false);
       stub(sayt, 'hideSayt');
 
       sayt.processClick(event);
@@ -196,13 +197,13 @@ describe('Sayt Component', () => {
 
     it('should not hide SAYT if the event target is the provided search box', () => {
       stub(sayt, 'contains').returns(false);
-      stub(sayt, 'nodeInSearchBar').returns(true);
+      stub(sayt, 'nodeInSearchbox').returns(true);
       stub(sayt, 'hideSayt');
 
       sayt.processClick(event);
 
       expect(sayt.contains).to.be.calledWith(node);
-      expect(sayt.nodeInSearchBar).to.be.calledWith(node);
+      expect(sayt.nodeInSearchbox).to.be.calledWith(node);
       expect(sayt.hideSayt).to.not.be.called;
     });
   });
@@ -224,19 +225,19 @@ describe('Sayt Component', () => {
 
       sayt.clickCloseSayt(event);
 
-      expect(preventDefault).to.be.calledOnce;
+      expect(preventDefault).to.be.called;
     });
   });
 
-  describe('nodeInSearchBar()', () => {
+  describe('nodeInSearchbox()', () => {
     it('should return true if given node is contained in the search bar', () => {
       const searchbox = {
         contains: spy(() => true),
       };
-      const getElementById = stub(document, 'getElementById').callsFake(() => searchbox);
+      const getElementById = stub(document, 'getElementById').returns(searchbox);
       sayt.searchbox = 'searchbox-id';
 
-      const result = sayt.nodeInSearchBar('node');
+      const result = sayt.nodeInSearchbox('node');
 
       expect(getElementById).to.be.calledWith('searchbox-id');
       expect(searchbox.contains).to.be.calledWith('node');
@@ -247,10 +248,10 @@ describe('Sayt Component', () => {
       const searchbox = {
         contains: stub().returns(false),
       };
-      const getElementById = stub(document, 'getElementById').callsFake(() => searchbox);
+      const getElementById = stub(document, 'getElementById').returns(searchbox);
       sayt.searchbox = 'searchbox-id';
 
-      const result = sayt.nodeInSearchBar('node');
+      const result = sayt.nodeInSearchbox('node');
 
       expect(getElementById).to.be.calledWith('searchbox-id');
       expect(searchbox.contains).to.be.calledWith('node');
@@ -261,7 +262,7 @@ describe('Sayt Component', () => {
       const getElementById = stub(document, 'getElementById').returns(null);
       sayt.searchbox = 'searchbox-id';
 
-      const result = sayt.nodeInSearchBar('node');
+      const result = sayt.nodeInSearchbox('node');
 
       expect(result).to.be.false;
       expect(getElementById).to.be.calledWith('searchbox-id');
@@ -270,7 +271,7 @@ describe('Sayt Component', () => {
     it('should return false if this.searchbox is not set', () => {
       sayt.searchbox = undefined;
 
-      const result = sayt.nodeInSearchBar('node');
+      const result = sayt.nodeInSearchbox('node');
 
       expect(result).to.be.false;
     });

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -20,7 +20,7 @@ describe('Sayt Component', () => {
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_SHOW, sayt.showCorrectSayt);
       expect(addEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(addEventListener).to.be.calledWith('click', sayt.processClick);
-      expect(addEventListener).to.be.calledWith('keypress', sayt.processKeyPress);
+      expect(addEventListener).to.be.calledWith('keydown', sayt.processKeyPress);
       expect(addEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, sayt.showCorrectSayt);
     });
   });
@@ -36,7 +36,7 @@ describe('Sayt Component', () => {
       expect(removeEventListener).to.be.calledWith(AUTOCOMPLETE_RECEIVED_RESULTS_EVENT, sayt.showCorrectSayt);
       expect(removeEventListener).to.be.calledWith(SAYT_EVENT.SAYT_HIDE, sayt.hideCorrectSayt);
       expect(removeEventListener).to.be.calledWith('click', sayt.processClick);
-      expect(removeEventListener).to.be.calledWith('keypress', sayt.processKeyPress);
+      expect(removeEventListener).to.be.calledWith('keydown', sayt.processKeyPress);
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -258,11 +258,13 @@ describe('Sayt Component', () => {
     });
 
     it('should return false if there is no search bar on the page', () => {
-      const querySelector = stub(document, 'querySelector').returns(null);
+      const getElementById = stub(document, 'getElementById').returns(null);
+      sayt.searchbox = 'searchbox-id';
 
       const result = sayt.nodeInSearchBar('node');
 
       expect(result).to.be.false;
+      expect(getElementById).to.be.calledWith('searchbox-id');
     });
 
     it('should not call document.querySelector() if this.searchbox is not set', () => {

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -61,17 +61,6 @@ describe('Sayt Component', () => {
     });
   });
 
-  describe('hideSayt()', () => {
-    it('should set the visible prop to false', () => {
-      sayt.hidden = false;
-      sayt.visible = true;
-
-      sayt.hideSayt();
-
-      expect(sayt.visible).to.be.false;
-    });
-  });
-
   describe('showCorrectSayt()', () => {
     it('should call showSayt() when event specifies correct searchbox ID ', () => {
       const showSayt = stub(sayt, 'showSayt');
@@ -93,6 +82,17 @@ describe('Sayt Component', () => {
 
       expect(isCorrectSayt).to.be.calledOnceWith(event);
       expect(showSayt).to.not.be.called;
+    });
+  });
+
+  describe('hideSayt()', () => {
+    it('should set the visible prop to false', () => {
+      sayt.hidden = false;
+      sayt.visible = true;
+
+      sayt.hideSayt();
+
+      expect(sayt.visible).to.be.false;
     });
   });
 
@@ -165,14 +165,6 @@ describe('Sayt Component', () => {
     });
   });
 
-  describe('render()', () => {
-    it('should return an instance of TemplateResult', () => {
-      const result = sayt.render();
-
-      expect(result).to.be.an.instanceof(TemplateResult);
-    });
-  });
-
   describe('processClick()', () => {
     let node: any = 'some-node';
     let event: Event;
@@ -214,6 +206,27 @@ describe('Sayt Component', () => {
       expect(sayt.contains).to.be.calledWith(node);
       expect(sayt.nodeInSearchBar).to.be.calledWith(node);
       expect(sayt.hideSayt).to.not.be.called;
+    });
+  });
+
+  describe('clickCloseSayt()', () => {
+    it('should close SAYT when activated', () => {
+      const hideSayt = stub(sayt, 'hideSayt');
+      const event = { preventDefault: () => null };
+
+      sayt.clickCloseSayt(event);
+
+      expect(hideSayt).to.be.calledOnce;
+    });
+
+    it('should prevent the default event action when activated', () => {
+      stub(sayt, 'hideSayt');
+      const preventDefault = spy();
+      const event = { preventDefault };
+
+      sayt.clickCloseSayt(event);
+
+      expect(preventDefault).to.be.calledOnce;
     });
   });
 
@@ -292,24 +305,11 @@ describe('Sayt Component', () => {
     });
   });
 
-  describe('clickCloseSayt()', () => {
-    it('should close SAYT when activated', () => {
-      const hideSayt = stub(sayt, 'hideSayt');
-      const event = { preventDefault: () => null };
+  describe('render()', () => {
+    it('should return an instance of TemplateResult', () => {
+      const result = sayt.render();
 
-      sayt.clickCloseSayt(event);
-
-      expect(hideSayt).to.be.calledOnce;
-    });
-
-    it('should prevent the default event action when activated', () => {
-      stub(sayt, 'hideSayt');
-      const preventDefault = spy();
-      const event = { preventDefault };
-
-      sayt.clickCloseSayt(event);
-
-      expect(preventDefault).to.be.calledOnce;
+      expect(result).to.be.an.instanceof(TemplateResult);
     });
   });
 });

--- a/packages/web-components/@sfx/sayt/test/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/sayt.test.ts
@@ -231,7 +231,7 @@ describe('Sayt Component', () => {
   describe('nodeInSearchBar()', () => {
     it('should return true if given node is contained in the search bar', () => {
       const searchbox = {
-        contains: stub().returns(true),
+        contains: spy(() => true),
       };
       const getElementById = stub(document, 'getElementById').callsFake(() => searchbox);
       sayt.searchbox = 'searchbox-id';

--- a/packages/web-components/@sfx/sayt/test/utils.ts
+++ b/packages/web-components/@sfx/sayt/test/utils.ts
@@ -1,1 +1,2 @@
 export * from '../../../../../test-tools/utils';
+export * from '../../../../../.storybook/common';

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -149,7 +149,7 @@ export default class SearchBox extends Base {
         searchbox: this.id,
       },
       bubbles: true,
-    })
+    });
   }
 
   // TODO Move this to the Storybook tab once functionality has been merged into sfx-view.

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -53,7 +53,10 @@ export default class SearchBox extends Base {
    */
   emitSearchEvent() {
     const searchboxRequestEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCH_REQUEST, {
-      detail: this.value,
+      detail: {
+        value: this.value,
+        searchbox: this.id,
+      },
       bubbles: true
     });
     this.dispatchEvent(searchboxRequestEvent);
@@ -135,6 +138,22 @@ export default class SearchBox extends Base {
   clickExposed() {
     const searchBoxClickedEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLICK, { bubbles: true });
     this.dispatchEvent(searchBoxClickedEvent);
+  }
+
+  /**
+   * Returns an event with a standard structure.
+   *
+   * @param type The type (or name) of the event to be emitted.
+   * @param detail A payload to be sent with the event.
+   */
+  getCustomEvent(type: string, detail: object) {
+    return new CustomEvent(type, {
+      detail: {
+        ...detail,
+        searchbox: this.id,
+      },
+      bubbles: true,
+    })
   }
 
   // TODO Move this to the Storybook tab once functionality has been merged into sfx-view.

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -142,7 +142,7 @@ export default class SearchBox extends Base {
    * @param type The type (or name) of the event to be emitted.
    * @param detail A payload to be sent with the event.
    */
-  createCustomEvent(type: string, detail: object = {}) {
+  createCustomEvent(type: string, detail?: object) {
     return new CustomEvent(type, {
       detail: {
         ...detail,

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -132,7 +132,7 @@ export default class SearchBox extends Base {
    * Invoked in response to a user clicking inside of the searchbox input.
    */
   clickExposed() {
-    const searchBoxClickedEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLICK, { bubbles: true });
+    const searchBoxClickedEvent = this.getCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
     this.dispatchEvent(searchBoxClickedEvent);
   }
 

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -140,7 +140,7 @@ export default class SearchBox extends Base {
    * @param type The type (or name) of the event to be emitted.
    * @param detail A payload to be sent with the event.
    */
-  createCustomEvent(type: string, detail?: object) {
+  createCustomEvent<T>(type: string, detail?: T): CustomEvent<T> {
     return new CustomEvent(type, {
       detail: {
         ...detail,

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -52,7 +52,7 @@ export default class SearchBox extends Base {
    * Invoked in response to user interactions: `enter` key or click on search button.
    */
   emitSearchEvent() {
-    const searchboxRequestEvent = this.getCustomEvent(SEARCHBOX_EVENT.SEARCH_REQUEST, {
+    const searchboxRequestEvent = this.createCustomEvent(SEARCHBOX_EVENT.SEARCH_REQUEST, {
       value: this.value,
     });
     this.dispatchEvent(searchboxRequestEvent);
@@ -63,7 +63,7 @@ export default class SearchBox extends Base {
    * Invoked in response to a click on the clear button.
    */
   emitSearchBoxClearClick() {
-    const searchboxClearedEvent = this.getCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
+    const searchboxClearedEvent = this.createCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
     this.dispatchEvent(searchboxClearedEvent);
   }
 
@@ -90,7 +90,7 @@ export default class SearchBox extends Base {
     const value = (e.target as HTMLInputElement).value;
     this.updateSearchTermValue(value);
     this.dispatchEvent(
-      this.getCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, {
+      this.createCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, {
         value,
       })
     );
@@ -132,7 +132,7 @@ export default class SearchBox extends Base {
    * Invoked in response to a user clicking inside of the searchbox input.
    */
   clickExposed() {
-    const searchBoxClickedEvent = this.getCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
+    const searchBoxClickedEvent = this.createCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
     this.dispatchEvent(searchBoxClickedEvent);
   }
 
@@ -142,7 +142,7 @@ export default class SearchBox extends Base {
    * @param type The type (or name) of the event to be emitted.
    * @param detail A payload to be sent with the event.
    */
-  getCustomEvent(type: string, detail: object = {}) {
+  createCustomEvent(type: string, detail: object = {}) {
     return new CustomEvent(type, {
       detail: {
         ...detail,

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -52,12 +52,8 @@ export default class SearchBox extends Base {
    * Invoked in response to user interactions: `enter` key or click on search button.
    */
   emitSearchEvent() {
-    const searchboxRequestEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCH_REQUEST, {
-      detail: {
-        value: this.value,
-        searchbox: this.id,
-      },
-      bubbles: true
+    const searchboxRequestEvent = this.getCustomEvent(SEARCHBOX_EVENT.SEARCH_REQUEST, {
+      value: this.value,
     });
     this.dispatchEvent(searchboxRequestEvent);
   }
@@ -67,7 +63,7 @@ export default class SearchBox extends Base {
    * Invoked in response to a click on the clear button.
    */
   emitSearchBoxClearClick() {
-    const searchboxClearedEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK, { bubbles: true });
+    const searchboxClearedEvent = this.getCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
     this.dispatchEvent(searchboxClearedEvent);
   }
 

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -87,11 +87,11 @@ export default class SearchBox extends Base {
    * @param e The KeyboardEvent object.
    */
   handleInput(e: KeyboardEvent) {
-    this.updateSearchTermValue((e.target as HTMLInputElement).value);
+    const value = (e.target as HTMLInputElement).value;
+    this.updateSearchTermValue(value);
     this.dispatchEvent(
-      new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, {
-        detail: (e.target as HTMLInputElement).value,
-        bubbles: true
+      this.getCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, {
+        value,
       })
     );
   }
@@ -142,7 +142,7 @@ export default class SearchBox extends Base {
    * @param type The type (or name) of the event to be emitted.
    * @param detail A payload to be sent with the event.
    */
-  getCustomEvent(type: string, detail: object) {
+  getCustomEvent(type: string, detail: object = {}) {
     return new CustomEvent(type, {
       detail: {
         ...detail,

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -90,9 +90,7 @@ export default class SearchBox extends Base {
     const value = (e.target as HTMLInputElement).value;
     this.updateSearchTermValue(value);
     this.dispatchEvent(
-      this.createCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, {
-        value,
-      })
+      this.createCustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, { value })
     );
   }
 

--- a/packages/web-components/@sfx/search-box/stories/index.ts
+++ b/packages/web-components/@sfx/search-box/stories/index.ts
@@ -40,7 +40,7 @@ storiesOf('Components|Searchbox', module)
   `
     )
     .add(
-      'Without a clear button, without a search button',
+      'With a clear button, without a search button',
       () => `
     <sfx-search-box clearbutton></sfx-search-box>
   `
@@ -50,7 +50,7 @@ storiesOf('Components|Searchbox', module)
       () => `
     <sfx-search-box placeholder="${text(
       'Placeholder Title',
-      'Search'
+      'Placeholder here...'
     )}"></sfx-search-box>
   `
     );

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -91,7 +91,7 @@ describe('SearchBox Component', () => {
   });
 
   describe('updateText', () => {
-    it('should update the value property with information from the event', () => {
+    it('should update the value property with data from the event', () => {
       const detail = 'inputText';
       const inputEvent = new CustomEvent('some-test-type', { detail });
       const updateSearchTermValue = stub(searchbox, 'updateSearchTermValue');

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -69,12 +69,16 @@ describe('SearchBox Component', () => {
   describe('emitSearchEvent', () => {
     it('should dispatch a search request event', () => {
       const value = searchbox.value = 'a';
+      const id = searchbox.id = 'some-id';
 
       searchbox.emitSearchEvent();
       const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
       expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCH_REQUEST);
-      expect(passedEvent.detail).to.equal(value);
+      expect(passedEvent.detail).to.deep.equal({
+        value,
+        searchbox: id,
+      });
       expect(passedEvent.bubbles).to.equal(true);
     });
   });
@@ -171,6 +175,27 @@ describe('SearchBox Component', () => {
 
       expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
       expect(passedEvent.bubbles).to.be.true;
+    });
+  });
+
+  describe('getCustomEvent', () => {
+    it('should return a CustomEvent with the provided type and detail', () => {
+      const type = 'event-type';
+      const detail = { a: 1, b: 2 };
+
+      const result = searchbox.getCustomEvent(type, detail);
+
+      expect(result.type).to.equal(type);
+      expect(result.detail).to.include(detail);
+    });
+
+    it('should return a CustomEvent that bubbles and has a searchbox attribute', () => {
+      const id = searchbox.id = 'some-id';
+
+      const result = searchbox.getCustomEvent('some-type');
+
+      expect(result.bubbles).to.be.true;
+      expect(result.detail.searchbox).to.equal(id);
     });
   });
 

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -68,36 +68,36 @@ describe('SearchBox Component', () => {
 
   describe('emitSearchEvent', () => {
     it('should dispatch a search request event', () => {
-      const searchRequestEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCH_REQUEST, {
-        detail: 'a',
-        bubbles: true
-      });
-      searchbox.value = 'a';
+      const value = searchbox.value = 'a';
 
       searchbox.emitSearchEvent();
+      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
-      expect(searchboxDispatchEvent).to.have.been.calledWith(searchRequestEvent);
+      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCH_REQUEST);
+      expect(passedEvent.detail).to.equal(value);
+      expect(passedEvent.bubbles).to.equal(true);
     });
   });
 
   describe('emitSearchBoxClearClick', () => {
     it('should dispatch an emitSearchBoxClearClick', () => {
-      const searchboxClearedEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
-
       searchbox.emitSearchBoxClearClick();
+      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
-      expect(searchboxDispatchEvent).to.have.been.calledWith(searchboxClearedEvent);
+      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
+      expect(passedEvent.bubbles).to.equal(true);
     });
   });
 
   describe('updateText', () => {
-    it('should update the value property in response to the data received', () => {
+    it('should update the value property with information from the event', () => {
       const detail = 'inputText';
-      const inputEvent = new CustomEvent(SEARCHBOX_EVENT.UPDATE_SEARCH_TERM, { detail });
+      const inputEvent = new CustomEvent('some-test-type', { detail });
+      const updateSearchTermValue = stub(searchbox, 'updateSearchTermValue');
   
       searchbox.updateText(inputEvent);
 
-      expect(searchbox.value).to.equal(detail);
+      expect(updateSearchTermValue).to.be.calledWith(detail);
     });
   });
 
@@ -113,26 +113,26 @@ describe('SearchBox Component', () => {
   });
 
   describe('handleInput', () => {
-    it('should invoke the updateSearchTermValue function', () => {
+    it('should invoke the updateSearchTermValue function with a value from the event', () => {
       const updateSearchTermValueStub = stub(searchbox, 'updateSearchTermValue');
       const searchTerm = 'dee';
 
       searchbox.handleInput({ target: { value: searchTerm } });
+      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
       expect(updateSearchTermValueStub).to.have.been.calledWith(searchTerm);
     });
 
     it('should dispatch a search box change event', () => {
-      const target = { value: 'dee' };
-      const searchboxChangeEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CHANGE, {
-        detail: target,
-        bubbles: true
-      });
-      stub(searchbox, 'updateSearchTermValue');
+      const updateSearchTermValueStub = stub(searchbox, 'updateSearchTermValue');
+      const searchTerm = 'dee';
 
-      searchbox.handleInput({ target });
+      searchbox.handleInput({ target: { value: searchTerm } });
+      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
-      expect(searchboxDispatchEvent).to.have.been.calledWith(searchboxChangeEvent);
+      expect(passedEvent.bubbles).to.equal(true);
+      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CHANGE);
+      expect(passedEvent.detail).to.equal(searchTerm);
     });
   });
 
@@ -166,11 +166,11 @@ describe('SearchBox Component', () => {
 
   describe('clickExposed', () => {
     it('should dispatch a search box clicked event', () => {
-      const searchboxClickedEvent = new CustomEvent(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
-
       searchbox.clickExposed();
+      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
-      expect(searchboxDispatchEvent).to.have.been.calledWith(searchboxClickedEvent);
+      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
+      expect(passedEvent.bubbles).to.be.true;
     });
   });
 

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -136,7 +136,7 @@ describe('SearchBox Component', () => {
 
       expect(passedEvent.bubbles).to.equal(true);
       expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CHANGE);
-      expect(passedEvent.detail).to.equal(searchTerm);
+      expect(passedEvent.detail).to.include({ value: searchTerm });
     });
   });
 

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -70,22 +70,22 @@ describe('SearchBox Component', () => {
     it('should dispatch a search request event', () => {
       const value = searchbox.value = 'a';
       const id = searchbox.id = 'some-id';
-      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
+      const createCustomEvent = stub(searchbox, 'createCustomEvent').returns('some-event');
 
       searchbox.emitSearchEvent();
 
-      expect(getCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCH_REQUEST, { value });
+      expect(createCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCH_REQUEST, { value });
       expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
 
   describe('emitSearchBoxClearClick', () => {
     it('should dispatch an emitSearchBoxClearClick', () => {
-      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
+      const createCustomEvent = stub(searchbox, 'createCustomEvent').returns('some-event');
 
       searchbox.emitSearchBoxClearClick();
 
-      expect(getCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
+      expect(createCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
       expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
@@ -125,11 +125,11 @@ describe('SearchBox Component', () => {
 
     it('should dispatch a search box change event with a value from the event', () => {
       const searchTerm = 'dee';
-      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
+      const createCustomEvent = stub(searchbox, 'createCustomEvent').returns('some-event');
 
       searchbox.handleInput({ target: { value: searchTerm } });
 
-      expect(getCustomEvent).to.be.calledWith(
+      expect(createCustomEvent).to.be.calledWith(
         SEARCHBOX_EVENT.SEARCHBOX_CHANGE,
         { value: searchTerm },
       );
@@ -167,21 +167,21 @@ describe('SearchBox Component', () => {
 
   describe('clickExposed', () => {
     it('should dispatch a search box clicked event', () => {
-      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
+      const createCustomEvent = stub(searchbox, 'createCustomEvent').returns('some-event');
 
       searchbox.clickExposed();
 
-      expect(getCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
+      expect(createCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
       expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
 
-  describe('getCustomEvent', () => {
+  describe('createCustomEvent', () => {
     it('should return a CustomEvent with the provided type and detail', () => {
       const type = 'event-type';
       const detail = { a: 1, b: 2 };
 
-      const result = searchbox.getCustomEvent(type, detail);
+      const result = searchbox.createCustomEvent(type, detail);
 
       expect(result.type).to.equal(type);
       expect(result.detail).to.include(detail);
@@ -190,7 +190,7 @@ describe('SearchBox Component', () => {
     it('should return a CustomEvent that bubbles and has a searchbox attribute', () => {
       const id = searchbox.id = 'some-id';
 
-      const result = searchbox.getCustomEvent('some-type');
+      const result = searchbox.createCustomEvent('some-type');
 
       expect(result.bubbles).to.be.true;
       expect(result.detail.searchbox).to.equal(id);

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -70,26 +70,23 @@ describe('SearchBox Component', () => {
     it('should dispatch a search request event', () => {
       const value = searchbox.value = 'a';
       const id = searchbox.id = 'some-id';
+      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
 
       searchbox.emitSearchEvent();
-      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
-      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCH_REQUEST);
-      expect(passedEvent.detail).to.deep.equal({
-        value,
-        searchbox: id,
-      });
-      expect(passedEvent.bubbles).to.equal(true);
+      expect(getCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCH_REQUEST, { value });
+      expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
 
   describe('emitSearchBoxClearClick', () => {
     it('should dispatch an emitSearchBoxClearClick', () => {
-      searchbox.emitSearchBoxClearClick();
-      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
+      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
 
-      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
-      expect(passedEvent.bubbles).to.equal(true);
+      searchbox.emitSearchBoxClearClick();
+
+      expect(getCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCHBOX_CLEAR_CLICK);
+      expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
 
@@ -122,21 +119,21 @@ describe('SearchBox Component', () => {
       const searchTerm = 'dee';
 
       searchbox.handleInput({ target: { value: searchTerm } });
-      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
       expect(updateSearchTermValueStub).to.have.been.calledWith(searchTerm);
     });
 
-    it('should dispatch a search box change event', () => {
-      const updateSearchTermValueStub = stub(searchbox, 'updateSearchTermValue');
+    it('should dispatch a search box change event with a value from the event', () => {
       const searchTerm = 'dee';
+      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
 
       searchbox.handleInput({ target: { value: searchTerm } });
-      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
 
-      expect(passedEvent.bubbles).to.equal(true);
-      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CHANGE);
-      expect(passedEvent.detail).to.include({ value: searchTerm });
+      expect(getCustomEvent).to.be.calledWith(
+        SEARCHBOX_EVENT.SEARCHBOX_CHANGE,
+        { value: searchTerm },
+      );
+      expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
 
@@ -170,11 +167,12 @@ describe('SearchBox Component', () => {
 
   describe('clickExposed', () => {
     it('should dispatch a search box clicked event', () => {
-      searchbox.clickExposed();
-      const passedEvent = searchboxDispatchEvent.getCall(0).args[0];
+      const getCustomEvent = stub(searchbox, 'getCustomEvent').returns('some-event');
 
-      expect(passedEvent.type).to.equal(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
-      expect(passedEvent.bubbles).to.be.true;
+      searchbox.clickExposed();
+
+      expect(getCustomEvent).to.be.calledWith(SEARCHBOX_EVENT.SEARCHBOX_CLICK);
+      expect(searchboxDispatchEvent).to.be.calledWith('some-event');
     });
   });
 


### PR DESCRIPTION
Ensures SAYT is shown/hidden when required, rather than simply listening for show/hide events.

From this PR:
* Update SAYT to accept a `searchbox` attribute
* Update SAYT to only show/hide itself when the correct `searchbox` attribute is provided (or none at all).
* Add optional `Close` link to SAYT
  * Allow for `Close` link text to be customizable (eg. `X`)
* Updated all Search events to include the ID of the search box
  * Updated Search tests accordingly
* Update Search event-based tests for validity (they were not testing what we thought they were)
* Update SAYT Storybook stories to output the code required to produce the given result
  * Added `html-entities` as a requirement
* Listen on `autocomplete-receive-results` event to show SAYT (ie. automatically show SAYT once a subcomponent has results to show)
* Unit tests for all new functions in SAYT component
* Minor fixes to Search Storybook stories


Caveats/TO DO:
* No story added for Search + SAYT because they do not currently interact directly. They require the Logic Layer (SAYT Driver) to interact. In the meantime, there are stories that use `<input>` boxes.
* styles for Storybook code blocks are `<style>` tags inside of a function, rather than being an imported stylesheet (had trouble getting this to work).
* Syntax highlighting needed for display code (XML)
* Code output is still needed for all other Storybook stories (eg. for Search, Autocomplete, and Base)