### PR TITLE
SFX-354: Update Autocomplete and Products to listen to relevant events 

### DIFF
--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -103,19 +103,27 @@ export const autocompleteResults: AutocompleteResultGroup<AutocompleteSearchTerm
   }
 ];
 
-export const autocompleteResponseEvent = {
-  name: AUTOCOMPLETE_RESPONSE,
-  payload: {
-    results: autocompleteResults,
+export function generateAutocompleteResultsEvent(group?: string) {
+  return {
+    name: AUTOCOMPLETE_RESPONSE,
+    payload: {
+      results: autocompleteResults,
+      group,
+    }
   }
-};
+}
 
-export const saytProductsResponseEvent = {
-  name: SAYT_PRODUCTS_RESPONSE,
-  payload: {
-    products: getProducts(5),
+export function generateProductsResultsEvent(eventName: string, productCount: number, group?: string) {
+  return {
+    name: eventName,
+    payload: {
+      results: {
+        products: getProducts(productCount)
+      },
+      group,
+    }
   }
-};
+}
 
 export function getSaytProductsResponseEvent(): CustomEvent<SaytProductsResponsePayload> {
   return new CustomEvent(SAYT_PRODUCTS_RESPONSE, {

--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -2,6 +2,7 @@ import { XmlEntities } from 'html-entities';
 import {
   AUTOCOMPLETE_RESPONSE,
   SAYT_PRODUCTS_RESPONSE,
+  SEARCH_RESPONSE,
   AutocompleteResultGroup,
   AutocompleteSearchTermItem,
   Product,
@@ -103,7 +104,7 @@ export const autocompleteResults: AutocompleteResultGroup<AutocompleteSearchTerm
   }
 ];
 
-export function generateAutocompleteResultsEvent(group?: string) {
+export const generateAutocompleteResultsEvent = (group?: string) => {
   return {
     name: AUTOCOMPLETE_RESPONSE,
     payload: {
@@ -113,12 +114,22 @@ export function generateAutocompleteResultsEvent(group?: string) {
   }
 }
 
-export function generateProductsResultsEvent(eventName: string, productCount: number, group?: string) {
+export const generateSaytProductsResponseEvent = (productCount: number, group?: string) => {
   return {
-    name: eventName,
+    name: SAYT_PRODUCTS_RESPONSE,
+    payload: {
+      products: getProducts(productCount),
+      group,
+    }
+  }
+}
+
+export const generateSearchResponseEvent = (productCount: number, group?: string) => {
+  return {
+    name: SEARCH_RESPONSE,
     payload: {
       results: {
-        products: getProducts(productCount)
+        records: getProducts(productCount)
       },
       group,
     }

--- a/packages/web-components/@sfx/autocomplete/README.md
+++ b/packages/web-components/@sfx/autocomplete/README.md
@@ -21,7 +21,7 @@ This event is dispatched when one of the search terms inside of the `sfx-autocom
 ## Customizations
 
 - `caption`: Optional attribute to create and populate an `<h3>` tag at the top of the Autocomplete component.
-- `group`: Optional attribute to add the `sayt` component to a grouping of related search components.
+- `group`: Optional attribute to add the `sayt` component to a grouping of related search components. The component will only act on events if they contain the same group name as the component.
 
 ## Testing
 

--- a/packages/web-components/@sfx/autocomplete/README.md
+++ b/packages/web-components/@sfx/autocomplete/README.md
@@ -2,8 +2,21 @@
 
 ## Functionality
 
-The component listens for an event, which is fired when the autocomplete data is received.
-The component then populates a list with the received data.
+The Autocomplete component displays search terms related to a query term. It is also able to dispatch Sayt product search requests.
+
+This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
+
+### Recieved Events
+
+#### `AUTOCOMPLETE_RESPONSE`
+
+Upon receiving this event, the `sfx-autocomplete` component will populate its `results` property with search terms.
+
+### Dispatched Events
+
+#### `AUTOCOMPLETE_ACTIVE_TERM`
+
+This event is dispatched when one of the search terms inside of the `sfx-autocomplete` component is put in the active state or hovered on.
 
 ## Customizations
 
@@ -26,3 +39,5 @@ yarn test
 ```sh
 yarn tdd
 ```
+
+[sfx-events]: https://github.com/groupby/sfx-events

--- a/packages/web-components/@sfx/autocomplete/README.md
+++ b/packages/web-components/@sfx/autocomplete/README.md
@@ -7,7 +7,8 @@ The component then populates a list with the received data.
 
 ## Customizations
 
-Autocomplete allows for an optional title, which populates inside an `<h3>` tag. The title text is populated via the `caption` attribute.
+- `caption`: Optional attribute to create and populate an `<h3>` tag at the top of the Autocomplete component.
+- `group`: Optional attribute to add the `sayt` component to a grouping of related search components.
 
 ## Testing
 

--- a/packages/web-components/@sfx/autocomplete/README.md
+++ b/packages/web-components/@sfx/autocomplete/README.md
@@ -2,7 +2,7 @@
 
 ## Functionality
 
-The Autocomplete component displays search terms related to a query term. It is also able to dispatch Sayt product search requests.
+The Autocomplete component displays search terms related to a query term. It also dispatches events whenever these search terms are interacted with.
 
 This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
 

--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -21,6 +21,10 @@ export default class Autocomplete extends LitElement {
    * The text to use in the header.
    */
   @property({ type: String, reflect: true }) caption: string = '';
+  /**
+   * The optional search box ID this will check in events.
+   */
+  @property({ type: String, reflect: true }) group: string = '';
 
   /**
    * Constructs an instance of Autocomplete.
@@ -53,7 +57,10 @@ export default class Autocomplete extends LitElement {
    * @param e The event object.
    */
   receivedResults(e: CustomEvent<AutocompleteResponsePayload>) {
-    this.results = e.detail.results || [];
+    const eventGroup = e.detail.group || '';
+    if (eventGroup === this.group) {
+      this.results = e.detail.results || [];
+    }
   }
 
   /**

--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -78,6 +78,7 @@ export default class Autocomplete extends LitElement {
     const sentEvent = new CustomEvent<AutocompleteActiveTermPayload>(AUTOCOMPLETE_ACTIVE_TERM, {
       detail: {
         query: term,
+        group: this.group,
       },
       bubbles: true,
     });

--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -22,7 +22,7 @@ export default class Autocomplete extends LitElement {
    */
   @property({ type: String, reflect: true }) caption: string = '';
   /**
-   * The optional search box ID this will check in events.
+   * The optional group name this will check in events.
    */
   @property({ type: String, reflect: true }) group: string = '';
 

--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -60,7 +60,8 @@ export default class Autocomplete extends LitElement {
    */
   receivedResults(e: CustomEvent<AutocompleteResponsePayload>) {
     const eventGroup = e.detail.group || '';
-    if (eventGroup === this.group) {
+    const componentGroup = this.group || '';
+    if (eventGroup === componentGroup) {
       this.results = e.detail.results || [];
     }
   }

--- a/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@sfx/autocomplete/src/autocomplete.ts
@@ -22,7 +22,9 @@ export default class Autocomplete extends LitElement {
    */
   @property({ type: String, reflect: true }) caption: string = '';
   /**
-   * The optional group name this will check in events.
+   * The name of the event group that this component belongs to.
+   * This component will dispatch events with this group in their
+   * payloads and will only react to events that contain this group.
    */
   @property({ type: String, reflect: true }) group: string = '';
 

--- a/packages/web-components/@sfx/autocomplete/stories/index.ts
+++ b/packages/web-components/@sfx/autocomplete/stories/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@sfx/events';
 import {
   getDisplayCode,
-  autocompleteResponseEvent,
+  generateAutocompleteResultsEvent,
   autocompleteResults,
   hidePrompt,
 } from '../../../../../.storybook/common';
@@ -94,7 +94,7 @@ storiesOf('Components|Autocomplete', module)
      `;
     },
     {
-      customEvents: [autocompleteResponseEvent],
+      customEvents: [generateAutocompleteResultsEvent()],
       notes: {
         markdown: `
           ${autocompleteNotesIntro}
@@ -112,6 +112,16 @@ storiesOf('Components|Autocomplete', module)
               1. Visit the **Knobs** tab and modify the text inside the "Optional Title" field.
               2. Navigate to the **Custom Events** tab and emit the event.
               3. See the component update with the payload of the event and the optional title.
+
+            ### If using the SF-X Autocomplete component outside of the SF-X Sayt component, a \`group\` attribute can be used to distinguish what events it should listen to.
+            * This is only needed if multiple Autocomplete components are on the same page and the desire is for them to listen to different events.
+            * The SF-X Sayt component will take care of this.
+            * Ex.
+
+            \`\`\`html
+            <sfx-autocomplete group="group1"></sfx-autocomplete>
+            <sfx-autocomplete group="group2"></sfx-autocomplete>
+            \`\`\`
             `
       }
     }

--- a/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
@@ -133,6 +133,15 @@ describe('Autcomplete Component', () => {
 
       expect(autocomplete.results).to.equal(results);
     });
+
+    it('should default the group in the component to an empty string if it is falsey', () => {
+      autocomplete.group = undefined;
+      event.detail = { results, group: '' };
+
+      autocomplete.receivedResults(event);
+
+      expect(autocomplete.results).to.equal(results);
+    });
   });
 
   describe('handleHoverTerm', () => {

--- a/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
@@ -1,6 +1,6 @@
 import { TemplateResult, LitElement } from 'lit-element';
 import { AUTOCOMPLETE_RESPONSE, AUTOCOMPLETE_ACTIVE_TERM } from '@sfx/events';
-import { expect, spy, stub } from '../utils';
+import { expect, stub } from '../utils';
 import Autocomplete from '../../src/autocomplete';
 
 describe('Autcomplete Component', () => {
@@ -26,11 +26,16 @@ describe('Autcomplete Component', () => {
         expect(autocomplete.title).to.equal('');
       });
     });
+
+    describe('group property', () => {
+      it('should have default value of an empty string', () => {
+        expect(autocomplete.group).to.equal('');
+      });
+    });
   });
 
   describe('connectedCallback', () => {
     let windowAddEventListener;
-    let autocompleteAddEventListener;
 
     beforeEach(() => {
       windowAddEventListener = stub(window, 'addEventListener');
@@ -56,7 +61,6 @@ describe('Autcomplete Component', () => {
 
   describe('disconnectedCallback', () => {
     let windowRemoveEventListener;
-    let autocompleteRemoveEventListener;
 
     beforeEach(() => {
       windowRemoveEventListener = stub(window, 'removeEventListener');
@@ -89,21 +93,45 @@ describe('Autcomplete Component', () => {
   });
 
   describe('receivedResults', () => {
-    it('should update the results property in response to data received', () => {
-      const results = [
-        { title: 'Brands', items: [{ label: 'Cats' }, { label: 'Dogs' }] },
-        { title: 'default', items: [{ label: 'Cars' }, { label: 'Bikes' }] }
-      ];
-
-      autocomplete.receivedResults({ detail: { results } });
-
-      expect(autocomplete.results).to.deep.equal(results);
-    });
+    const results = [
+      { title: 'Brands', items: [{ label: 'Cats' }, { label: 'Dogs' }] },
+      { title: 'default', items: [{ label: 'Cars' }, { label: 'Bikes' }] }
+    ];
+    const group = 'group';
+    let event = {
+      detail: {},
+    };
 
     it('should set the results property to an empty array if the response data is undefined', () => {
-      autocomplete.receivedResults({ detail: {} });
+      autocomplete.receivedResults(event);
 
       expect(autocomplete.results).to.deep.equal([]);
+    });
+
+    it('should set the results when the event group matches the component group', () => {
+      event.detail = { results, group };
+      autocomplete.group = group;
+
+      autocomplete.receivedResults(event);
+
+      expect(autocomplete.results).to.equal(results);
+    });
+
+    it('should not set the results when the group component and the event do not match', () => {
+      event.detail = { results, group };
+      autocomplete.group = 'different group';
+
+      autocomplete.receivedResults(event);
+
+      expect(autocomplete.results).to.deep.equal([]);
+    });
+
+    it('should default the group in the event to an empty string if it is falsey', () => {
+      event.detail = { results, group: undefined };
+
+      autocomplete.receivedResults(event);
+
+      expect(autocomplete.results).to.equal(results);
     });
   });
 

--- a/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
@@ -165,6 +165,7 @@ describe('Autcomplete Component', () => {
     });
 
     it('should emit an event when hovering an autocomplete term', () => {
+      const group = autocomplete.group = 'some-group';
       const CustomEvent = stub(window, 'CustomEvent').returns({});
       const mouseEvent = {
         target: {
@@ -177,6 +178,7 @@ describe('Autcomplete Component', () => {
 
       expect(CustomEvent).to.be.calledWith(AUTOCOMPLETE_ACTIVE_TERM, {
         detail: {
+          group,
           query: mouseEvent.target.innerText,
         },
         bubbles: true,

--- a/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@sfx/autocomplete/test/unit/autocomplete.test.ts
@@ -117,7 +117,7 @@ describe('Autcomplete Component', () => {
       expect(autocomplete.results).to.equal(results);
     });
 
-    it('should not set the results when the group component and the event do not match', () => {
+    it('should not set the results when the group in the component and the event do not match', () => {
       event.detail = { results, group };
       autocomplete.group = 'different group';
 

--- a/packages/web-components/@sfx/products/CHANGELOG.md
+++ b/packages/web-components/@sfx/products/CHANGELOG.md
@@ -9,3 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SFX-200: Created the products wrapper.
   - This component renders a series of sfx-product components.
   - SFX-248: The `@sfx/events` package is used for event names and payload interfaces.
+  - SFX-354: `sfx-products` and `sfx-products-sayt` extend from `sfx-products-base`
+    and listen on Search and SAYT-related events respectively.

--- a/packages/web-components/@sfx/products/README.md
+++ b/packages/web-components/@sfx/products/README.md
@@ -21,7 +21,7 @@ The base component can be used to display product data directly through attribut
 
 #### Group
 
-This optional attribute will add a Products component to a grouping of related components that communicate with each other. It can be used on any of the Products components.
+This optional attribute will add a Products component to a grouping of related components that communicate with each other. The component will only act on events if they contain the same group name as the component. It can be used in any of the Products components.
 
 Ex.
 ```html

--- a/packages/web-components/@sfx/products/README.md
+++ b/packages/web-components/@sfx/products/README.md
@@ -48,7 +48,7 @@ Upon receiving this event, the `sfx-products-sayt` component will populate the `
 
 ### Functionality
 
-The Search version of the Products component is used to display search results.
+The Search version of the Products component is used to display search results. It is extended from the `sfx-products-base` component.
 
 This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
 

--- a/packages/web-components/@sfx/products/README.md
+++ b/packages/web-components/@sfx/products/README.md
@@ -15,7 +15,7 @@ There are three versions of the Products component:
 
 The base component can be used to display product data directly through attributes; however, it does not listen to any events for product data.
 
-*NOTE: This component is not meant to be used directly, but is provided as an option to extend and create a custom Products component.*
+**NOTE:** This component is not meant to be used directly, but is provided as an option to extend and create a custom Products component.
 
 ### Customization
 
@@ -28,7 +28,7 @@ Ex.
 <sfx-products group="search-group-1"></sfx-products>
 ```
 
-*NOTE: This attribute is unnecessary if there is only one group and sayt pairing and one product search results grid on the webpage.*
+**NOTE:** This attribute is unnecessary if there is only one group and sayt pairing and one product search results grid on the webpage.
 
 ## sfx-products-sayt
 

--- a/packages/web-components/@sfx/products/README.md
+++ b/packages/web-components/@sfx/products/README.md
@@ -1,18 +1,45 @@
 # SF-X Products Component
 
 ## Functionality
-The `sfx-products` component acts as a wrapper around a series of individual
+The Products component acts as a wrapper around a series of individual
 `sfx-product` components. It uses a list of information about products
 and passes each item to a single product for rendering.
 
-### Received Events
+There are three versions of the Products component:
+- `sfx-products-base`
+- `sfx-products-sayt`
+- `sfx-products`
 
-#### `sfx::sayt_products_response`
-Upon receiving this event, the `sfx-products` component will accept
-the passed products data and update/add/remove any child product tiles.
+### sfx-products-base
+The base component can be used to display product data directly through attributes; however, it does not listen to any events for product data. It can be extended for event listening by adding an event listener for a desired event with the `setProductsFromEvent()` callback in the component's `connnectedCallback()`.
+
+Ex.
+```js
+connectedCallback() {
+  super.connectedCallback();
+
+  window.addEventListener(EVENT_NAME, this.setProductsFromEvent);
+}
+```
+
+*NOTE: This component is not meant to be used directly, but is provided as an option to extend and create a custom Products component.*
+
+### sfx-products-sayt
+The Sayt version of the Products component is used inside of a Sayt component. It listens for the `sfx::provide-products` event and will update its product grid with the event's payload.
+
+### sfx-products
+The Search version of the Products component is used to display search results. It listens for the `sfx::search_response` event and will update its product grid with the event's payload.
 
 ## Customization
-This component does not have any customization attributes.
+### Group
+This optional attribute will add a Products component to a grouping of related components that communicate with each other. It can be used on any of the Products components.
+
+Ex.
+```html
+<sfx-products group="search-group-1"></sfx-products>
+```
+
+*NOTE: This attribute is unnecessary if there is only one group and sayt pairing and one product search results grid on the webpage.*
 
 ## Testing
 The test suite for this component is contained in `/packages/web-components/@sfx/products/test`.

--- a/packages/web-components/@sfx/products/README.md
+++ b/packages/web-components/@sfx/products/README.md
@@ -1,6 +1,5 @@
 # SF-X Products Component
 
-## Functionality
 The Products component acts as a wrapper around a series of individual
 `sfx-product` components. It uses a list of information about products
 and passes each item to a single product for rendering.
@@ -10,28 +9,18 @@ There are three versions of the Products component:
 - `sfx-products-sayt`
 - `sfx-products`
 
-### sfx-products-base
-The base component can be used to display product data directly through attributes; however, it does not listen to any events for product data. It can be extended for event listening by adding an event listener for a desired event with the `setProductsFromEvent()` callback in the component's `connnectedCallback()`.
+## sfx-products-base
 
-Ex.
-```js
-connectedCallback() {
-  super.connectedCallback();
+### Functionality
 
-  window.addEventListener(EVENT_NAME, this.setProductsFromEvent);
-}
-```
+The base component can be used to display product data directly through attributes; however, it does not listen to any events for product data.
 
 *NOTE: This component is not meant to be used directly, but is provided as an option to extend and create a custom Products component.*
 
-### sfx-products-sayt
-The Sayt version of the Products component is used inside of a Sayt component. It listens for the `sfx::provide-products` event and will update its product grid with the event's payload.
+### Customization
 
-### sfx-products
-The Search version of the Products component is used to display search results. It listens for the `sfx::search_response` event and will update its product grid with the event's payload.
+#### Group
 
-## Customization
-### Group
 This optional attribute will add a Products component to a grouping of related components that communicate with each other. It can be used on any of the Products components.
 
 Ex.
@@ -41,8 +30,37 @@ Ex.
 
 *NOTE: This attribute is unnecessary if there is only one group and sayt pairing and one product search results grid on the webpage.*
 
+## sfx-products-sayt
+
+### Functionality
+
+The Sayt version of the Products component is used inside of a Sayt component. It is extended from the `sfx-products-base` component.
+
+This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
+
+### Received Events
+
+#### `SAYT_PRODUCTS_RESPONSE`
+
+Upon receiving this event, the `sfx-products-sayt` component will populate the `products` property and render the data.
+
+## sfx-products
+
+### Functionality
+
+The Search version of the Products component is used to display search results.
+
+This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
+
+### Received Events
+
+#### `SEARCH_RESPONSE`
+
+Upon receiving this event, the `sfx-products` component will populate the `products` property and render the data.
+
 ## Testing
-The test suite for this component is contained in `/packages/web-components/@sfx/products/test`.
+
+The test suite for this package is contained in `/packages/web-components/@sfx/products/test`.
 To run the tests, navigate to this folder and use one of the following commands based on the desired testing flow:
 
 - To run the tests once:
@@ -56,3 +74,5 @@ yarn test
 ```sh
 yarn tdd
 ```
+
+[sfx-events]: https://github.com/groupby/sfx-events

--- a/packages/web-components/@sfx/products/src/index.ts
+++ b/packages/web-components/@sfx/products/src/index.ts
@@ -1,1 +1,3 @@
-export { default as Products } from './products';
+export { default as ProductsBase } from './products-base';
+export { default as ProductsSayt } from './products-sayt';
+export { default as ProductsSearch } from './products-search';

--- a/packages/web-components/@sfx/products/src/products-base.ts
+++ b/packages/web-components/@sfx/products/src/products-base.ts
@@ -7,11 +7,7 @@ import {
   property,
   TemplateResult,
 } from 'lit-element';
-import {
-  SAYT_PRODUCTS_RESPONSE,
-  Product,
-  SaytProductsResponsePayload,
-} from '@sfx/events';
+import { Product } from '@sfx/events';
 
 /**
  * The `sfx-products-base` web component wraps and renders a number of
@@ -20,6 +16,9 @@ import {
  */
 @customElement('sfx-products-base')
 export default class ProductsBase extends LitElement {
+  /**
+   * The product data to be rendered.
+   */
   @property({ type: Array }) products: Product[] = [];
   /**
    * The name of the event group that this component belongs to.

--- a/packages/web-components/@sfx/products/src/products-base.ts
+++ b/packages/web-components/@sfx/products/src/products-base.ts
@@ -12,65 +12,40 @@ import {
 } from '@sfx/events';
 
 /**
- * The `sfx-products` web component wraps and renders a number of
+ * The `sfx-products-base` web component wraps and renders a number of
  * `sfx-product` components. It wraps each `sfx-product` component in an
  * additional wrapper for flexibility.
  */
-@customElement('sfx-products')
-export default class Products extends LitElement {
+@customElement('sfx-products-base')
+export default class ProductsBase extends LitElement {
   @property({ type: Array }) products: Product[] = [];
-
   /**
-   * Binds relevant methods.
+   * The optional search box ID this will check in events.
    */
-  constructor() {
-    super();
-
-    this.setProductsFromEvent = this.setProductsFromEvent.bind(this);
-  }
+  @property({ type: String, reflect: true }) group: string = '';
 
   /**
-   * Registers event listeners and sets the ARIA role. The ARIA role is
-   * set to `list` if one is not already specified.
+   * Sets the ARIA role to `list` if one is not already specified.
    */
   connectedCallback() {
     super.connectedCallback();
 
-
     if (!this.getAttribute('role')) {
       this.setAttribute('role', 'list');
     }
-
-    window.addEventListener(SAYT_PRODUCTS_RESPONSE, this.setProductsFromEvent);
-  }
-
-  /**
-   * Removes event listeners.
-   */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    window.removeEventListener(SAYT_PRODUCTS_RESPONSE, this.setProductsFromEvent);
-  }
-
-  /**
-   * Sets the `products` property from the products in an event.
-   *
-   * @param event An event containing a search result with product data.
-   */
-  setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload>) {
-    this.products = event.detail.products || [];
   }
 
   render(): TemplateResult {
     return html`
       <style>
-        sfx-products {
+        sfx-products,
+        sfx-products-base,
+        sfx-products-sayt {
           display: flex;
           flex-wrap: wrap;
         }
 
-        sfx-products[hidden] {
+        sfx-products-base[hidden] {
           display: none;
         }
 

--- a/packages/web-components/@sfx/products/src/products-base.ts
+++ b/packages/web-components/@sfx/products/src/products-base.ts
@@ -39,6 +39,11 @@ export default class ProductsBase extends LitElement {
     }
   }
 
+  /**
+   * Returns styles to be included with the component. When the
+   * [[render]] function is not being overridden, override this function
+   * to include additional styles for this component.
+   */
   protected renderStyles(): CSSResult {
     return css`
       sfx-products-base {
@@ -55,8 +60,6 @@ export default class ProductsBase extends LitElement {
   render(): TemplateResult {
     return html`
       <style>
-        ${this.renderStyles()}
-
         sfx-product {
           display: block;
         }
@@ -64,6 +67,8 @@ export default class ProductsBase extends LitElement {
         sfx-product[hidden] {
           display: none;
         }
+
+        ${this.renderStyles()}
       </style>
 
       ${this.products.map(product => {

--- a/packages/web-components/@sfx/products/src/products-base.ts
+++ b/packages/web-components/@sfx/products/src/products-base.ts
@@ -20,7 +20,7 @@ import {
 export default class ProductsBase extends LitElement {
   @property({ type: Array }) products: Product[] = [];
   /**
-   * The optional search box ID this will check in events.
+   * The optional group name this will check in events.
    */
   @property({ type: String, reflect: true }) group: string = '';
 

--- a/packages/web-components/@sfx/products/src/products-base.ts
+++ b/packages/web-components/@sfx/products/src/products-base.ts
@@ -1,4 +1,6 @@
 import {
+  css,
+  CSSResult,
   customElement,
   html,
   LitElement,
@@ -37,19 +39,23 @@ export default class ProductsBase extends LitElement {
     }
   }
 
+  protected renderStyles(): CSSResult {
+    return css`
+      sfx-products-base {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      sfx-products-base[hidden] {
+        display: none;
+      }
+    `;
+  }
+
   render(): TemplateResult {
     return html`
       <style>
-        sfx-products,
-        sfx-products-base,
-        sfx-products-sayt {
-          display: flex;
-          flex-wrap: wrap;
-        }
-
-        sfx-products-base[hidden] {
-          display: none;
-        }
+        ${this.renderStyles()}
 
         sfx-product {
           display: block;

--- a/packages/web-components/@sfx/products/src/products-base.ts
+++ b/packages/web-components/@sfx/products/src/products-base.ts
@@ -20,7 +20,9 @@ import {
 export default class ProductsBase extends LitElement {
   @property({ type: Array }) products: Product[] = [];
   /**
-   * The optional group name this will check in events.
+   * The name of the event group that this component belongs to.
+   * This component will dispatch events with this group in their
+   * payloads and will only react to events that contain this group.
    */
   @property({ type: String, reflect: true }) group: string = '';
 

--- a/packages/web-components/@sfx/products/src/products-sayt.ts
+++ b/packages/web-components/@sfx/products/src/products-sayt.ts
@@ -48,7 +48,8 @@ export default class ProductsSayt extends ProductsBase {
    */
   setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload>) {
     const eventGroup = event.detail.group || '';
-    if (eventGroup === this.group) {
+    const componentGroup = this.group || '';
+    if (eventGroup === componentGroup) {
       this.products = event.detail.products || [];
     }
   }

--- a/packages/web-components/@sfx/products/src/products-sayt.ts
+++ b/packages/web-components/@sfx/products/src/products-sayt.ts
@@ -1,4 +1,4 @@
-import { customElement } from 'lit-element';
+import { css, CSSResult, customElement } from 'lit-element';
 import {
   SAYT_PRODUCTS_RESPONSE,
   SaytProductsResponsePayload,
@@ -49,5 +49,18 @@ export default class ProductsSayt extends ProductsBase {
     if (eventGroup === this.group) {
       this.products = event.detail.products || [];
     }
+  }
+
+  protected renderStyles(): CSSResult {
+    return css`
+      sfx-products-sayt {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      sfx-products-sayt[hidden] {
+        display: none;
+      }
+    `;
   }
 }

--- a/packages/web-components/@sfx/products/src/products-sayt.ts
+++ b/packages/web-components/@sfx/products/src/products-sayt.ts
@@ -9,6 +9,8 @@ import { ProductsBase } from './';
  * The `sfx-products-sayt` web component wraps and renders a number of
  * `sfx-product` components. It wraps each `sfx-product` component in an
  * additional wrapper for flexibility.
+ *
+ * This component updates upon receiving a [[SAYT_PRODUCTS_RESPONSE]] event.
  */
 @customElement('sfx-products-sayt')
 export default class ProductsSayt extends ProductsBase {

--- a/packages/web-components/@sfx/products/src/products-sayt.ts
+++ b/packages/web-components/@sfx/products/src/products-sayt.ts
@@ -1,0 +1,53 @@
+import { customElement } from 'lit-element';
+import {
+  SAYT_PRODUCTS_RESPONSE,
+  SaytProductsResponsePayload,
+} from '@sfx/events';
+import { ProductsBase } from './';
+
+/**
+ * The `sfx-products-sayt` web component wraps and renders a number of
+ * `sfx-product` components. It wraps each `sfx-product` component in an
+ * additional wrapper for flexibility.
+ */
+@customElement('sfx-products-sayt')
+export default class ProductsSayt extends ProductsBase {
+  /**
+   * Binds relevant methods.
+   */
+  constructor() {
+    super();
+
+    this.setProductsFromEvent = this.setProductsFromEvent.bind(this);
+  }
+
+  /**
+   * Registers event listeners.
+   */
+  connectedCallback() {
+    super.connectedCallback();
+
+    window.addEventListener(SAYT_PRODUCTS_RESPONSE, this.setProductsFromEvent);
+  }
+
+  /**
+   * Removes event listeners.
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    window.removeEventListener(SAYT_PRODUCTS_RESPONSE, this.setProductsFromEvent);
+  }
+
+  /**
+   * Sets the `products` property from the products in an event.
+   *
+   * @param event An event containing a search result with product data.
+   */
+  setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload>) {
+    const eventGroup = event.detail.group || '';
+    if (eventGroup === this.group) {
+      this.products = event.detail.products || [];
+    }
+  }
+}

--- a/packages/web-components/@sfx/products/src/products-search.ts
+++ b/packages/web-components/@sfx/products/src/products-search.ts
@@ -1,4 +1,4 @@
-import { customElement } from 'lit-element';
+import { css, CSSResult, customElement } from 'lit-element';
 import {
   SEARCH_RESPONSE,
   SearchResponsePayload,
@@ -49,5 +49,18 @@ export default class ProductsSearch extends ProductsBase {
     if (eventGroup === this.group) {
       this.products = event.detail.results.records || [];
     }
+  }
+
+  protected renderStyles(): CSSResult {
+    return css`
+      sfx-products {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      sfx-products[hidden] {
+        display: none;
+      }
+    `;
   }
 }

--- a/packages/web-components/@sfx/products/src/products-search.ts
+++ b/packages/web-components/@sfx/products/src/products-search.ts
@@ -48,7 +48,8 @@ export default class ProductsSearch extends ProductsBase {
    */
   setProductsFromEvent(event: CustomEvent<SearchResponsePayload>) {
     const eventGroup = event.detail.group || '';
-    if (eventGroup === this.group) {
+    const componentGroup = this.group || '';
+    if (eventGroup === componentGroup) {
       this.products = event.detail.results.records || [];
     }
   }

--- a/packages/web-components/@sfx/products/src/products-search.ts
+++ b/packages/web-components/@sfx/products/src/products-search.ts
@@ -9,6 +9,8 @@ import { ProductsBase } from '.';
  * The `sfx-products` web component wraps and renders a number of
  * `sfx-product` components. It wraps each `sfx-product` component in an
  * additional wrapper for flexibility.
+ *
+ * This component updates upon receiving a [[SEARCH_RESPONSE]] event.
  */
 @customElement('sfx-products')
 export default class ProductsSearch extends ProductsBase {

--- a/packages/web-components/@sfx/products/src/products-search.ts
+++ b/packages/web-components/@sfx/products/src/products-search.ts
@@ -1,0 +1,53 @@
+import { customElement } from 'lit-element';
+import {
+  SEARCH_RESPONSE,
+  SearchResponsePayload,
+} from '@sfx/events';
+import { ProductsBase } from '.';
+
+/**
+ * The `sfx-products` web component wraps and renders a number of
+ * `sfx-product` components. It wraps each `sfx-product` component in an
+ * additional wrapper for flexibility.
+ */
+@customElement('sfx-products')
+export default class ProductsSearch extends ProductsBase {
+  /**
+   * Binds relevant methods.
+   */
+  constructor() {
+    super();
+
+    this.setProductsFromEvent = this.setProductsFromEvent.bind(this);
+  }
+
+  /**
+   * Registers event listeners.
+   */
+  connectedCallback() {
+    super.connectedCallback();
+
+    window.addEventListener(SEARCH_RESPONSE, this.setProductsFromEvent);
+  }
+
+  /**
+   * Removes event listeners.
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    window.removeEventListener(SEARCH_RESPONSE, this.setProductsFromEvent);
+  }
+
+  /**
+   * Sets the `products` property from the products in an event.
+   *
+   * @param event An event containing a search result with product data.
+   */
+  setProductsFromEvent(event: CustomEvent<SearchResponsePayload>) {
+    const eventGroup = event.detail.group || '';
+    if (eventGroup === this.group) {
+      this.products = event.detail.results.records || [];
+    }
+  }
+}

--- a/packages/web-components/@sfx/products/stories/index.ts
+++ b/packages/web-components/@sfx/products/stories/index.ts
@@ -2,22 +2,23 @@ import { storiesOf } from '@storybook/html';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import {
   SAYT_PRODUCTS_RESPONSE,
+  SEARCH_RESPONSE,
   Product,
 } from '@sfx/events';
 import {
   getDisplayCode,
   getProducts,
-  saytProductsResponseEvent,
+  generateProductsResultsEvent,
   hidePrompt,
 } from '../../../../../.storybook/common';
 import '..';
 
-function getProductsComponent(productsArray: Product[] = []) {
+function getProductsComponent(productsArray: Product[] = [], componentSuffix: String) {
   if (productsArray.length > 0) {
     const products = text('Products', JSON.stringify(productsArray));
-    return `<sfx-products products="${products}"></sfx-products>`
+    return `<sfx-products${componentSuffix} products="${products}"></sfx-products${componentSuffix}>`
   } else {
-    return '<sfx-products></sfx-products>';
+    return `<sfx-products${componentSuffix}></sfx-products${componentSuffix}>`;
   }
 }
 
@@ -26,7 +27,7 @@ const productsNotesMarkdownIntro = ` # SF-X Products Component
 [Package README](https://github.com/groupby/sfx-view/tree/master/packages/web-components/%40sfx/products "SF-X Products README").
 
 \`\`\`html
-<sfx-products></sfx-products>
+<sfx-products-base></sfx-products-base>
 \`\`\`
 
 ## Demonstrated in this story`;
@@ -36,20 +37,19 @@ storiesOf('Components|Products', module)
   .add(
     'Default',
     () => {
-      const productsComponent = getProductsComponent(getProducts(10));
+      const productsComponent = getProductsComponent(getProducts(10), '-base');
       return `
     ${productsComponent}
     `;
     },
     {
-      customEvents: [saytProductsResponseEvent],
       notes: {
         markdown: `
         ${productsNotesMarkdownIntro}
 
-          ### The SF-X Products component populated with hardcoded products data.
+          ### The SF-X Products Base component populated with hardcoded products data.
 
-          * The SF-X Products component renders a collection of products, with the data passed directly via the  \`products\` attribute.
+          * The SF-X Products Base component renders a collection of products, with the data passed directly via the  \`products\` attribute.
           * ***Disclaimer***: although possible, it is not recommended to pass arrays of data via an attribute.
           * To modify the data within the \`products\` attribute in this story:
             1. Visit the **Knobs** tab and update the data inside the "Products" field.
@@ -57,7 +57,7 @@ storiesOf('Components|Products', module)
 
 
           \`\`\`html
-          <sfx-products
+          <sfx-products-base
             products="[
               {
                 title: 'Best Shoe',
@@ -77,34 +77,95 @@ storiesOf('Components|Products', module)
                   'https://images.unsplash.com/photo-1515955656352-a1fa3ffcd111?ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&h=350&amp;q=80',
                 imageAlt: 'A classic blue shoe',
               }
-          ]"></sfx-products>
+          ]"></sfx-products-base>
           \`\`\`
           `
       }
     }
   ).add(
-    'Rendering with event payload',
+    'Products from Sayt events',
     () => {
       hidePrompt(SAYT_PRODUCTS_RESPONSE);
-      const productsComponent = getProductsComponent();
+      const productsComponent = getProductsComponent([], '-sayt');
       return `
-      ${productsComponent}
-      <p class="prompt">Explore the <b>Custom Events</b> and <b>Knobs</b> tabs to render the component.</p>
-      ${getDisplayCode(productsComponent)}
-    `;
+        ${productsComponent}
+        <p class="prompt">Explore the <b>Custom Events</b> and <b>Knobs</b> tabs to render the component.</p>
+        ${getDisplayCode(productsComponent)}
+      `;
     },
     {
-      customEvents: [saytProductsResponseEvent],
+      customEvents: [generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3)],
       notes: {
         markdown: `
-        ${productsNotesMarkdownIntro}
+          # SF-X Products Sayt Component
 
-          ### The SF-X Products component renders a product grid in response to the \`${SAYT_PRODUCTS_RESPONSE}\` event.
+          [Package README](https://github.com/groupby/sfx-view/tree/master/packages/web-components/%40sfx/products "SF-X Products README").
+
+          \`\`\`html
+          <sfx-products-sayt></sfx-products-sayt>
+          \`\`\`
+
+          ## Demonstrated in this story
+
+          ### The SF-X Products Sayt component is used inside of a Sayt component. It renders a product grid in response to the \`${SAYT_PRODUCTS_RESPONSE}\` event.
             * The payload of the event contains an array of products.
             * To emit the event in this story:
               1. Visit the **Custom Events** tab and locate the \`${SAYT_PRODUCTS_RESPONSE}\` event.
               2. Click "emit".
               3. See the component update with the product data contained in the array.
+
+          ### If using the SF-X Products Sayt component outside of the SF-X Sayt component, a \`group\` attribute can be used to distinguish what events it should listen to.
+          * This is only needed if multiple Products Sayt components are on the same page and the desire is for them to listen to different events.
+          * The SF-X Sayt component will take care of this.
+          * Ex.
+
+          \`\`\`html
+          <sfx-products-sayt group="group1"></sfx-products-sayt>
+          <sfx-products-sayt group="group2"></sfx-products-sayt>
+          \`\`\`
+        `
+      }
+    }
+  ).add(
+    'Products from Search events',
+    () => {
+      hidePrompt(SEARCH_RESPONSE);
+      const productsComponent = getProductsComponent([], '');
+      return `
+        ${productsComponent}
+        <p class="prompt">Explore the <b>Custom Events</b> and <b>Knobs</b> tabs to render the component.</p>
+        ${getDisplayCode(productsComponent)}
+      `;
+    },
+    {
+      customEvents: [generateProductsResultsEvent(SEARCH_RESPONSE, 15)],
+      notes: {
+        markdown: `
+          # SF-X Products Sayt Component
+
+          [Package README](https://github.com/groupby/sfx-view/tree/master/packages/web-components/%40sfx/products "SF-X Products README").
+
+          \`\`\`html
+          <sfx-products></sfx-products>
+          \`\`\`
+
+          ## Demonstrated in this story
+
+          ### The SF-X Products component can be used as a product listing grid. It renders a grid in response to the \`${SEARCH_RESPONSE}\` event.
+            * The payload of the event contains an array of products.
+            * To emit the event in this story:
+              1. Visit the **Custom Events** tab and locate the \`${SEARCH_RESPONSE}\` event.
+              2. Click "emit".
+              3. See the component update with the product data contained in the array.
+
+          ### The Products component can take a \`group\` attribute to determine what group of events it will listen to.
+            * Can be useful if mulitple product grids that render products from different collections or a specific subset of a collection are on the page.
+              * Ex.
+
+            \`\`\`html
+            <sfx-products group="group1"></sfx-products>
+            <sfx-products group="group2"></sfx-products>
+            \`\`\`
         `
       }
     }

--- a/packages/web-components/@sfx/products/stories/index.ts
+++ b/packages/web-components/@sfx/products/stories/index.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../../.storybook/common';
 import '..';
 
-function getProductsComponent(productsArray: Product[] = [], componentSuffix: String) {
+function getProductsComponent(productsArray: Product[] = [], componentSuffix: string) {
   if (productsArray.length > 0) {
     const products = text('Products', JSON.stringify(productsArray));
     return `<sfx-products${componentSuffix} products="${products}"></sfx-products${componentSuffix}>`

--- a/packages/web-components/@sfx/products/stories/index.ts
+++ b/packages/web-components/@sfx/products/stories/index.ts
@@ -8,7 +8,8 @@ import {
 import {
   getDisplayCode,
   getProducts,
-  generateProductsResultsEvent,
+  generateSaytProductsResponseEvent,
+  generateSearchResponseEvent,
   hidePrompt,
 } from '../../../../../.storybook/common';
 import '..';
@@ -94,7 +95,7 @@ storiesOf('Components|Products', module)
       `;
     },
     {
-      customEvents: [generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3)],
+      customEvents: [generateSaytProductsResponseEvent(3)],
       notes: {
         markdown: `
           # SF-X Products Sayt Component
@@ -138,7 +139,7 @@ storiesOf('Components|Products', module)
       `;
     },
     {
-      customEvents: [generateProductsResultsEvent(SEARCH_RESPONSE, 15)],
+      customEvents: [generateSearchResponseEvent(15)],
       notes: {
         markdown: `
           # SF-X Products Sayt Component

--- a/packages/web-components/@sfx/products/test/unit/products.test.ts
+++ b/packages/web-components/@sfx/products/test/unit/products.test.ts
@@ -1,16 +1,26 @@
 import { expect, sinon, stub } from '../utils';
-import Products from '../../src/products';
-import { SAYT_PRODUCTS_RESPONSE } from '@sfx/events';
+import { SAYT_PRODUCTS_RESPONSE, SEARCH_RESPONSE } from '@sfx/events';
+import ProductsBase from '../../src/products-base';
+import ProductsSayt from '../../src/products-sayt';
+import ProductsSearch from '../../src/products-search';
 
-describe('Products Component', () => {
+describe('Products Base Component', () => {
   let component;
   beforeEach(() => {
-    component = new Products();
+    component = new ProductsBase();
   });
 
   describe('constructor', () => {
-    it('should default to have an empty array of products', () => {
-      expect(component.products).to.deep.equal([]);
+    describe('products property', () => {
+      it('should default to be an empty array of products', () => {
+        expect(component.products).to.deep.equal([]);
+      });
+    });
+
+    describe('group property', () => {
+      it('should have default value of an empty string', () => {
+        expect(component.group).to.equal('');
+      });
     });
   });
 
@@ -39,6 +49,23 @@ describe('Products Component', () => {
       component.connectedCallback();
 
       expect(setAttribute).to.not.be.called;
+    });
+  });
+});
+
+describe('Products Sayt Component', () => {
+  let component;
+  beforeEach(() => {
+    component = new ProductsSayt();
+  });
+
+  describe('connectedCallback', () => {
+    it('should call super', () => {
+      const superConnected = stub(Object.getPrototypeOf(component), 'connectedCallback');
+
+      component.connectedCallback();
+
+      expect(superConnected).to.be.calledOnce;
     });
 
     it('should set up event listener for a provide-products event to set products', () => {
@@ -69,21 +96,127 @@ describe('Products Component', () => {
   });
 
   describe('setProductsFromEvent', () => {
-    it('should set the event products payload into the component', () => {
-      const products = [1, 2, 3];
-      const event = { detail: { products } };
+    let products;
+    let group;
+    beforeEach(() => {
+      products = [1, 2, 3];
+      group = 'group';
+    });
+
+    it('should set products to an empty array if the event payload does not contain products', () => {
+      const event = { detail: {} };
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.deep.equal([]);
+    });
+
+    it('should set products when the event matches the group in the component', () => {
+      const event = { detail: { products, group } };
+      component.group = group;
 
       component.setProductsFromEvent(event);
 
       expect(component.products).to.equal(products);
     });
 
-    it('should set the products property to an empty array if payload of the event is undefined', () => {
-      const event = { detail: { results: {} } };
+    it('should not set products when the group in the component and event do not match', () => {
+      const event = { detail: { products, group } };
 
       component.setProductsFromEvent(event);
 
       expect(component.products).to.deep.equal([]);
+    });
+
+    it('should default the group in the event to an empty string if it is falsey', () => {
+      const event = { detail: { products } };
+
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.equal(products);
+    });
+  });
+});
+
+describe('Products Search Component', () => {
+  let component;
+  beforeEach(() => {
+    component = new ProductsSearch();
+  });
+
+  describe('connectedCallback', () => {
+    it('should call super', () => {
+      const superConnected = stub(Object.getPrototypeOf(component), 'connectedCallback');
+
+      component.connectedCallback();
+
+      expect(superConnected).to.be.calledOnce;
+    });
+
+    it('should set up event listener for a provide-products event to set products', () => {
+      const addEventListener = sinon.stub(window, 'addEventListener');
+
+      component.connectedCallback();
+
+      expect(addEventListener).to.be.calledWith(SEARCH_RESPONSE, component.setProductsFromEvent);
+    });
+  });
+
+  describe('disconnectedCallback', () => {
+    it('should call super', () => {
+      const superDisconnected = stub(Object.getPrototypeOf(component), 'disconnectedCallback');
+
+      component.disconnectedCallback();
+
+      expect(superDisconnected).to.be.calledOnce;
+    });
+
+    it('should remove provide-products event listener', () => {
+      const removeEventListener = sinon.stub(window, 'removeEventListener');
+
+      component.disconnectedCallback();
+
+      expect(removeEventListener).to.be.calledWith(SEARCH_RESPONSE, component.setProductsFromEvent);
+    });
+  });
+
+  describe('setProductsFromEvent', () => {
+    let records;
+    let group;
+    beforeEach(() => {
+      records = [1, 2, 3];
+      group = 'group';
+    });
+
+    it('should set products to an empty array if the event payload does not contain records', () => {
+      const event = { detail: { results: {} } };
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.deep.equal([]);
+    });
+
+    it('should set products when the event matches the group in the component', () => {
+      const event = { detail: { results: { records }, group } };
+      component.group = group;
+
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.equal(records);
+    });
+
+    it('should not set products when the group in the component and event do not match', () => {
+      const event = { detail: { results: { records }, group } };
+
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.deep.equal([]);
+    });
+
+    it('should default the group in the event to an empty string if it is falsey', () => {
+      const event = { detail: { results: { records } } };
+
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.equal(records);
     });
   });
 });

--- a/packages/web-components/@sfx/products/test/unit/products.test.ts
+++ b/packages/web-components/@sfx/products/test/unit/products.test.ts
@@ -70,7 +70,7 @@ describe('Products Sayt Component', () => {
       expect(superConnected).to.be.calledOnce;
     });
 
-    it('should set up event listener for a provide-products event to set products', () => {
+    it('should set up an event listener for a sayt products event to set products', () => {
       const addEventListener = sinon.stub(window, 'addEventListener');
 
       component.connectedCallback();
@@ -88,7 +88,7 @@ describe('Products Sayt Component', () => {
       expect(superDisconnected).to.be.calledOnce;
     });
 
-    it('should remove provide-products event listener', () => {
+    it('should remove an event listener for sayt products', () => {
       const removeEventListener = sinon.stub(window, 'removeEventListener');
 
       component.disconnectedCallback();
@@ -165,7 +165,7 @@ describe('Products Search Component', () => {
       expect(superConnected).to.be.calledOnce;
     });
 
-    it('should set up event listener for a provide-products event to set products', () => {
+    it('should set up an event listener for a search response to set products', () => {
       const addEventListener = sinon.stub(window, 'addEventListener');
 
       component.connectedCallback();
@@ -183,7 +183,7 @@ describe('Products Search Component', () => {
       expect(superDisconnected).to.be.calledOnce;
     });
 
-    it('should remove provide-products event listener', () => {
+    it('should remove an event listener for search responses', () => {
       const removeEventListener = sinon.stub(window, 'removeEventListener');
 
       component.disconnectedCallback();

--- a/packages/web-components/@sfx/products/test/unit/products.test.ts
+++ b/packages/web-components/@sfx/products/test/unit/products.test.ts
@@ -6,6 +6,7 @@ import ProductsSearch from '../../src/products-search';
 
 describe('Products Base Component', () => {
   let component;
+
   beforeEach(() => {
     component = new ProductsBase();
   });
@@ -55,6 +56,7 @@ describe('Products Base Component', () => {
 
 describe('Products Sayt Component', () => {
   let component;
+
   beforeEach(() => {
     component = new ProductsSayt();
   });
@@ -98,6 +100,7 @@ describe('Products Sayt Component', () => {
   describe('setProductsFromEvent', () => {
     let products;
     let group;
+
     beforeEach(() => {
       products = [1, 2, 3];
       group = 'group';
@@ -139,6 +142,7 @@ describe('Products Sayt Component', () => {
 
 describe('Products Search Component', () => {
   let component;
+
   beforeEach(() => {
     component = new ProductsSearch();
   });
@@ -182,6 +186,7 @@ describe('Products Search Component', () => {
   describe('setProductsFromEvent', () => {
     let records;
     let group;
+
     beforeEach(() => {
       records = [1, 2, 3];
       group = 'group';

--- a/packages/web-components/@sfx/products/test/unit/products.test.ts
+++ b/packages/web-components/@sfx/products/test/unit/products.test.ts
@@ -137,6 +137,15 @@ describe('Products Sayt Component', () => {
 
       expect(component.products).to.equal(products);
     });
+
+    it('should default the group in the component to an empty string if it is falsey', () => {
+      component.group = undefined;
+      const event = { detail: { products } };
+
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.equal(products);
+    });
   });
 });
 
@@ -217,6 +226,15 @@ describe('Products Search Component', () => {
     });
 
     it('should default the group in the event to an empty string if it is falsey', () => {
+      const event = { detail: { results: { records } } };
+
+      component.setProductsFromEvent(event);
+
+      expect(component.products).to.equal(records);
+    });
+
+    it('should default the group in the component to an empty string if it is falsey', () => {
+      component.group = undefined;
       const event = { detail: { results: { records } } };
 
       component.setProductsFromEvent(event);

--- a/packages/web-components/@sfx/sayt/CHANGELOG.md
+++ b/packages/web-components/@sfx/sayt/CHANGELOG.md
@@ -7,6 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - SFX-191: Added the `sayt` component.
-  - This component renders `sayt` related components such as `sfx-autocomplete` and `sfx-products`.
+  - This component renders `sayt` related components such as `sfx-autocomplete` and `sfx-products-sayt`.
   - SFX-333: It emits events for requesting products and autocomplete terms.
   - SFX-248: The `@sfx/events` package is used for event names and payload interfaces.

--- a/packages/web-components/@sfx/sayt/README.md
+++ b/packages/web-components/@sfx/sayt/README.md
@@ -3,7 +3,7 @@
 ## Functionality
 
 The `sayt` component acts as a wrapper around the `sfx-autocomplete` and
-`sfx-products` components and acts to show and hide all of these components
+`sfx-products-sayt` components and acts to show and hide all of these components
 in response to interactions with the `sfx-search-box` component.
 
 ### Received Events
@@ -30,6 +30,8 @@ particular customizations:
 - `closeText`: Customizes the text in the close button.
 - `visible`: Determines the visibility of the `sayt` component.
 - `minSearchLength`: The minimum length of the search term required before a SAYT request will be made with it.
+- `searchbox`: Optional ID of the searchbox paired with this component.
+- `group`: Optional attribute to add the `sayt` component to a grouping of related search components.
 
 ## Testing
 

--- a/packages/web-components/@sfx/sayt/README.md
+++ b/packages/web-components/@sfx/sayt/README.md
@@ -6,17 +6,47 @@ The `sayt` component acts as a wrapper around the `sfx-autocomplete` and
 `sfx-products-sayt` components and acts to show and hide all of these components
 in response to interactions with the `sfx-search-box` component.
 
+This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
+
 ### Received Events
 
-#### `sfx::sayt_show`
+#### `SAYT_HIDE`
+
+Upon receiving this event, the `sayt` component will apply the `hidden`
+attribute to itself and hide its child elements.
+
+#### `SAYT_SHOW`
 
 Upon receiving this event, the `sayt` component will remove the `hidden`
 attribute from itself and display its child elements.
 
-#### `sfx::sayt_hide`
+#### `SAYT_PRODUCTS_RESPONSE`
 
-Upon receiving this event, the `sayt` component will apply the `hidden`
-attribute to itself and hide its child elements.
+Upon receiving this event, the `sayt` component will remove the `hidden`
+attribute from itself and display its child elements.
+
+#### `AUTOCOMPLETE_RESPONSE`
+
+Upon receiving this event, the `sayt` component will remove the `hidden`
+attribute from itself and display its child elements.
+
+#### `AUTOCOMPLETE_ACTIVE_TERM`
+
+Upon receiving this event, the `sayt` component will dispatch a request for SAYT Products.
+
+#### `SEARCHBOX_INPUT`
+
+Upon receiving this event, the `sayt` component will dispatch requests for SAYT autocomplete terms and Products based on the included query term.
+
+### DISPATCHED EVENTS
+
+#### `AUTOCOMPLETE_REQUEST`
+
+This event is dispatched to request SAYT autocomplete terms based on the included query term.
+
+#### `SAYT_PRODUCTS_RESPONSE`
+
+This event is dispatched to request SAYT products based on the included query term.
 
 ## Customization
 
@@ -31,7 +61,7 @@ particular customizations:
 - `visible`: Determines the visibility of the `sayt` component.
 - `minSearchLength`: The minimum length of the search term required before a SAYT request will be made with it.
 - `searchbox`: Optional ID of the searchbox paired with this component.
-- `group`: Optional attribute to add the `sayt` component to a grouping of related search components.
+- `group`: Optional attribute to add the `sayt` component to a grouping of related search components. The component will only act on events if they contain the same group name as the component.
 
 ## Testing
 
@@ -43,3 +73,5 @@ To run the tests, navigate to this folder and use one of the following commands 
 ```sh
 yarn test
 ```
+
+[sfx-events]: https://github.com/groupby/sfx-events

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -240,7 +240,9 @@ export default class Sayt extends LitElement {
    * @param event The hover event dispatched from autocomplete.
    */
   handleAutocompleteTermHover(event: CustomEvent<AutocompleteActiveTermPayload>) {
-    this.requestSaytProducts(event.detail.query);
+    if (this.isCorrectSayt(event)) {
+      this.requestSaytProducts(event.detail.query);
+    }
   }
 
   /**

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -214,7 +214,7 @@ export default class Sayt extends LitElement {
   }
 
   /**
-   * Dispatches an [[AUTOCOMPLETE_RESPONSE]] event with the provided data.
+   * Dispatches an [[AUTOCOMPLETE_REQUEST]] event with the provided data.
    *
    * @param query The search term to use.
    */

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -353,13 +353,13 @@ export default class Sayt extends LitElement {
         ${this.hideAutocomplete
           ? ''
           : html`
-            <sfx-autocomplete group="${ifDefined(this.group ? this.group : undefined)}">
+            <sfx-autocomplete group="${ifDefined(this.group)}">
             </sfx-autocomplete>`
         }
         ${this.hideProducts
           ? ''
           : html`
-            <sfx-products-sayt group="${ifDefined(this.group ? this.group : undefined)}">
+            <sfx-products-sayt group="${ifDefined(this.group)}">
             </sfx-products-sayt>`
         }
       </div>

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -259,7 +259,7 @@ export default class Sayt extends LitElement {
    * @param event The [[SEARCHBOX_INPUT]] event dispatched from the searchbox.
    */
   processSfxSearchboxChange(event: CustomEvent<SearchboxInputPayload>) {
-    if (event.detail.group === this.group) {
+    if (this.isCorrectSayt(event)) {
       this.requestSayt(event.detail.term);
     }
   }

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -37,7 +37,7 @@ export default class Sayt extends LitElement {
    */
   @property({ type: String, reflect: true }) searchbox = '';
   /**
-   * Stores the group ID this component belongs to.
+   * The optional group name this will check in events.
    */
   @property({ type: String, reflect: true }) group = '';
   /**
@@ -183,7 +183,7 @@ export default class Sayt extends LitElement {
 
   /**
    * Triggers requests for Sayt autocomplete terms and Sayt products
-   * simultaneously using a query and group ID.
+   * simultaneously using a query and group name.
    * They will only be called if the term is at least [[minSearchLength]] long.
    *
    * @param query The search term to use.
@@ -253,7 +253,8 @@ export default class Sayt extends LitElement {
   }
 
   /**
-   * Handles SF-X searchbox changes by passing the event's value to `requestSayt()`.
+   * Handles SF-X searchbox changes by passing the event's value to `requestSayt()`
+   * if [[isCorrectSayt]] returns `true`.
    * Used when a `searchbox` ID is not passed to the Sayt component.
    *
    * @param event The [[SEARCHBOX_INPUT]] event dispatched from the searchbox.
@@ -266,10 +267,10 @@ export default class Sayt extends LitElement {
 
   /**
    * Determines whether an event refers to the correct SAYT. This is true if
-   * a matching `group` ID is specified in the event. If a `group` ID does not
-   * exist in the event then it will default to an empty string.
+   * the `group` in the event matches this component's group. If `group` is not defined
+   * in the event, it will default to an empty string.
    *
-   * @param event An event that contains a group ID for comparison.
+   * @param event An event that contains a group name for comparison.
    */
   isCorrectSayt(event: CustomEvent<WithGroup>): boolean {
     const group = event.detail && event.detail.group || '';

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -37,7 +37,9 @@ export default class Sayt extends LitElement {
    */
   @property({ type: String, reflect: true }) searchbox = '';
   /**
-   * The optional group name this will check in events.
+   * The name of the event group that this component belongs to.
+   * This component will dispatch events with this group in their
+   * payloads and will only react to events that contain this group.
    */
   @property({ type: String, reflect: true }) group = '';
   /**

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -1,5 +1,5 @@
 import { LitElement, customElement, html, property, PropertyValues } from 'lit-element';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import {
   AUTOCOMPLETE_ACTIVE_TERM,
   AUTOCOMPLETE_REQUEST,

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -13,6 +13,7 @@ import '../src';
 import {
   generateAutocompleteResultsEvent,
   generateProductsResultsEvent,
+  getSaytProductsResponseEvent,
   getDisplayCode,
   autocompleteResults,
   hidePrompt,
@@ -195,7 +196,7 @@ storiesOf('Components|SAYT', module)
               * \`hideProducts\`
               * \`closeText\`
               * \`minSearchLength\`
-                * **Note**: to observe the impact of modifying this attribute, it is necessary to add an event listener to listen for either the \`${AUTOCOMPLETE_RESPONSE} \`or \`${SAYT_PRODUCTS_REQUEST}\` events. These events will trigger when the number of characters typed into the input box is equal to or greater than the number defined in the attribute.
+                * **Note**: to observe the impact of modifying this attribute, it is necessary to add an event listener to listen for either the \`${AUTOCOMPLETE_REQUEST} \`or \`${SAYT_PRODUCTS_REQUEST}\` events. These events will trigger when the number of characters typed into the input box is equal to or greater than the number defined in the attribute.
             * To modify these attributes:
               1. Visit the **Knobs** tab and click any of the "Hide Autocomplete", "Hide Products", and "Show Close button'", and/or update the text contained within the "Close link text" field.
               2. Emit the appropriate events

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -12,7 +12,7 @@ import {
 import '../src';
 import {
   generateAutocompleteResultsEvent,
-  generateProductsResultsEvent,
+  generateSaytProductsResponseEvent,
   getSaytProductsResponseEvent,
   getDisplayCode,
   autocompleteResults,
@@ -142,7 +142,7 @@ storiesOf('Components|SAYT', module)
     },
     {
       customEvents: [
-        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3),
+        generateSaytProductsResponseEvent(3),
         generateAutocompleteResultsEvent(),
         generateSaytHideEvent(),
         generateSaytShowEvent(),
@@ -249,7 +249,7 @@ storiesOf('Components|SAYT', module)
     },
     {
       customEvents: [
-        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3),
+        generateSaytProductsResponseEvent(3),
         generateAutocompleteResultsEvent(),
         generateSaytHideEvent(),
         generateSaytShowEvent(),
@@ -328,9 +328,9 @@ storiesOf('Components|SAYT', module)
     },
     {
       customEvents: [
-        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3, 'group1'),
+        generateSaytProductsResponseEvent(3, 'group1'),
         generateAutocompleteResultsEvent('group1'),
-        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3, 'group2'),
+        generateSaytProductsResponseEvent(3, 'group2'),
         generateAutocompleteResultsEvent('group2'),
         generateSaytHideEvent('group1'),
         generateSaytShowEvent('group1'),

--- a/packages/web-components/@sfx/sayt/stories/index.ts
+++ b/packages/web-components/@sfx/sayt/stories/index.ts
@@ -11,10 +11,9 @@ import {
 } from '@sfx/events';
 import '../src';
 import {
+  generateAutocompleteResultsEvent,
+  generateProductsResultsEvent,
   getDisplayCode,
-  getSaytProductsResponseEvent,
-  saytProductsResponseEvent,
-  autocompleteResponseEvent,
   autocompleteResults,
   hidePrompt,
 } from '../../../../../.storybook/common';
@@ -33,7 +32,7 @@ const saytNotesMarkdownIntro = ` # SF-X SAYT Component
 
 ## Demonstrated in this story`;
 
-function getSayt(searchbox: string = ''): string {
+function getSayt(searchbox: string = '', group?: string): string {
   const closeText = text('Close link text', '×');
   const showCloseButton = boolean('Show Close button', true) ? 'showclosebutton' : '';
   const hideAutocomplete = boolean('Hide Autocomplete', false) ? 'hideAutocomplete' : '';
@@ -43,6 +42,7 @@ function getSayt(searchbox: string = ''): string {
   return (
     '<sfx-sayt\n' +
     (searchbox ? `  searchbox="${searchbox}"\n` : '') +
+    (group ? `  group="${group}"\n` : '') +
     `  closetext="${closeText}"\n` +
     (showCloseButton ? `  ${showCloseButton}\n` : '') +
     (hideAutocomplete ? `  ${hideAutocomplete}\n` : '') +
@@ -52,14 +52,22 @@ function getSayt(searchbox: string = ''): string {
   );
 }
 
-const saytHide = {
-  name: SAYT_HIDE,
-  payload: ''
+const generateSaytHideEvent = function(group = '') {
+  return {
+    name: SAYT_HIDE,
+    payload: {
+      group
+    },
+  };
 };
 
-const saytShow = {
-  name: SAYT_SHOW,
-  payload: ''
+const generateSaytShowEvent = function(group = '') {
+  return {
+    name: SAYT_SHOW,
+    payload: {
+      group
+    },
+  };
 };
 
 const autocompleteDataReceivedEvent = new CustomEvent<AutocompleteResponsePayload>(AUTOCOMPLETE_RESPONSE, {
@@ -132,7 +140,12 @@ storiesOf('Components|SAYT', module)
         ;
     },
     {
-      customEvents: [saytProductsResponseEvent, autocompleteResponseEvent, saytHide, saytShow],
+      customEvents: [
+        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3),
+        generateAutocompleteResultsEvent(),
+        generateSaytHideEvent(),
+        generateSaytShowEvent(),
+      ],
       notes: {
         markdown: `
         ${saytNotesMarkdownIntro}
@@ -234,8 +247,13 @@ storiesOf('Components|SAYT', module)
     `;
     },
     {
-      customEvents: [saytProductsResponseEvent, autocompleteResponseEvent, saytHide, saytShow],
-      notes: {
+      customEvents: [
+        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3),
+        generateAutocompleteResultsEvent(),
+        generateSaytHideEvent(),
+        generateSaytShowEvent(),
+      ],
+        notes: {
         markdown: `
         ${saytNotesMarkdownIntro}
 
@@ -268,8 +286,8 @@ storiesOf('Components|SAYT', module)
       hidePrompt(SAYT_HIDE);
       const input1 = `<input type="text" id="search-box1" placeholder="Search here" />`;
       const input2 = `<input type="text" id="search-box2" placeholder="Or search here" />`;
-      const sayt1 = getSayt('search-box1');
-      const sayt2 = getSayt('search-box2');
+      const sayt1 = getSayt('search-box1', 'group1');
+      const sayt2 = getSayt('search-box2', 'group2');
 
       return `
       <style>
@@ -308,12 +326,21 @@ storiesOf('Components|SAYT', module)
 
     },
     {
-      customEvents: [saytProductsResponseEvent, autocompleteResponseEvent, saytHide, saytShow],
-      notes: {
+      customEvents: [
+        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3, 'group1'),
+        generateAutocompleteResultsEvent('group1'),
+        generateProductsResultsEvent(SAYT_PRODUCTS_RESPONSE, 3, 'group2'),
+        generateAutocompleteResultsEvent('group2'),
+        generateSaytHideEvent('group1'),
+        generateSaytShowEvent('group1'),
+        generateSaytHideEvent('group2'),
+        generateSaytShowEvent('group2'),
+      ],
+        notes: {
         markdown: `
           ${saytNotesMarkdownIntro}
 
-            ### Two SF-X SAYT components act independently when mulitple SAYT components are included on a page, if the \`searchbox\` attribute is set.
+            ### Two SF-X SAYT components act independently when mulitple SAYT components are included on a page, if the \`group\` attribute is set.
               * A click on one SAYT component will result in the other SAYT closing.
               * To demonstrate in this story:
                 1. Open both SAYTs.
@@ -334,6 +361,7 @@ storiesOf('Components|SAYT', module)
       <input type="text" id="search-box1" placeholder="Search here" />
       <sfx-sayt
         searchbox="search-box1"
+        group="group1"
         closetext="×"
         showclosebutton
         visible
@@ -341,6 +369,7 @@ storiesOf('Components|SAYT', module)
       <input type="text" id="search-box2" placeholder="Search here" />
       <sfx-sayt
         searchbox="search-box2"
+        group="group2"
         closetext="×"
         showclosebutton
         visible

--- a/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
@@ -356,13 +356,20 @@ describe('Sayt Component', () => {
   });
 
   describe('processSfxSearchboxChange()', () => {
+    let term;
+    let event;
+    let isCorrectSayt;
+    let requestSayt;
+
+    beforeEach(() => {
+      term = 'some-term'
+      event = { detail: { term } };
+      isCorrectSayt = stub(sayt, 'isCorrectSayt');
+      requestSayt = stub(sayt, 'requestSayt');
+    });
+
     it('should trigger a Sayt request if the event and component groups match', () => {
-      const term = 'some-value';
-      const group = sayt.group = 'group'
-      const event = {
-        detail: { term, group },
-      };
-      const requestSayt = stub(sayt, 'requestSayt');
+      isCorrectSayt.returns(true);
 
       sayt.processSfxSearchboxChange(event);
 
@@ -370,12 +377,7 @@ describe('Sayt Component', () => {
     });
 
     it('should not trigger a Sayt request if the event and component groups do not match', () => {
-      const term = 'some-term';
-      const event = {
-        detail: { term, group: 'different-group' },
-      };
-      const requestSayt = stub(sayt, 'requestSayt');
-      sayt.group = 'group'
+      isCorrectSayt.returns(false);
 
       sayt.processSfxSearchboxChange(event);
 

--- a/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
@@ -289,14 +289,34 @@ describe('Sayt Component', () => {
   });
 
   describe('handleAutocompleteTermHover()', () => {
-    it('should call requestSaytProducts() with the event query', () => {
+    let isCorrectSayt;
+
+    beforeEach(() => {
+      isCorrectSayt = stub(sayt, 'isCorrectSayt');
+    });
+
+    it('should call requestSaytProducts() with the event query if the event and component groups match', () => {
+      const group = sayt.group = 'group';
       const requestSaytProducts = stub(sayt, 'requestSaytProducts');
       const query = 'some-query';
-      const event = { detail: { query } };
+      const event = { detail: { query, group } };
+      isCorrectSayt.returns(true);
 
       sayt.handleAutocompleteTermHover(event);
 
       expect(requestSaytProducts).to.be.calledWith(query);
+    });
+
+    it('should not call requestSaytProducts() with the event query if the event and component groups do not match', () => {
+      const requestSaytProducts = stub(sayt, 'requestSaytProducts');
+      const query = 'some-query';
+      const event = { detail: { query, group: 'other-group' } };
+      sayt.group = 'group';
+      isCorrectSayt.returns(false);
+
+      sayt.handleAutocompleteTermHover(event);
+
+      expect(requestSaytProducts).to.not.be.called;
     });
   });
 

--- a/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
@@ -303,7 +303,7 @@ describe('Sayt Component', () => {
   describe('dispatchRequestEvent()', () => {
     it('should dispatch an event with a payload that includes the query and the group property', () => {
       const eventName = 'some-event-name';
-      const group = sayt.group = 'some-group-id';
+      const group = sayt.group = 'some-group-name';
       const query = 'some-query';
       const eventObj = { a: 'a' };
       const customEvent = stub(window, 'CustomEvent').returns(eventObj);
@@ -387,7 +387,7 @@ describe('Sayt Component', () => {
 
   describe('isCorrectSayt()', () => {
     it('should return true if the event provides the correct group name', () => {
-      const group = sayt.group = 'some-group-id';
+      const group = sayt.group = 'some-group-name';
       const event = { detail: { group } };
 
       const result = sayt.isCorrectSayt(event);
@@ -404,8 +404,8 @@ describe('Sayt Component', () => {
       expect(result).to.be.false;
     });
 
-    it('should use an empty string for comparison if the event group name is falsey', () => {
-      const event = { detail: { group: undefined } };
+    it('should use an empty string for comparison if the event group name is undefined', () => {
+      const event = { detail: {} };
       sayt.group = '';
 
       const result = sayt.isCorrectSayt(event);

--- a/packages/web-components/@sfx/search-box/README.md
+++ b/packages/web-components/@sfx/search-box/README.md
@@ -4,27 +4,31 @@
 
 The component accepts text input and dispatches events based on input.
 
-### Events
+This component listens for and dispatches a number of events. These events are defined in the [`@sfx/events`][sfx-events] package.
 
-#### `sfx::searchbox_clear`
+### Received Events
+
+#### `UPDATE_SEARCH_TERM`
+
+This component listens for this event, whose payload is the search term, and updates the value property and input box value with the event's payload.
+
+### Dispatched Events
+
+#### `SEARCHBOX_CLEAR`
 
 Dispatched when a user clicks on the clear button.
 
-#### `sfx::searchbox_click`
+#### `SEARCHBOX_CLICK`
 
 Dispatched when a user clicks anywhere within the search box input area.
 
-#### `sfx::search_request`
-
-Dispatched when a user clicks on the search button or hits `enter` within the search box. This event sends the search term value entered into the search box.
-
-#### `sfx::searchbox_input`
+#### `SEARCHBOX_INPUT`
 
 Dispatched when the value changes inside the search box input.
 
-#### `sfx::update_search_term`
+#### `SEARCH_REQUEST`
 
-This component listens for this event, whose payload is the search term, and updates the value property and input box value with the event's payload.
+Dispatched when a user clicks on the search button or hits `enter` within the search box. This event sends the search term value entered into the search box.
 
 ## Customizations
 
@@ -61,3 +65,5 @@ yarn tdd:interaction
 ```sh
 yarn test:all
 ```
+
+[sfx-events]: https://github.com/groupby/sfx-events

--- a/packages/web-components/@sfx/search-box/README.md
+++ b/packages/web-components/@sfx/search-box/README.md
@@ -33,6 +33,7 @@ Users of the component can add the following attributes to the custom element:
 - `clearbutton`: adds clear button
 - `searchbutton`: adds search button
 - `placeholder`: if populated with a string, will replace the default placeholder text in the search box.
+- `group`: Optional attribute to add this component to a grouping of related search components.
 
 ## Testing
 

--- a/packages/web-components/@sfx/search-box/README.md
+++ b/packages/web-components/@sfx/search-box/README.md
@@ -37,7 +37,7 @@ Users of the component can add the following attributes to the custom element:
 - `clearbutton`: adds clear button
 - `searchbutton`: adds search button
 - `placeholder`: if populated with a string, will replace the default placeholder text in the search box.
-- `group`: Optional attribute to add this component to a grouping of related search components.
+- `group`: Optional attribute to add this component to a grouping of related search components. The component will only act on events if they contain the same group name as the component.
 
 ## Testing
 

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -45,7 +45,7 @@ export default class SearchBox extends Base {
    */
   @property({ type: String, reflect: true }) collection: string = '';
   /**
-   * Determines the group that the component belongs to.
+   * The optional group name this will check in events.
    */
   @property({ type: String, reflect: true }) group: string = '';
 

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -45,7 +45,9 @@ export default class SearchBox extends Base {
    */
   @property({ type: String, reflect: true }) collection: string = '';
   /**
-   * The optional group name this will check in events.
+   * The name of the event group that this component belongs to.
+   * This component will dispatch events with this group in their
+   * payloads and will only react to events that contain this group.
    */
   @property({ type: String, reflect: true }) group: string = '';
 

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -44,6 +44,10 @@ export default class SearchBox extends Base {
    * Determines the collection used for search.
    */
   @property({ type: String, reflect: true }) collection: string = '';
+  /**
+   * Determines the group that the component belongs to.
+   */
+  @property({ type: String, reflect: true }) group: string = '';
 
   constructor() {
     super();
@@ -169,7 +173,7 @@ export default class SearchBox extends Base {
     return new CustomEvent<T>(type, {
       detail: {
         ...detail,
-        searchbox: this.id
+        group: this.group,
       },
       bubbles: true,
     });

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -104,7 +104,11 @@ export default class SearchBox extends Base {
    * @param e The event object.
    */
   updateText(e: CustomEvent<UpdateSearchTermPayload>) {
-    this.updateSearchTermValue(e.detail.term);
+    const eventGroup = e.detail.group || '';
+    const componentGroup = this.group || '';
+    if (eventGroup === componentGroup) {
+      this.updateSearchTermValue(e.detail.term);
+    }
   }
 
   /**

--- a/packages/web-components/@sfx/search-box/stories/index.ts
+++ b/packages/web-components/@sfx/search-box/stories/index.ts
@@ -69,6 +69,26 @@ storiesOf('Components|Searchbox', module)
               1. Navigate to the **Custom Events** tab and locate the \`${UPDATE_SEARCH_TERM}\` event.
               2. Click "emit".
               3. See the component update with the new search term.
+
+          ### Multiple Search Box components can behave independently
+            * If multiple Search Box, Sayt, and Products components are on the page, the \`group\` attribute can be used to send events to specific groups.
+              * Ex.
+
+                \`\`\`html
+                <!-- Two searchboxes -->
+                <sfx-search-box
+                  placeholder="Search Here"
+                  group="group1"
+                  searchbutton
+                  clearbutton
+                ></sfx-search-box>
+                <sfx-search-box
+                  placeholder="Search Here"
+                  group="group2"
+                  searchbutton
+                  clearbutton
+                ></sfx-search-box>
+                \`\`\`
               `
       }
     }

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -51,6 +51,12 @@ describe('SearchBox Component', () => {
         expect(searchbox.clearButton).to.be.false;
       });
     });
+
+    describe('group property', () => {
+      it('should have default value of an empty string', () => {
+        expect(searchbox.group).to.equal('');
+      });
+    });
   });
 
   describe('connectCallback', () => {
@@ -219,13 +225,13 @@ describe('SearchBox Component', () => {
       expect(result.detail).to.include(detail);
     });
 
-    it('should return a CustomEvent that bubbles and has a searchbox attribute', () => {
-      const id = searchbox.id = 'some-id';
+    it('should return a CustomEvent that bubbles and has a group attribute', () => {
+      const group = searchbox.group = 'some-id';
 
       const result = searchbox.createCustomEvent('some-type');
 
       expect(result.bubbles).to.be.true;
-      expect(result.detail.searchbox).to.equal(id);
+      expect(result.detail.group).to.equal(group);
     });
   });
 

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -128,10 +128,43 @@ describe('SearchBox Component', () => {
   });
 
   describe('updateText', () => {
-    it('should update the value property with data from the event', () => {
-      const term = 'inputText';
+    const term = 'inputText';
+    const group = 'some-group';
+    let updateSearchTermValue;
+
+    beforeEach(() => {
+      updateSearchTermValue = stub(searchbox, 'updateSearchTermValue');
+    });
+
+    it('should update the value property with data from the event when the event group matches the component group', () => {
+      const inputEvent = new CustomEvent('some-test-type', { detail: { term, group } });
+      searchbox.group = group;
+
+      searchbox.updateText(inputEvent);
+
+      expect(updateSearchTermValue).to.be.calledWith(term);
+    });
+
+    it('should not update the value property with data from the event when the group in the component and the event do not match', () => {
+      const inputEvent = new CustomEvent('some-test-type', { detail: { term, group } });
+      searchbox.group = 'different group';
+
+      searchbox.updateText(inputEvent);
+
+      expect(updateSearchTermValue).to.not.be.called;
+    });
+
+    it('should default the group in the event to an empty string if it is falsey', () => {
       const inputEvent = new CustomEvent('some-test-type', { detail: { term } });
-      const updateSearchTermValue = stub(searchbox, 'updateSearchTermValue');
+
+      searchbox.updateText(inputEvent);
+
+      expect(updateSearchTermValue).to.be.calledWith(term);
+    });
+
+    it('should default the group in the component to an empty string if it is falsey', () => {
+      const inputEvent = new CustomEvent('some-test-type', { detail: { term, group: '' } });
+      searchbox.group = undefined;
 
       searchbox.updateText(inputEvent);
 

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -225,8 +225,8 @@ describe('SearchBox Component', () => {
       expect(result.detail).to.include(detail);
     });
 
-    it('should return a CustomEvent that bubbles and has a group attribute', () => {
-      const group = searchbox.group = 'some-id';
+    it('should return a CustomEvent that bubbles and has a group property', () => {
+      const group = searchbox.group = 'group';
 
       const result = searchbox.createCustomEvent('some-type');
 

--- a/themes/sfx-bold-theme/components/_products.scss
+++ b/themes/sfx-bold-theme/components/_products.scss
@@ -1,3 +1,5 @@
+sfx-products-base,
+sfx-products-sayt,
 sfx-products {
   padding: var(--sfx-spacing-product);
 

--- a/themes/sfx-bold-theme/components/_sayt.scss
+++ b/themes/sfx-bold-theme/components/_sayt.scss
@@ -32,7 +32,7 @@ sfx-sayt {
     margin-top: -1px;
   }
 
-  sfx-products {
+  sfx-products-sayt {
     flex: 66%;
   }
 }

--- a/themes/sfx-elegant-theme/components/_products.scss
+++ b/themes/sfx-elegant-theme/components/_products.scss
@@ -1,3 +1,5 @@
+sfx-products-base,
+sfx-products-sayt,
 sfx-products {
   padding: var(--sfx-spacing-product);
 

--- a/themes/sfx-elegant-theme/components/_sayt.scss
+++ b/themes/sfx-elegant-theme/components/_sayt.scss
@@ -29,7 +29,7 @@ sfx-sayt {
     margin-top: -1px;
   }
 
-  sfx-products {
+  sfx-products-sayt {
     flex: 66%;
   }
 }


### PR DESCRIPTION
Change the Autocomplete and Products components to only listen to events if their `group` property matches what is in incoming events. 

Update the Searchbox and Sayt components to include the same `group` property.

Created two child components to extend from a `sfx-products-base` component. `sfx-products-sayt` will listen to `sfx::sayt_products_response` and `sfx-products` will listen to `sfx::search_response`. 

Changed sayt to listen to autocomplete hover events on the component to avoid listening on other sayt components.