### PR TITLE
Expect searchterm to be nested inside object

### DIFF
--- a/packages/web-components/@sfx/search-box/test/interaction/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/interaction/search-box.test.ts
@@ -111,7 +111,7 @@ describe('SearchBox Component Interaction Tests', () => {
     }).then(() => {
       return eventListenerPromise;
     }).then((e) => {
-      expect(e.detail).to.equal(searchTerm);
+      expect(e.detail.value).to.equal(searchTerm);
     });
   });
 });


### PR DESCRIPTION
Fix failing interaction test. It was looking for the searchterm to be the entire event `.detail`, but Search now provides an object containing a `value` (the searchterm) and other information.