### PR TITLE
SFX-299: Fix container size of components

### DIFF
--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -79,6 +79,11 @@ export default class Autocomplete extends Base {
    */
   render() {
     return html`
+      <style>
+        sfx-autocomplete {
+          display: block;
+        }
+      </style>
       ${this.caption && this.results.length > 0
         ? html`<h3>${this.caption}</h3>`
         : ''}

--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -83,6 +83,10 @@ export default class Autocomplete extends Base {
         sfx-autocomplete {
           display: block;
         }
+
+        sfx-autocomplete[hidden] {
+          display: none;
+        }
       </style>
       ${this.caption && this.results.length > 0
         ? html`<h3>${this.caption}</h3>`

--- a/packages/web-components/@sfx/product/src/product.ts
+++ b/packages/web-components/@sfx/product/src/product.ts
@@ -67,7 +67,11 @@ export default class Product extends Base {
     const { title, price, variants, productUrl, imageSrc, imageAlt } = this.product;
 
     return html`
-      <style>.product-variants { padding: 0 }</style>
+      <style>
+        .product-variants {
+          padding: 0;
+        }
+      </style>
       <slot name="image">
         ${ imageSrc ? html`<img src="${ imageSrc }" alt="${ imageAlt }" />`: '' }
       </slot>

--- a/packages/web-components/@sfx/products/src/products.ts
+++ b/packages/web-components/@sfx/products/src/products.ts
@@ -69,6 +69,10 @@ export default class Products extends LitElement {
           flex-wrap: wrap;
         }
 
+        sfx-products[hidden] {
+          display: none;
+        }
+
         sfx-product {
           display: block;
         }

--- a/packages/web-components/@sfx/products/src/products.ts
+++ b/packages/web-components/@sfx/products/src/products.ts
@@ -72,6 +72,10 @@ export default class Products extends LitElement {
         sfx-product {
           display: block;
         }
+
+        sfx-product[hidden] {
+          display: none;
+        }
       </style>
 
       ${this.products.map(product => {

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -191,6 +191,10 @@ export default class Sayt extends LitElement {
           sfx-sayt {
             display: block;
           }
+
+          sfx-sayt[hidden] {
+            display: none;
+          }
         ` : ''}
       </style>
       ${ this.showCloseButton ?

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -187,15 +187,13 @@ export default class Sayt extends LitElement {
   render() {
     return html`
       <style>
-        ${ this.visible ? `
-          sfx-sayt {
-            display: block;
-          }
+        sfx-sayt {
+          display: block;
+        }
 
-          sfx-sayt[hidden] {
-            display: none;
-          }
-        ` : ''}
+        sfx-sayt[hidden] {
+          display: none;
+        }
       </style>
       ${ this.showCloseButton ?
         html`<button aria-label="Close" @click=${ this.clickCloseSayt }>

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -186,6 +186,13 @@ export default class Sayt extends LitElement {
    */
   render() {
     return html`
+      <style>
+        ${ this.visible ? `
+          sfx-sayt {
+            display: block;
+          }
+        ` : ''}
+      </style>
       ${ this.showCloseButton ?
         html`<button aria-label="Close" @click=${ this.clickCloseSayt }>
           ${ this.closeText }

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -174,6 +174,10 @@ export default class SearchBox extends Base {
         sfx-search-box {
           display: inline-block;
         }
+
+        sfx-search-box[hidden] {
+          display: none;
+        }
       </style>
       <input
         type="text"

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -172,7 +172,7 @@ export default class SearchBox extends Base {
     return html`
       <style>
         sfx-search-box {
-          display: block;
+          display: inline-block;
         }
       </style>
       <input

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -170,6 +170,11 @@ export default class SearchBox extends Base {
 
   render() {
     return html`
+      <style>
+        sfx-search-box {
+          display: block;
+        }
+      </style>
       <input
         type="text"
         placeholder="${this.placeholder}"


### PR DESCRIPTION
This adds `display: block` to most components. Note that in any component that can be shown/hidden, the `block` display must be active only when shown.

Caveats:
* The following components do not have a correct container size when used in isolation:
  * `List`
  * `Product`
  * `Base`
  (None of the above components are currently used in isolation, so this is technically not yet a problem. Additionally, Base should never be used in isolation.)