### PR TITLE
SFX-385: Allow for passing custom product transformer

### DIFF
--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -136,7 +136,7 @@ export const generateSearchResponseEvent = (productCount: number, group?: string
   }
 }
 
-export function getSaytProductsResponseEvent(): CustomEvent<SaytProductsResponsePayload> {
+export function getSaytProductsResponseEvent(): CustomEvent<SaytProductsResponsePayload<any>> {
   return new CustomEvent(SAYT_PRODUCTS_RESPONSE, {
     detail: {
       products: getProducts(5),

--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -136,7 +136,7 @@ export const generateSearchResponseEvent = (productCount: number, group?: string
   }
 }
 
-export function getSaytProductsResponseEvent(): CustomEvent<SaytProductsResponsePayload<any>> {
+export function getSaytProductsResponseEvent(): CustomEvent<SaytProductsResponsePayload<Product>> {
   return new CustomEvent(SAYT_PRODUCTS_RESPONSE, {
     detail: {
       products: getProducts(5),

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -7,8 +7,8 @@
     <script src="./temp/sfx-all-plugins-bundle.js"></script>
   </head>
   <body>
-    <sfx-search-box placeholder="search" clearbutton searchbutton></sfx-search-box>
-    <sfx-sayt visible></sfx-sayt>
+    <sfx-search-box id="main-search" placeholder="search" clearbutton searchbutton></sfx-search-box>
+    <sfx-sayt searchbox="main-search" visible></sfx-sayt>
     <sfx-list class="product-grid"></sfx-list>
 
     <script>
@@ -67,6 +67,10 @@
       });
 
       window.addEventListener('sfx::sayt_products_response', (event) => {
+        console.log(event.type, event.detail);
+      });
+
+      window.addEventListener('sfx::sayt_products_error', (event) => {
         console.log(event.type, event.detail);
       });
     </script>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -46,7 +46,7 @@
       }
 
       function searchProductTransformer(record) {
-        return { title: record.title };
+        return { label: record.title };
       }
 
       // init core and plugins
@@ -58,11 +58,12 @@
       const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin({ productTransformer: searchProductTransformer });
       // register all plugins with core
       core.register([saytPlugin, saytDriverPlugin, domEventsPlugin, searchPlugin, searchDriverPlugin]);
+
       // search integration/functionality test
       window.addEventListener('sfx::search_response', (e) => {
         const productsGrid = document.querySelector('sfx-products');
         if (productsGrid) {
-          productsGrid.products = e.detail.products;
+          productsGrid.items = e.detail.products;
         }
       });
 

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -57,9 +57,9 @@
       // init core and plugins
       const core = new sfxCore.Core();
       const domEventsPlugin = new sfxPlugins.DomEventsPlugin()
-      const saytPlugin = new sfxPlugins.SaytPlugin({subdomain: 'apparel', collection: 'products'});
+      const saytPlugin = new sfxPlugins.SaytPlugin({ subdomain: 'apparel' });
       const saytDriverPlugin = new sfxPlugins.SaytDriverPlugin({ productTransformer });
-      const searchPlugin = new sfxPlugins.SearchPlugin({ customerId: 'apparel', collection: 'products', area: 'Storefront'});
+      const searchPlugin = new sfxPlugins.SearchPlugin({ customerId: 'apparel' });
       const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin({ productTransformer: searchProductTransformer });
       // register all plugins with core
       core.register([saytPlugin, saytDriverPlugin, domEventsPlugin, searchPlugin, searchDriverPlugin]);

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -46,7 +46,7 @@
       }
 
       function searchProductTransformer(record) {
-        return { title: 'product 1' };
+        return { title: record.title + '!!!' };
       }
 
       // init core and plugins

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -9,10 +9,10 @@
 
   <body>
     <sfx-search-box id="main-search" placeholder="search" clearbutton searchbutton></sfx-search-box>
-    <sfx-sayt searchbox="main-search" visible></sfx-sayt>
+    <sfx-sayt searchbox="main-search"></sfx-sayt>
 
     <sfx-search-box id="secondary-search" group="secondary" placeholder="search" clearbutton searchbutton></sfx-search-box>
-    <sfx-sayt searchbox="secondary-search" group="secondary" visible></sfx-sayt>
+    <sfx-sayt searchbox="secondary-search" group="secondary"></sfx-sayt>
 
     <sfx-products></sfx-products>
 

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -3,8 +3,8 @@
   <head>
     <title>Demo of Logic and View Integration</title>
     <script src="../dist/components.js"></script>
-    <!-- <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script> -->
-    <script src="./temp/sfx-all-plugins-bundle.js"></script>
+    <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script>
+    <!-- <script src="./temp/sfx-all-plugins-bundle.js"></script> -->
   </head>
   <body>
     <sfx-search-box id="main-search" placeholder="search" clearbutton searchbutton></sfx-search-box>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -46,7 +46,7 @@
       }
 
       function searchProductTransformer(record) {
-        return { title: record.title + '!!!' };
+        return { title: record.title };
       }
 
       // init core and plugins

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -50,7 +50,7 @@
       const core = new sfxCore.Core();
       const domEventsPlugin = new sfxPlugins.DomEventsPlugin()
       const saytPlugin = new sfxPlugins.SaytPlugin({subdomain: 'apparel', collection: 'products'});
-      const saytDriverPlugin = new sfxPlugins.SaytDriverPlugin(productTransformer);
+      const saytDriverPlugin = new sfxPlugins.SaytDriverPlugin({ productTransformer });
       const searchPlugin = new sfxPlugins.SearchPlugin({ customerId: 'apparel', collection: 'products', area: 'Storefront'});
       const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin();
       // register all plugins with core

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -45,6 +45,9 @@
         }
       }
 
+      function searchProductTransformer(record) {
+        return { title: 'product 1' };
+      }
 
       // init core and plugins
       const core = new sfxCore.Core();
@@ -52,16 +55,15 @@
       const saytPlugin = new sfxPlugins.SaytPlugin({subdomain: 'apparel', collection: 'products'});
       const saytDriverPlugin = new sfxPlugins.SaytDriverPlugin({ productTransformer });
       const searchPlugin = new sfxPlugins.SearchPlugin({ customerId: 'apparel', collection: 'products', area: 'Storefront'});
-      const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin();
+      const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin({ productTransformer: searchProductTransformer });
       // register all plugins with core
       core.register([saytPlugin, saytDriverPlugin, domEventsPlugin, searchPlugin, searchDriverPlugin]);
       // search integration/functionality test
       window.addEventListener('sfx::search_response', (e) => {
-        const testListResults = e.detail.results.records.map(item => {
-          return { label : item.title };
-        });
-        document.getElementsByClassName('product-grid')[0]
-        .setAttribute('items', JSON.stringify(testListResults));
+        const productsGrid = document.querySelector('sfx-products');
+        if (productsGrid) {
+          productsGrid.products = e.detail.products;
+        }
       });
 
       window.addEventListener('sfx::sayt_products_response', (event) => {

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -6,10 +6,15 @@
     <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script>
     <!-- <script src="./temp/sfx-all-plugins-bundle.js"></script> -->
   </head>
+
   <body>
     <sfx-search-box id="main-search" placeholder="search" clearbutton searchbutton></sfx-search-box>
     <sfx-sayt searchbox="main-search" visible></sfx-sayt>
-    <sfx-list class="product-grid"></sfx-list>
+
+    <sfx-search-box id="secondary-search" group="secondary" placeholder="search" clearbutton searchbutton></sfx-search-box>
+    <sfx-sayt searchbox="secondary-search" group="secondary" visible></sfx-sayt>
+
+    <sfx-products></sfx-products>
 
     <script>
       function parseRecord(record) {
@@ -58,14 +63,6 @@
       const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin({ productTransformer: searchProductTransformer });
       // register all plugins with core
       core.register([saytPlugin, saytDriverPlugin, domEventsPlugin, searchPlugin, searchDriverPlugin]);
-
-      // search integration/functionality test
-      window.addEventListener('sfx::search_response', (e) => {
-        const productsGrid = document.querySelector('sfx-products');
-        if (productsGrid) {
-          productsGrid.items = e.detail.products;
-        }
-      });
 
       window.addEventListener('sfx::sayt_products_response', (event) => {
         console.log(event.type, event.detail);

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -3,7 +3,8 @@
   <head>
     <title>Demo of Logic and View Integration</title>
     <script src="../dist/components.js"></script>
-    <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script>
+    <!-- <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script> -->
+    <script src="./temp/sfx-all-plugins-bundle.js"></script>
   </head>
   <body>
     <sfx-search-box placeholder="search" clearbutton searchbutton></sfx-search-box>
@@ -11,11 +12,45 @@
     <sfx-list class="product-grid"></sfx-list>
 
     <script>
+      function parseRecord(record) {
+        const data = record.allMeta;
+        const firstVariant = data.visualVariants[0];
+        const nonvisualVariants = firstVariant.nonvisualVariants;
+        if (!nonvisualVariants[0]) throw new Error('No nonvisual variants');
+
+        return {
+          data,
+          firstVariant,
+          nonvisualVariants,
+        };
+      }
+
+      function productTransformer(record) {
+        let filter;
+        try {
+          filter = parseRecord(record);
+        } catch(error) {
+          console.error(error);
+          return;
+        }
+        const { data, firstVariant, nonvisualVariants } = filter;
+
+        return {
+          title: data.title,
+          price: nonvisualVariants[0].originalPrice,
+          imageSrc: firstVariant.productImage,
+          imageAlt: data.title,
+          productUrl: firstVariant.productImage,
+          // @TODO Handle variants
+        }
+      }
+
+
       // init core and plugins
       const core = new sfxCore.Core();
       const domEventsPlugin = new sfxPlugins.DomEventsPlugin()
       const saytPlugin = new sfxPlugins.SaytPlugin({subdomain: 'apparel', collection: 'products'});
-      const saytDriverPlugin = new sfxPlugins.SaytDriverPlugin();
+      const saytDriverPlugin = new sfxPlugins.SaytDriverPlugin(productTransformer);
       const searchPlugin = new sfxPlugins.SearchPlugin({ customerId: 'apparel', collection: 'products', area: 'Storefront'});
       const searchDriverPlugin = new sfxPlugins.SearchDriverPlugin();
       // register all plugins with core
@@ -27,6 +62,10 @@
         });
         document.getElementsByClassName('product-grid')[0]
         .setAttribute('items', JSON.stringify(testListResults));
+      });
+
+      window.addEventListener('sfx::sayt_products_response', (event) => {
+        console.log(event.type, event.detail);
       });
     </script>
   </body>

--- a/demo/temp/sfx-all-plugins-bundle.js
+++ b/demo/temp/sfx-all-plugins-bundle.js
@@ -15350,10 +15350,11 @@ var events_1 = __webpack_require__(/*! @sfx/events */ "../sfx-events/dist/index.
  */
 var SaytDriverPlugin = /** @class */ (function () {
     /**
-     * Binds relevant functions. Sets transformProduct property if a
+     * Binds relevant functions. Sets [[transformProduct]] property if a
      * product transformer function is passed.
      */
     function SaytDriverPlugin(options) {
+        if (options === void 0) { options = {}; }
         /**
          * Name of the events plugin.
          */
@@ -15364,21 +15365,16 @@ var SaytDriverPlugin = /** @class */ (function () {
         this.defaultSearchConfig = {
             fields: ['*'],
         };
-        /**
-         * Default product transformer identity function.
-         * Intended to be overwritten by passing a custom product transformer.
-         *
-         * @param product The product to be returned as-is.
-         * @returns The received product object.
-         */
-        this.transformProduct = (function (product) { return product; });
         this.fetchAutocompleteTerms = this.fetchAutocompleteTerms.bind(this);
         this.fetchProductData = this.fetchProductData.bind(this);
         this.autocompleteCallback = this.autocompleteCallback.bind(this);
         this.searchCallback = this.searchCallback.bind(this);
-        if (options && options.productTransformer) {
-            this.transformProduct = options.productTransformer;
-        }
+        var 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        _a = options.productTransformer, 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        productTransformer = _a === void 0 ? (function (product) { return product; }) : _a;
+        this.transformProduct = productTransformer;
     }
     Object.defineProperty(SaytDriverPlugin.prototype, "metadata", {
         get: function () {
@@ -15427,10 +15423,8 @@ var SaytDriverPlugin = /** @class */ (function () {
     SaytDriverPlugin.prototype.fetchAutocompleteTerms = function (event) {
         var _this = this;
         var _a = event.detail, query = _a.query, group = _a.group, config = _a.config;
-        console.log("in fetchAutocompleteTerms:", query, group, config);
         this.sendAutocompleteApiRequest(query, config)
             .then(function (results) {
-            console.log('Received autocomplete terms:', results);
             var payload = { results: results, group: group };
             _this.core[_this.eventsPluginName].dispatchEvent(events_1.AUTOCOMPLETE_RESPONSE, payload);
         })
@@ -15498,17 +15492,15 @@ var SaytDriverPlugin = /** @class */ (function () {
     };
     /**
      * Extracts query and products from the given response.
-     * Calls `this.transformProduct` on each product found in the response.
-     * Filters out any products that map to a falsy value.
+     * It calls [[transformProduct]] on each product found in the response
+     * and filters out any that map to a falsy value.
      *
      * @param response An object containing the original search response.
      * @returns An object containing an array of valid simplified products and the original response.
      */
     SaytDriverPlugin.prototype.searchCallback = function (searchResponse) {
         var records = searchResponse.records;
-        var mappedRecords = records
-            .map(this.transformProduct)
-            .filter(Boolean);
+        var mappedRecords = records.map(this.transformProduct).filter(Boolean);
         return {
             products: mappedRecords,
             originalResponse: searchResponse,
@@ -15648,6 +15640,7 @@ var SearchDriverPlugin = /** @class */ (function () {
      * callbacks.
      */
     function SearchDriverPlugin(options) {
+        if (options === void 0) { options = {}; }
         /**
          * Name of the events plugin.
          */
@@ -15658,19 +15651,14 @@ var SearchDriverPlugin = /** @class */ (function () {
         this.defaultSearchConfig = {
             fields: ['*'],
         };
-        /**
-         * Default product transformer identity function.
-         * Intended to be overwritten by passing a custom product transformer.
-         *
-         * @param product The product to be returned as-is.
-         * @returns The received product object.
-         */
-        this.transformProduct = (function (product) { return product; });
         this.fetchSearchData = this.fetchSearchData.bind(this);
         this.searchCallback = this.searchCallback.bind(this);
-        if (options && options.productTransformer) {
-            this.transformProduct = options.productTransformer;
-        }
+        var 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        _a = options.productTransformer, 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        productTransformer = _a === void 0 ? (function (product) { return product; }) : _a;
+        this.transformProduct = productTransformer;
     }
     Object.defineProperty(SearchDriverPlugin.prototype, "metadata", {
         get: function () {
@@ -15738,7 +15726,7 @@ var SearchDriverPlugin = /** @class */ (function () {
     };
     /**
      * Extracts query and products from the given response.
-     * Calls `this.transformProduct` on each product found in the response.
+     * Calls [[transformProduct]] on each product found in the response.
      * Filters out any products that map to a falsy value.
      *
      * @param response An object containing the original query and product records.
@@ -15746,9 +15734,7 @@ var SearchDriverPlugin = /** @class */ (function () {
      */
     SearchDriverPlugin.prototype.searchCallback = function (response) {
         var records = response.records;
-        var mappedRecords = records
-            .map(this.transformProduct)
-            .filter(Boolean);
+        var mappedRecords = records.map(this.transformProduct).filter(Boolean);
         return {
             originalResponse: response,
             products: mappedRecords,

--- a/demo/temp/sfx-all-plugins-bundle.js
+++ b/demo/temp/sfx-all-plugins-bundle.js
@@ -86,600 +86,185 @@
 /************************************************************************/
 /******/ ({
 
-/***/ "../../api-javascript/dist/core/bridge.js":
-/*!*************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/dist/core/bridge.js ***!
-  \*************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b)
-                if (b.hasOwnProperty(p))
-                    d[p] = b[p]; };
-        return extendStatics(d, b);
-    };
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function (t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s)
-                if (Object.prototype.hasOwnProperty.call(s, p))
-                    t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-var clone = __webpack_require__(/*! clone */ "../../api-javascript/node_modules/clone/clone.js");
-var fetchPonyfill = __webpack_require__(/*! fetch-ponyfill */ "../../api-javascript/node_modules/fetch-ponyfill/build/fetch-browser.js");
-var qs = __webpack_require__(/*! qs */ "../../api-javascript/node_modules/qs/lib/index.js");
-var utils_1 = __webpack_require__(/*! ../utils */ "../../api-javascript/dist/utils/index.js");
-var query_1 = __webpack_require__(/*! ./query */ "../../api-javascript/dist/core/query.js");
-var SEARCH = '/search';
-var REFINEMENTS = '/refinements';
-var INVALID_QUERY_ERROR = 'query was not of a recognised type';
-var createTimeoutPromise = function (timeout) {
-    return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-            reject(new BridgeTimeout("Timed out in " + timeout + " ms"));
-        }, timeout);
-    });
-};
-var BridgeTimeout = /** @class */ (function (_super) {
-    __extends(BridgeTimeout, _super);
-    /* istanbul ignore next */
-    function BridgeTimeout(err) {
-        return _super.call(this, err) || this;
-    }
-    return BridgeTimeout;
-}(Error));
-exports.BridgeTimeout = BridgeTimeout;
-var BridgeError = /** @class */ (function (_super) {
-    __extends(BridgeError, _super);
-    /* istanbul ignore next */
-    function BridgeError(statusText, status, data) {
-        var _this = _super.call(this, statusText) || this;
-        _this.status = status;
-        _this.data = data;
-        Object.setPrototypeOf(_this, BridgeError.prototype);
-        return _this;
-    }
-    Object.defineProperty(BridgeError.prototype, "statusText", {
-        get: function () {
-            return this.message;
-        },
-        enumerable: true,
-        configurable: true
-    });
-    return BridgeError;
-}(Error));
-exports.BridgeError = BridgeError;
-exports.DEFAULT_CONFIG = {
-    timeout: 1500
-};
-var AbstractBridge = /** @class */ (function () {
-    function AbstractBridge(config) {
-        this.fetch = fetchPonyfill().fetch;
-        this.headers = {};
-        this.config = Object.assign({}, exports.DEFAULT_CONFIG, config);
-    }
-    AbstractBridge.prototype.search = function (query, callback) {
-        var _a = this.extractRequest(query), request = _a.request, queryParams = _a.queryParams;
-        if (request === null)
-            return this.generateError(INVALID_QUERY_ERROR, callback);
-        var response = this.fireRequest(this.bridgeUrl, request, queryParams)
-            .then(AbstractBridge.transformRecords)
-            .then(AbstractBridge.transformRefinements);
-        return this.handleResponse(response, callback);
-    };
-    AbstractBridge.prototype.refinements = function (query, navigationName, callback) {
-        var request = this.extractRequest(query).request;
-        if (request === null)
-            return this.generateError(INVALID_QUERY_ERROR, callback);
-        var refinementsRequest = { originalQuery: request, navigationName: navigationName };
-        var response = this.fireRequest(this.refinementsUrl, refinementsRequest);
-        return this.handleResponse(response, callback);
-    };
-    AbstractBridge.prototype.handleResponse = function (response, callback) {
-        if (callback) {
-            response.then(function (res) { return callback(undefined, res); }, function (err) { return callback(err); });
-        }
-        else {
-            return response;
-        }
-    };
-    AbstractBridge.prototype.extractRequest = function (query) {
-        switch (typeof query) {
-            case 'string': return { request: new query_1.Query(query).build(), queryParams: {} };
-            case 'object': return query instanceof query_1.Query
-                ? { request: query.build(), queryParams: query.queryParams }
-                : { request: clone(query), queryParams: {} };
-            default: return { request: null, queryParams: null };
-        }
-    };
-    AbstractBridge.prototype.generateError = function (error, callback) {
-        var err = new Error(error);
-        if (callback) {
-            callback(err);
-        }
-        else {
-            return Promise.reject(err);
-        }
-    };
-    // tslint:disable-next-line max-line-length
-    AbstractBridge.prototype.fireRequest = function (url, body, queryParams) {
-        var _this = this;
-        if (queryParams === void 0) {
-            queryParams = {};
-        }
-        var options = {
-            method: 'POST',
-            headers: __assign({ 'Content-Type': 'application/json' }, this.headers),
-            body: JSON.stringify(AbstractBridge.normalizeRequest(this.augmentRequest(body))),
-        };
-        var params = qs.stringify(queryParams);
-        url = params ? url + "?" + params : url;
-        return Promise.race([this.fetch(url, options), createTimeoutPromise(this.config.timeout)])
-            .then(function (res) {
-            if (res.ok) {
-                return res.json();
-            }
-            else {
-                return res.json().then(function (err) {
-                    throw new BridgeError(res.statusText, res.status, err);
-                });
-            }
-        })
-            .catch(function (err) {
-            if (_this.errorHandler) {
-                _this.errorHandler(err);
-            }
-            throw err;
-        });
-    };
-    AbstractBridge.normalizeRequest = function (request) {
-        Object.keys(utils_1.Normalizers).forEach(function (normalize) { return utils_1.Normalizers[normalize](request); });
-        return request;
-    };
-    AbstractBridge.transform = function (response, key, callback) {
-        var _a;
-        if (response[key]) {
-            return Object.assign(response, (_a = {}, _a[key] = response[key].map(callback), _a));
-        }
-        else {
-            return response;
-        }
-    };
-    AbstractBridge.transformRecords = function (response) {
-        return AbstractBridge.transform(response, 'records', AbstractBridge.convertRecordFields);
-    };
-    AbstractBridge.transformRefinements = function (response) {
-        var transformed = AbstractBridge.transform(response, 'availableNavigation', AbstractBridge.convertRefinement);
-        return AbstractBridge.transform(transformed, 'selectedNavigation', AbstractBridge.convertRefinement);
-    };
-    AbstractBridge.convertRecordFields = function (record) {
-        var converted = Object.assign(record, { id: record._id, url: record._u, title: record._t });
-        delete converted._id;
-        delete converted._u;
-        delete converted._t;
-        if (record._snippet) {
-            converted.snippet = record._snippet;
-            delete converted._snippet;
-        }
-        return converted;
-    };
-    AbstractBridge.convertRefinement = function (navigation) {
-        if (navigation.range) {
-            navigation.min = Number.MAX_SAFE_INTEGER;
-            navigation.max = Number.MIN_SAFE_INTEGER;
-            navigation.refinements = navigation.refinements
-                .map(function (ref) {
-                navigation.min = Math.min(navigation.min, ref.low);
-                navigation.max = Math.max(navigation.max, ref.high);
-                return (__assign({}, ref, { high: parseFloat(ref.high), low: parseFloat(ref.low) }));
-            });
-        }
-        return navigation;
-    };
-    return AbstractBridge;
-}());
-exports.AbstractBridge = AbstractBridge;
-var CloudBridge = /** @class */ (function (_super) {
-    __extends(CloudBridge, _super);
-    function CloudBridge(clientKey, customerId, config) {
-        if (config === void 0) {
-            config = {};
-        }
-        var _this = _super.call(this, config) || this;
-        _this.clientKey = clientKey;
-        _this.baseUrl = "https://" + customerId + ".groupbycloud.com:443/api/v1";
-        _this.bridgeUrl = _this.baseUrl + SEARCH;
-        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
-        return _this;
-    }
-    CloudBridge.prototype.augmentRequest = function (request) {
-        return Object.assign(request, { clientKey: this.clientKey });
-    };
-    return CloudBridge;
-}(AbstractBridge));
-exports.CloudBridge = CloudBridge;
-var BrowserBridge = /** @class */ (function (_super) {
-    __extends(BrowserBridge, _super);
-    function BrowserBridge(customerId, https, config) {
-        if (https === void 0) {
-            https = false;
-        }
-        if (config === void 0) {
-            config = {};
-        }
-        var _this = _super.call(this, config) || this;
-        var scheme = https ? 'https' : 'http';
-        var port = https ? ':443' : '';
-        _this.baseUrl = config.proxyUrl || scheme + "://" + customerId + "-cors.groupbycloud.com" + port + "/api/v1";
-        _this.bridgeUrl = _this.baseUrl + SEARCH;
-        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
-        return _this;
-    }
-    BrowserBridge.prototype.augmentRequest = function (request) {
-        return request;
-    };
-    return BrowserBridge;
-}(AbstractBridge));
-exports.BrowserBridge = BrowserBridge;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/dist/core/query.js":
-/*!************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/dist/core/query.js ***!
-  \************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-var clone = __webpack_require__(/*! clone */ "../../api-javascript/node_modules/clone/clone.js");
-var deepEqual = __webpack_require__(/*! deep-equal */ "../../api-javascript/node_modules/deep-equal/index.js");
-var filterObject = __webpack_require__(/*! filter-object */ "../../api-javascript/node_modules/filter-object/index.js");
-var qs = __webpack_require__(/*! qs */ "../../api-javascript/node_modules/qs/lib/index.js");
-var utils_1 = __webpack_require__(/*! ../utils */ "../../api-javascript/dist/utils/index.js");
-var REFINEMENT_MASK = '{navigationName,value,low,high}';
-var Query = /** @class */ (function () {
-    function Query(query) {
-        if (query === void 0) {
-            query = '';
-        }
-        this.request = {};
-        this.unprocessedNavigations = [];
-        this.queryParams = {};
-        this.request.query = query;
-        this.request.sort = [];
-        this.request.fields = [];
-        this.request.orFields = [];
-        this.request.refinements = [];
-        this.request.customUrlParams = [];
-        this.request.includedNavigations = [];
-        this.request.excludedNavigations = [];
-        this.request.wildcardSearchEnabled = false;
-        this.request.pruneRefinements = true;
-    }
-    Query.prototype.withQuery = function (query) {
-        this.request.query = query;
-        return this;
-    };
-    Query.prototype.withConfiguration = function (configuration, mask) {
-        if (mask === void 0) {
-            mask = '*';
-        }
-        Object.assign(this.request, filterObject(configuration, mask));
-        return this;
-    };
-    Query.prototype.withSelectedRefinements = function () {
-        var _this = this;
-        var refinements = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            refinements[_i] = arguments[_i];
-        }
-        refinements.forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
-        return this;
-    };
-    Query.prototype.withoutSelectedRefinements = function () {
-        var _this = this;
-        var refinements = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            refinements[_i] = arguments[_i];
-        }
-        refinements.forEach(function (refinement) {
-            var index = _this.request.refinements.findIndex(function (ref) { return deepEqual(ref, refinement); });
-            if (index > -1)
-                _this.request.refinements.splice(index, 1);
-        });
-        return this;
-    };
-    Query.prototype.withRefinements = function (navigationName) {
-        var _this = this;
-        var refinements = [];
-        for (var _i = 1; _i < arguments.length; _i++) {
-            refinements[_i - 1] = arguments[_i];
-        }
-        var convert = function (refinement) { return Object.assign(refinement, { navigationName: navigationName }); };
-        refinements.map(convert).forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
-        return this;
-    };
-    Query.prototype.withNavigations = function () {
-        var _a;
-        var navigations = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            navigations[_i] = arguments[_i];
-        }
-        (_a = this.unprocessedNavigations).push.apply(_a, navigations);
-        return this;
-    };
-    Query.prototype.withCustomUrlParams = function (customUrlParams) {
-        var _a, _b;
-        if (typeof customUrlParams === 'string') {
-            (_a = this.request.customUrlParams).push.apply(_a, this.convertParamString(customUrlParams));
-        }
-        else if (Array.isArray(customUrlParams)) {
-            (_b = this.request.customUrlParams).push.apply(_b, customUrlParams);
-        }
-        return this;
-    };
-    Query.prototype.withFields = function () {
-        var _a;
-        var fields = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            fields[_i] = arguments[_i];
-        }
-        (_a = this.request.fields).push.apply(_a, fields);
-        return this;
-    };
-    Query.prototype.withOrFields = function () {
-        var _a;
-        var orFields = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            orFields[_i] = arguments[_i];
-        }
-        (_a = this.request.orFields).push.apply(_a, orFields);
-        return this;
-    };
-    Query.prototype.withSorts = function () {
-        var _a;
-        var sorts = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            sorts[_i] = arguments[_i];
-        }
-        (_a = this.request.sort).push.apply(_a, sorts);
-        return this;
-    };
-    Query.prototype.withoutSorts = function () {
-        var sorts = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            sorts[_i] = arguments[_i];
-        }
-        this.request.sort = this.request.sort.filter(function (oldSort) {
-            return !sorts.find(function (sort) {
-                return sort.type === 'ByIds'
-                    ? oldSort.type === 'ByIds' && sort.ids.toString() === oldSort.ids.toString()
-                    : sort.field === oldSort.field;
-            });
-        });
-        return this;
-    };
-    Query.prototype.withIncludedNavigations = function () {
-        var _a;
-        var navigationNames = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            navigationNames[_i] = arguments[_i];
-        }
-        (_a = this.request.includedNavigations).push.apply(_a, navigationNames);
-        return this;
-    };
-    Query.prototype.withExcludedNavigations = function () {
-        var _a;
-        var navigationNames = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            navigationNames[_i] = arguments[_i];
-        }
-        (_a = this.request.excludedNavigations).push.apply(_a, navigationNames);
-        return this;
-    };
-    Query.prototype.withQueryParams = function (queryParams) {
-        switch (typeof queryParams) {
-            case 'string':
-                return Object.assign(this, { queryParams: this.convertQueryString(queryParams) });
-            case 'object':
-                return Object.assign(this, { queryParams: queryParams });
-        }
-    };
-    Query.prototype.refineByValue = function (navigationName, value, exclude) {
-        if (exclude === void 0) {
-            exclude = false;
-        }
-        return this.withSelectedRefinements({
-            navigationName: navigationName,
-            value: value,
-            exclude: exclude,
-            type: 'Value'
-        });
-    };
-    Query.prototype.refineByRange = function (navigationName, low, high, exclude) {
-        if (exclude === void 0) {
-            exclude = false;
-        }
-        return this.withSelectedRefinements({
-            navigationName: navigationName,
-            low: low,
-            high: high,
-            exclude: exclude,
-            type: 'Range'
-        });
-    };
-    Query.prototype.restrictNavigation = function (restrictNavigation) {
-        this.request.restrictNavigation = restrictNavigation;
-        return this;
-    };
-    Query.prototype.skip = function (skip) {
-        this.request.skip = skip;
-        return this;
-    };
-    Query.prototype.withPageSize = function (pageSize) {
-        this.request.pageSize = pageSize;
-        return this;
-    };
-    Query.prototype.withMatchStrategy = function (matchStrategy) {
-        this.request.matchStrategy = matchStrategy;
-        return this;
-    };
-    Query.prototype.withBiasing = function (biasing) {
-        this.request.biasing = biasing;
-        return this;
-    };
-    Query.prototype.enableWildcardSearch = function () {
-        this.request.wildcardSearchEnabled = true;
-        return this;
-    };
-    Query.prototype.disableAutocorrection = function () {
-        this.request.disableAutocorrection = true;
-        return this;
-    };
-    Query.prototype.disableBinaryPayload = function () {
-        this.request.returnBinary = false;
-        return this;
-    };
-    Query.prototype.allowPrunedRefinements = function () {
-        this.request.pruneRefinements = false;
-        return this;
-    };
-    Query.prototype.build = function () {
-        var _this = this;
-        var builtRequest = this.raw;
-        utils_1.NavigationConverter.convert(this.unprocessedNavigations)
-            .forEach(function (ref) { return _this.addRefinement(ref, builtRequest.refinements); });
-        return this.clearEmptyArrays(builtRequest);
-    };
-    Object.defineProperty(Query.prototype, "raw", {
-        get: function () {
-            return clone(this.request, false);
-        },
-        enumerable: true,
-        configurable: true
-    });
-    Object.defineProperty(Query.prototype, "rawNavigations", {
-        get: function () {
-            return Object.create(this.unprocessedNavigations);
-        },
-        enumerable: true,
-        configurable: true
-    });
-    Query.prototype.addRefinement = function (refinement, refinements) {
-        var _this = this;
-        if (!refinements.find(function (ref) { return _this.refinementMatches(ref, refinement); })) {
-            refinements.push(refinement);
-        }
-    };
-    Query.prototype.refinementMatches = function (target, original) {
-        return deepEqual(filterObject(target, REFINEMENT_MASK), filterObject(original, REFINEMENT_MASK));
-    };
-    Query.prototype.convertParamString = function (customUrlParams) {
-        var parsed = qs.parse(customUrlParams);
-        return Object.keys(parsed).reduce(function (converted, key) { return converted.concat({ key: key, value: parsed[key] }); }, []);
-    };
-    Query.prototype.convertQueryString = function (queryParams) {
-        return qs.parse(queryParams);
-    };
-    Query.prototype.clearEmptyArrays = function (request) {
-        for (var key in request) {
-            if (Array.isArray(request[key]) && request[key].length === 0) {
-                delete request[key];
-            }
-        }
-        return request;
-    };
-    return Query;
-}());
-exports.Query = Query;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/dist/index.js":
-/*!*******************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/dist/index.js ***!
-  \*******************************************************/
+/***/ "../sfx-events/dist/index.js":
+/*!***********************************!*\
+  !*** ../sfx-events/dist/index.js ***!
+  \***********************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 function __export(m) {
-    for (var p in m)
-        if (!exports.hasOwnProperty(p))
-            exports[p] = m[p];
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! ./core/query */ "../../api-javascript/dist/core/query.js"));
-__export(__webpack_require__(/*! ./core/bridge */ "../../api-javascript/dist/core/bridge.js"));
-
+__export(__webpack_require__(/*! ./sayt */ "../sfx-events/dist/sayt/index.js"));
+__export(__webpack_require__(/*! ./search */ "../sfx-events/dist/search/index.js"));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ "../../api-javascript/dist/utils/index.js":
-/*!*************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/dist/utils/index.js ***!
-  \*************************************************************/
+/***/ "../sfx-events/dist/sayt/autocomplete-list.js":
+/*!****************************************************!*\
+  !*** ../sfx-events/dist/sayt/autocomplete-list.js ***!
+  \****************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var NavigationConverter = /** @class */ (function () {
-    function NavigationConverter() {
-    }
-    NavigationConverter.convert = function (navigations) {
-        return navigations.reduce(function (refinements, navigation) {
-            navigation.refinements
-                // tslint:disable-next-line max-line-length
-                .forEach(function (refinement) { return refinements.push(Object.assign(refinement, { navigationName: navigation.name })); });
-            return refinements;
-        }, []);
-    };
-    return NavigationConverter;
-}());
-exports.NavigationConverter = NavigationConverter;
-var Normalizers;
-(function (Normalizers) {
-    function normalizeSort(request) {
-        if (request.sort && !Array.isArray(request.sort) && request.sort.field === '_relevance') {
-            delete request.sort;
-        }
-    }
-    Normalizers.normalizeSort = normalizeSort;
-})(Normalizers = exports.Normalizers || (exports.Normalizers = {}));
-
+/** The name of the event fired to change the active query term. */
+exports.AUTOCOMPLETE_ACTIVE_TERM = 'sfx::autocomplete_active_term';
+//# sourceMappingURL=autocomplete-list.js.map
 
 /***/ }),
 
-/***/ "../../api-javascript/node_modules/arr-flatten/index.js":
-/*!***************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/arr-flatten/index.js ***!
-  \***************************************************************************/
+/***/ "../sfx-events/dist/sayt/autocomplete.js":
+/*!***********************************************!*\
+  !*** ../sfx-events/dist/sayt/autocomplete.js ***!
+  \***********************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+/** The name of the event fired to request autocomplete data. */
+exports.AUTOCOMPLETE_REQUEST = 'sfx::autocomplete_request';
+/** The name of the event fired when the results of an autocomplete request have been received. */
+exports.AUTOCOMPLETE_RESPONSE = 'sfx::autocomplete_response';
+/** The name of the event fired when an autocomplete request fails. */
+exports.AUTOCOMPLETE_ERROR = 'sfx::autocomplete_error';
+//# sourceMappingURL=autocomplete.js.map
+
+/***/ }),
+
+/***/ "../sfx-events/dist/sayt/index.js":
+/*!****************************************!*\
+  !*** ../sfx-events/dist/sayt/index.js ***!
+  \****************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(__webpack_require__(/*! ./autocomplete */ "../sfx-events/dist/sayt/autocomplete.js"));
+__export(__webpack_require__(/*! ./autocomplete-list */ "../sfx-events/dist/sayt/autocomplete-list.js"));
+__export(__webpack_require__(/*! ./products */ "../sfx-events/dist/sayt/products.js"));
+__export(__webpack_require__(/*! ./sayt */ "../sfx-events/dist/sayt/sayt.js"));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ "../sfx-events/dist/sayt/products.js":
+/*!*******************************************!*\
+  !*** ../sfx-events/dist/sayt/products.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+/** The name of the event fired to request SAYT products. */
+exports.SAYT_PRODUCTS_REQUEST = 'sfx::sayt_products_request';
+/** The name of the event fired when the results of a SAYT products request have been received. */
+exports.SAYT_PRODUCTS_RESPONSE = 'sfx::sayt_products_response';
+/** The name of the event fired when a SAYT products request fails. */
+exports.SAYT_PRODUCTS_ERROR = 'sfx::sayt_products_error';
+//# sourceMappingURL=products.js.map
+
+/***/ }),
+
+/***/ "../sfx-events/dist/sayt/sayt.js":
+/*!***************************************!*\
+  !*** ../sfx-events/dist/sayt/sayt.js ***!
+  \***************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+/** The name of the event fired when SAYT should be hidden. */
+exports.SAYT_HIDE = 'sfx::sayt_hide';
+/** The name of the event fired when SAYT should be shown. */
+exports.SAYT_SHOW = 'sfx::sayt_show';
+//# sourceMappingURL=sayt.js.map
+
+/***/ }),
+
+/***/ "../sfx-events/dist/search/index.js":
+/*!******************************************!*\
+  !*** ../sfx-events/dist/search/index.js ***!
+  \******************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(__webpack_require__(/*! ./search */ "../sfx-events/dist/search/search.js"));
+__export(__webpack_require__(/*! ./searchbox */ "../sfx-events/dist/search/searchbox.js"));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ "../sfx-events/dist/search/search.js":
+/*!*******************************************!*\
+  !*** ../sfx-events/dist/search/search.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+/** The name of the event fired to request a search. */
+exports.SEARCH_REQUEST = 'sfx::search_request';
+/** The name of the event fired when the results of a search request have been received.  */
+exports.SEARCH_RESPONSE = 'sfx::search_response';
+/** The name of the event fired when a search request fails. */
+exports.SEARCH_ERROR = 'sfx::search_error';
+//# sourceMappingURL=search.js.map
+
+/***/ }),
+
+/***/ "../sfx-events/dist/search/searchbox.js":
+/*!**********************************************!*\
+  !*** ../sfx-events/dist/search/searchbox.js ***!
+  \**********************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+/** The name of the event fired when the search term is to be updated. */
+exports.UPDATE_SEARCH_TERM = 'sfx::update_search_term';
+/** The name of the event fired when the user has changed the text in the search box. */
+exports.SEARCHBOX_INPUT = 'sfx::searchbox_input';
+/** The name of the event fired when the search box is clicked. */
+exports.SEARCHBOX_CLICK = 'sfx::searchbox_click';
+/** The name of the event fired when the search box is cleared. */
+exports.SEARCHBOX_CLEAR = 'sfx::searchbox_clear';
+//# sourceMappingURL=searchbox.js.map
+
+/***/ }),
+
+/***/ "./node_modules/arr-flatten/index.js":
+/*!*******************************************!*\
+  !*** ./node_modules/arr-flatten/index.js ***!
+  \*******************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -710,10 +295,174 @@ function flat(arr, res) {
 
 /***/ }),
 
-/***/ "../../api-javascript/node_modules/clone/clone.js":
-/*!*********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/clone/clone.js ***!
-  \*********************************************************************/
+/***/ "./node_modules/base64-js/index.js":
+/*!*****************************************!*\
+  !*** ./node_modules/base64-js/index.js ***!
+  \*****************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+exports.byteLength = byteLength
+exports.toByteArray = toByteArray
+exports.fromByteArray = fromByteArray
+
+var lookup = []
+var revLookup = []
+var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
+
+var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+for (var i = 0, len = code.length; i < len; ++i) {
+  lookup[i] = code[i]
+  revLookup[code.charCodeAt(i)] = i
+}
+
+// Support decoding URL-safe base64 strings, as Node.js does.
+// See: https://en.wikipedia.org/wiki/Base64#URL_applications
+revLookup['-'.charCodeAt(0)] = 62
+revLookup['_'.charCodeAt(0)] = 63
+
+function getLens (b64) {
+  var len = b64.length
+
+  if (len % 4 > 0) {
+    throw new Error('Invalid string. Length must be a multiple of 4')
+  }
+
+  // Trim off extra bytes after placeholder bytes are found
+  // See: https://github.com/beatgammit/base64-js/issues/42
+  var validLen = b64.indexOf('=')
+  if (validLen === -1) validLen = len
+
+  var placeHoldersLen = validLen === len
+    ? 0
+    : 4 - (validLen % 4)
+
+  return [validLen, placeHoldersLen]
+}
+
+// base64 is 4/3 + up to two characters of the original data
+function byteLength (b64) {
+  var lens = getLens(b64)
+  var validLen = lens[0]
+  var placeHoldersLen = lens[1]
+  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+}
+
+function _byteLength (b64, validLen, placeHoldersLen) {
+  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+}
+
+function toByteArray (b64) {
+  var tmp
+  var lens = getLens(b64)
+  var validLen = lens[0]
+  var placeHoldersLen = lens[1]
+
+  var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen))
+
+  var curByte = 0
+
+  // if there are placeholders, only get up to the last complete 4 chars
+  var len = placeHoldersLen > 0
+    ? validLen - 4
+    : validLen
+
+  var i
+  for (i = 0; i < len; i += 4) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 18) |
+      (revLookup[b64.charCodeAt(i + 1)] << 12) |
+      (revLookup[b64.charCodeAt(i + 2)] << 6) |
+      revLookup[b64.charCodeAt(i + 3)]
+    arr[curByte++] = (tmp >> 16) & 0xFF
+    arr[curByte++] = (tmp >> 8) & 0xFF
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  if (placeHoldersLen === 2) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 2) |
+      (revLookup[b64.charCodeAt(i + 1)] >> 4)
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  if (placeHoldersLen === 1) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 10) |
+      (revLookup[b64.charCodeAt(i + 1)] << 4) |
+      (revLookup[b64.charCodeAt(i + 2)] >> 2)
+    arr[curByte++] = (tmp >> 8) & 0xFF
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  return arr
+}
+
+function tripletToBase64 (num) {
+  return lookup[num >> 18 & 0x3F] +
+    lookup[num >> 12 & 0x3F] +
+    lookup[num >> 6 & 0x3F] +
+    lookup[num & 0x3F]
+}
+
+function encodeChunk (uint8, start, end) {
+  var tmp
+  var output = []
+  for (var i = start; i < end; i += 3) {
+    tmp =
+      ((uint8[i] << 16) & 0xFF0000) +
+      ((uint8[i + 1] << 8) & 0xFF00) +
+      (uint8[i + 2] & 0xFF)
+    output.push(tripletToBase64(tmp))
+  }
+  return output.join('')
+}
+
+function fromByteArray (uint8) {
+  var tmp
+  var len = uint8.length
+  var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
+  var parts = []
+  var maxChunkLength = 16383 // must be multiple of 3
+
+  // go through the array every three bytes, we'll deal with trailing stuff later
+  for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+    parts.push(encodeChunk(
+      uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
+    ))
+  }
+
+  // pad the end with zeros, but make sure to not forget the extra bytes
+  if (extraBytes === 1) {
+    tmp = uint8[len - 1]
+    parts.push(
+      lookup[tmp >> 2] +
+      lookup[(tmp << 4) & 0x3F] +
+      '=='
+    )
+  } else if (extraBytes === 2) {
+    tmp = (uint8[len - 2] << 8) + uint8[len - 1]
+    parts.push(
+      lookup[tmp >> 10] +
+      lookup[(tmp >> 4) & 0x3F] +
+      lookup[(tmp << 2) & 0x3F] +
+      '='
+    )
+  }
+
+  return parts.join('')
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/clone/clone.js":
+/*!*************************************!*\
+  !*** ./node_modules/clone/clone.js ***!
+  \*************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -975,6080 +724,7 @@ if ( true && module.exports) {
   module.exports = clone;
 }
 
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../sfx/sfx-logic/node_modules/node-libs-browser/node_modules/buffer/index.js */ "./node_modules/node-libs-browser/node_modules/buffer/index.js").Buffer))
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/deep-equal/index.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/deep-equal/index.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-var pSlice = Array.prototype.slice;
-var objectKeys = __webpack_require__(/*! ./lib/keys.js */ "../../api-javascript/node_modules/deep-equal/lib/keys.js");
-var isArguments = __webpack_require__(/*! ./lib/is_arguments.js */ "../../api-javascript/node_modules/deep-equal/lib/is_arguments.js");
-
-var deepEqual = module.exports = function (actual, expected, opts) {
-  if (!opts) opts = {};
-  // 7.1. All identical values are equivalent, as determined by ===.
-  if (actual === expected) {
-    return true;
-
-  } else if (actual instanceof Date && expected instanceof Date) {
-    return actual.getTime() === expected.getTime();
-
-  // 7.3. Other pairs that do not both pass typeof value == 'object',
-  // equivalence is determined by ==.
-  } else if (!actual || !expected || typeof actual != 'object' && typeof expected != 'object') {
-    return opts.strict ? actual === expected : actual == expected;
-
-  // 7.4. For all other Object pairs, including Array objects, equivalence is
-  // determined by having the same number of owned properties (as verified
-  // with Object.prototype.hasOwnProperty.call), the same set of keys
-  // (although not necessarily the same order), equivalent values for every
-  // corresponding key, and an identical 'prototype' property. Note: this
-  // accounts for both named and indexed properties on Arrays.
-  } else {
-    return objEquiv(actual, expected, opts);
-  }
-}
-
-function isUndefinedOrNull(value) {
-  return value === null || value === undefined;
-}
-
-function isBuffer (x) {
-  if (!x || typeof x !== 'object' || typeof x.length !== 'number') return false;
-  if (typeof x.copy !== 'function' || typeof x.slice !== 'function') {
-    return false;
-  }
-  if (x.length > 0 && typeof x[0] !== 'number') return false;
-  return true;
-}
-
-function objEquiv(a, b, opts) {
-  var i, key;
-  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
-    return false;
-  // an identical 'prototype' property.
-  if (a.prototype !== b.prototype) return false;
-  //~~~I've managed to break Object.keys through screwy arguments passing.
-  //   Converting to array solves the problem.
-  if (isArguments(a)) {
-    if (!isArguments(b)) {
-      return false;
-    }
-    a = pSlice.call(a);
-    b = pSlice.call(b);
-    return deepEqual(a, b, opts);
-  }
-  if (isBuffer(a)) {
-    if (!isBuffer(b)) {
-      return false;
-    }
-    if (a.length !== b.length) return false;
-    for (i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
-    }
-    return true;
-  }
-  try {
-    var ka = objectKeys(a),
-        kb = objectKeys(b);
-  } catch (e) {//happens when one is a string literal and the other isn't
-    return false;
-  }
-  // having the same number of owned properties (keys incorporates
-  // hasOwnProperty)
-  if (ka.length != kb.length)
-    return false;
-  //the same set of keys (although not necessarily the same order),
-  ka.sort();
-  kb.sort();
-  //~~~cheap key test
-  for (i = ka.length - 1; i >= 0; i--) {
-    if (ka[i] != kb[i])
-      return false;
-  }
-  //equivalent values for every corresponding key, and
-  //~~~possibly expensive deep test
-  for (i = ka.length - 1; i >= 0; i--) {
-    key = ka[i];
-    if (!deepEqual(a[key], b[key], opts)) return false;
-  }
-  return typeof a === typeof b;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/deep-equal/lib/is_arguments.js":
-/*!*************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/deep-equal/lib/is_arguments.js ***!
-  \*************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-var supportsArgumentsClass = (function(){
-  return Object.prototype.toString.call(arguments)
-})() == '[object Arguments]';
-
-exports = module.exports = supportsArgumentsClass ? supported : unsupported;
-
-exports.supported = supported;
-function supported(object) {
-  return Object.prototype.toString.call(object) == '[object Arguments]';
-};
-
-exports.unsupported = unsupported;
-function unsupported(object){
-  return object &&
-    typeof object == 'object' &&
-    typeof object.length == 'number' &&
-    Object.prototype.hasOwnProperty.call(object, 'callee') &&
-    !Object.prototype.propertyIsEnumerable.call(object, 'callee') ||
-    false;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/deep-equal/lib/keys.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/deep-equal/lib/keys.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-exports = module.exports = typeof Object.keys === 'function'
-  ? Object.keys : shim;
-
-exports.shim = shim;
-function shim (obj) {
-  var keys = [];
-  for (var key in obj) keys.push(key);
-  return keys;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/expand-brackets/index.js":
-/*!*******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/expand-brackets/index.js ***!
-  \*******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * expand-brackets <https://github.com/jonschlinkert/expand-brackets>
- *
- * Copyright (c) 2015 Jon Schlinkert.
- * Licensed under the MIT license.
- */
-
-
-
-var isPosixBracket = __webpack_require__(/*! is-posix-bracket */ "../../api-javascript/node_modules/is-posix-bracket/index.js");
-
-/**
- * POSIX character classes
- */
-
-var POSIX = {
-  alnum: 'a-zA-Z0-9',
-  alpha: 'a-zA-Z',
-  blank: ' \\t',
-  cntrl: '\\x00-\\x1F\\x7F',
-  digit: '0-9',
-  graph: '\\x21-\\x7E',
-  lower: 'a-z',
-  print: '\\x20-\\x7E',
-  punct: '-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
-  space: ' \\t\\r\\n\\v\\f',
-  upper: 'A-Z',
-  word:  'A-Za-z0-9_',
-  xdigit: 'A-Fa-f0-9',
-};
-
-/**
- * Expose `brackets`
- */
-
-module.exports = brackets;
-
-function brackets(str) {
-  if (!isPosixBracket(str)) {
-    return str;
-  }
-
-  var negated = false;
-  if (str.indexOf('[^') !== -1) {
-    negated = true;
-    str = str.split('[^').join('[');
-  }
-  if (str.indexOf('[!') !== -1) {
-    negated = true;
-    str = str.split('[!').join('[');
-  }
-
-  var a = str.split('[');
-  var b = str.split(']');
-  var imbalanced = a.length !== b.length;
-
-  var parts = str.split(/(?::\]\[:|\[?\[:|:\]\]?)/);
-  var len = parts.length, i = 0;
-  var end = '', beg = '';
-  var res = [];
-
-  // start at the end (innermost) first
-  while (len--) {
-    var inner = parts[i++];
-    if (inner === '^[!' || inner === '[!') {
-      inner = '';
-      negated = true;
-    }
-
-    var prefix = negated ? '^' : '';
-    var ch = POSIX[inner];
-
-    if (ch) {
-      res.push('[' + prefix + ch + ']');
-    } else if (inner) {
-      if (/^\[?\w-\w\]?$/.test(inner)) {
-        if (i === parts.length) {
-          res.push('[' + prefix + inner);
-        } else if (i === 1) {
-          res.push(prefix + inner + ']');
-        } else {
-          res.push(prefix + inner);
-        }
-      } else {
-        if (i === 1) {
-          beg += inner;
-        } else if (i === parts.length) {
-          end += inner;
-        } else {
-          res.push('[' + prefix + inner + ']');
-        }
-      }
-    }
-  }
-
-  var result = res.join('|');
-  var rlen = res.length || 1;
-  if (rlen > 1) {
-    result = '(?:' + result + ')';
-    rlen = 1;
-  }
-  if (beg) {
-    rlen++;
-    if (beg.charAt(0) === '[') {
-      if (imbalanced) {
-        beg = '\\[' + beg.slice(1);
-      } else {
-        beg += ']';
-      }
-    }
-    result = beg + result;
-  }
-  if (end) {
-    rlen++;
-    if (end.slice(-1) === ']') {
-      if (imbalanced) {
-        end = end.slice(0, end.length - 1) + '\\]';
-      } else {
-        end = '[' + end;
-      }
-    }
-    result += end;
-  }
-
-  if (rlen > 1) {
-    result = result.split('][').join(']|[');
-    if (result.indexOf('|') !== -1 && !/\(\?/.test(result)) {
-      result = '(?:' + result + ')';
-    }
-  }
-
-  result = result.replace(/\[+=|=\]+/g, '\\b');
-  return result;
-}
-
-brackets.makeRe = function(pattern) {
-  try {
-    return new RegExp(brackets(pattern));
-  } catch (err) {}
-};
-
-brackets.isMatch = function(str, pattern) {
-  try {
-    return brackets.makeRe(pattern).test(str);
-  } catch (err) {
-    return false;
-  }
-};
-
-brackets.match = function(arr, pattern) {
-  var len = arr.length, i = 0;
-  var res = arr.slice();
-
-  var re = brackets.makeRe(pattern);
-  while (i < len) {
-    var ele = arr[i++];
-    if (!re.test(ele)) {
-      continue;
-    }
-    res.splice(i, 1);
-  }
-  return res;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/expand-range/index.js":
-/*!****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/index.js ***!
-  \****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * expand-range <https://github.com/jonschlinkert/expand-range>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT license.
- */
-
-
-
-var fill = __webpack_require__(/*! fill-range */ "../../api-javascript/node_modules/expand-range/node_modules/fill-range/index.js");
-
-module.exports = function expandRange(str, options, fn) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expand-range expects a string.');
-  }
-
-  if (typeof options === 'function') {
-    fn = options;
-    options = {};
-  }
-
-  if (typeof options === 'boolean') {
-    options = {};
-    options.makeRe = true;
-  }
-
-  // create arguments to pass to fill-range
-  var opts = options || {};
-  var args = str.split('..');
-  var len = args.length;
-  if (len > 3) { return str; }
-
-  // if only one argument, it can't expand so return it
-  if (len === 1) { return args; }
-
-  // if `true`, tell fill-range to regexify the string
-  if (typeof fn === 'boolean' && fn === true) {
-    opts.makeRe = true;
-  }
-
-  args.push(opts);
-  return fill.apply(null, args.concat(fn));
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/expand-range/node_modules/fill-range/index.js":
-/*!****************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/fill-range/index.js ***!
-  \****************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * fill-range <https://github.com/jonschlinkert/fill-range>
- *
- * Copyright (c) 2014-2018, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-var isObject = __webpack_require__(/*! isobject */ "../../api-javascript/node_modules/expand-range/node_modules/isobject/index.js");
-var isNumber = __webpack_require__(/*! is-number */ "../../api-javascript/node_modules/expand-range/node_modules/is-number/index.js");
-var randomize = __webpack_require__(/*! randomatic */ "../../api-javascript/node_modules/randomatic/index.js");
-var repeatStr = __webpack_require__(/*! repeat-string */ "../../api-javascript/node_modules/repeat-string/index.js");
-var repeat = __webpack_require__(/*! repeat-element */ "../../api-javascript/node_modules/repeat-element/index.js");
-
-/**
- * Expose `fillRange`
- */
-
-module.exports = fillRange;
-
-/**
- * Return a range of numbers or letters.
- *
- * @param  {String} `a` Start of the range
- * @param  {String} `b` End of the range
- * @param  {String} `step` Increment or decrement to use.
- * @param  {Function} `fn` Custom function to modify each element in the range.
- * @return {Array}
- */
-
-function fillRange(a, b, step, options, fn) {
-  if (a == null || b == null) {
-    throw new Error('fill-range expects the first and second args to be strings.');
-  }
-
-  if (typeof step === 'function') {
-    fn = step; options = {}; step = null;
-  }
-
-  if (typeof options === 'function') {
-    fn = options; options = {};
-  }
-
-  if (isObject(step)) {
-    options = step; step = '';
-  }
-
-  var expand, regex = false, sep = '';
-  var opts = options || {};
-
-  if (typeof opts.silent === 'undefined') {
-    opts.silent = true;
-  }
-
-  step = step || opts.step;
-
-  // store a ref to unmodified arg
-  var origA = a, origB = b;
-
-  b = (b.toString() === '-0') ? 0 : b;
-
-  if (opts.optimize || opts.makeRe) {
-    step = step ? (step += '~') : step;
-    expand = true;
-    regex = true;
-    sep = '~';
-  }
-
-  // handle special step characters
-  if (typeof step === 'string') {
-    var match = stepRe().exec(step);
-
-    if (match) {
-      var i = match.index;
-      var m = match[0];
-
-      // repeat string
-      if (m === '+') {
-        return repeat(a, b);
-
-      // randomize a, `b` times
-      } else if (m === '?') {
-        return [randomize(a, b)];
-
-      // expand right, no regex reduction
-      } else if (m === '>') {
-        step = step.substr(0, i) + step.substr(i + 1);
-        expand = true;
-
-      // expand to an array, or if valid create a reduced
-      // string for a regex logic `or`
-      } else if (m === '|') {
-        step = step.substr(0, i) + step.substr(i + 1);
-        expand = true;
-        regex = true;
-        sep = m;
-
-      // expand to an array, or if valid create a reduced
-      // string for a regex range
-      } else if (m === '~') {
-        step = step.substr(0, i) + step.substr(i + 1);
-        expand = true;
-        regex = true;
-        sep = m;
-      }
-    } else if (!isNumber(step)) {
-      if (!opts.silent) {
-        throw new TypeError('fill-range: invalid step.');
-      }
-      return null;
-    }
-  }
-
-  if (/[.&*()[\]^%$#@!]/.test(a) || /[.&*()[\]^%$#@!]/.test(b)) {
-    if (!opts.silent) {
-      throw new RangeError('fill-range: invalid range arguments.');
-    }
-    return null;
-  }
-
-  // has neither a letter nor number, or has both letters and numbers
-  // this needs to be after the step logic
-  if (!noAlphaNum(a) || !noAlphaNum(b) || hasBoth(a) || hasBoth(b)) {
-    if (!opts.silent) {
-      throw new RangeError('fill-range: invalid range arguments.');
-    }
-    return null;
-  }
-
-  // validate arguments
-  var isNumA = isNumber(zeros(a));
-  var isNumB = isNumber(zeros(b));
-
-  if ((!isNumA && isNumB) || (isNumA && !isNumB)) {
-    if (!opts.silent) {
-      throw new TypeError('fill-range: first range argument is incompatible with second.');
-    }
-    return null;
-  }
-
-  // by this point both are the same, so we
-  // can use A to check going forward.
-  var isNum = isNumA;
-  var num = formatStep(step);
-
-  // is the range alphabetical? or numeric?
-  if (isNum) {
-    // if numeric, coerce to an integer
-    a = +a; b = +b;
-  } else {
-    // otherwise, get the charCode to expand alpha ranges
-    a = a.charCodeAt(0);
-    b = b.charCodeAt(0);
-  }
-
-  // is the pattern descending?
-  var isDescending = a > b;
-
-  // don't create a character class if the args are < 0
-  if (a < 0 || b < 0) {
-    expand = false;
-    regex = false;
-  }
-
-  // detect padding
-  var padding = isPadded(origA, origB);
-  var res, pad, arr = [];
-  var ii = 0;
-
-  // character classes, ranges and logical `or`
-  if (regex) {
-    if (shouldExpand(a, b, num, isNum, padding, opts)) {
-      // make sure the correct separator is used
-      if (sep === '|' || sep === '~') {
-        sep = detectSeparator(a, b, num, isNum, isDescending);
-      }
-      return wrap([origA, origB], sep, opts);
-    }
-  }
-
-  while (isDescending ? (a >= b) : (a <= b)) {
-    if (padding && isNum) {
-      pad = padding(a);
-    }
-
-    // custom function
-    if (typeof fn === 'function') {
-      res = fn(a, isNum, pad, ii++);
-
-    // letters
-    } else if (!isNum) {
-      if (regex && isInvalidChar(a)) {
-        res = null;
-      } else {
-        res = String.fromCharCode(a);
-      }
-
-    // numbers
-    } else {
-      res = formatPadding(a, pad);
-    }
-
-    // add result to the array, filtering any nulled values
-    if (res !== null) arr.push(res);
-
-    // increment or decrement
-    if (isDescending) {
-      a -= num;
-    } else {
-      a += num;
-    }
-  }
-
-  // now that the array is expanded, we need to handle regex
-  // character classes, ranges or logical `or` that wasn't
-  // already handled before the loop
-  if ((regex || expand) && !opts.noexpand) {
-    // make sure the correct separator is used
-    if (sep === '|' || sep === '~') {
-      sep = detectSeparator(a, b, num, isNum, isDescending);
-    }
-    if (arr.length === 1 || a < 0 || b < 0) { return arr; }
-    return wrap(arr, sep, opts);
-  }
-
-  return arr;
-}
-
-/**
- * Wrap the string with the correct regex
- * syntax.
- */
-
-function wrap(arr, sep, opts) {
-  if (sep === '~') { sep = '-'; }
-  var str = arr.join(sep);
-  var pre = opts && opts.regexPrefix;
-
-  // regex logical `or`
-  if (sep === '|') {
-    str = pre ? pre + str : str;
-    str = '(' + str + ')';
-  }
-
-  // regex character class
-  if (sep === '-') {
-    str = (pre && pre === '^')
-      ? pre + str
-      : str;
-    str = '[' + str + ']';
-  }
-  return [str];
-}
-
-/**
- * Check for invalid characters
- */
-
-function isCharClass(a, b, step, isNum, isDescending) {
-  if (isDescending) { return false; }
-  if (isNum) { return a <= 9 && b <= 9; }
-  if (a < b) { return step === 1; }
-  return false;
-}
-
-/**
- * Detect the correct separator to use
- */
-
-function shouldExpand(a, b, num, isNum, padding, opts) {
-  if (isNum && (a > 9 || b > 9)) { return false; }
-  return !padding && num === 1 && a < b;
-}
-
-/**
- * Detect the correct separator to use
- */
-
-function detectSeparator(a, b, step, isNum, isDescending) {
-  var isChar = isCharClass(a, b, step, isNum, isDescending);
-  if (!isChar) {
-    return '|';
-  }
-  return '~';
-}
-
-/**
- * Correctly format the step based on type
- */
-
-function formatStep(step) {
-  return Math.abs(step >> 0) || 1;
-}
-
-/**
- * Format padding, taking leading `-` into account
- */
-
-function formatPadding(ch, pad) {
-  var res = pad ? pad + ch : ch;
-  if (pad && ch.toString().charAt(0) === '-') {
-    res = '-' + pad + ch.toString().substr(1);
-  }
-  return res.toString();
-}
-
-/**
- * Check for invalid characters
- */
-
-function isInvalidChar(str) {
-  var ch = toStr(str);
-  return ch === '\\'
-    || ch === '['
-    || ch === ']'
-    || ch === '^'
-    || ch === '('
-    || ch === ')'
-    || ch === '`';
-}
-
-/**
- * Convert to a string from a charCode
- */
-
-function toStr(ch) {
-  return String.fromCharCode(ch);
-}
-
-
-/**
- * Step regex
- */
-
-function stepRe() {
-  return /\?|>|\||\+|\~/g;
-}
-
-/**
- * Return true if `val` has either a letter
- * or a number
- */
-
-function noAlphaNum(val) {
-  return /[a-z0-9]/i.test(val);
-}
-
-/**
- * Return true if `val` has both a letter and
- * a number (invalid)
- */
-
-function hasBoth(val) {
-  return /[a-z][0-9]|[0-9][a-z]/i.test(val);
-}
-
-/**
- * Normalize zeros for checks
- */
-
-function zeros(val) {
-  if (/^-*0+$/.test(val.toString())) {
-    return '0';
-  }
-  return val;
-}
-
-/**
- * Return true if `val` has leading zeros,
- * or a similar valid pattern.
- */
-
-function hasZeros(val) {
-  return /[^.]\.|^-*0+[0-9]/.test(val);
-}
-
-/**
- * If the string is padded, returns a curried function with
- * the a cached padding string, or `false` if no padding.
- *
- * @param  {*} `origA` String or number.
- * @return {String|Boolean}
- */
-
-function isPadded(origA, origB) {
-  if (hasZeros(origA) || hasZeros(origB)) {
-    var alen = length(origA);
-    var blen = length(origB);
-
-    var len = alen >= blen
-      ? alen
-      : blen;
-
-    return function (a) {
-      return repeatStr('0', len - length(a));
-    };
-  }
-  return false;
-}
-
-/**
- * Get the string length of `val`
- */
-
-function length(val) {
-  return val.toString().length;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/expand-range/node_modules/is-number/index.js":
-/*!***************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/is-number/index.js ***!
-  \***************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * is-number <https://github.com/jonschlinkert/is-number>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/kind-of/index.js");
-
-module.exports = function isNumber(num) {
-  var type = typeOf(num);
-  if (type !== 'number' && type !== 'string') {
-    return false;
-  }
-  var n = +num;
-  return (n - n + 1) >= 0 && num !== '';
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/expand-range/node_modules/isarray/index.js":
-/*!*************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/isarray/index.js ***!
-  \*************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-var toString = {}.toString;
-
-module.exports = Array.isArray || function (arr) {
-  return toString.call(arr) == '[object Array]';
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/expand-range/node_modules/isobject/index.js":
-/*!**************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/isobject/index.js ***!
-  \**************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * isobject <https://github.com/jonschlinkert/isobject>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var isArray = __webpack_require__(/*! isarray */ "../../api-javascript/node_modules/expand-range/node_modules/isarray/index.js");
-
-module.exports = function isObject(val) {
-  return val != null && typeof val === 'object' && isArray(val) === false;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/extend-shallow/index.js":
-/*!******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/extend-shallow/index.js ***!
-  \******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var isObject = __webpack_require__(/*! is-extendable */ "../../api-javascript/node_modules/is-extendable/index.js");
-
-module.exports = function extend(o/*, objects*/) {
-  if (!isObject(o)) { o = {}; }
-
-  var len = arguments.length;
-  for (var i = 1; i < len; i++) {
-    var obj = arguments[i];
-
-    if (isObject(obj)) {
-      assign(o, obj);
-    }
-  }
-  return o;
-};
-
-function assign(a, b) {
-  for (var key in b) {
-    if (hasOwn(b, key)) {
-      a[key] = b[key];
-    }
-  }
-}
-
-/**
- * Returns true if the given `key` is an own property of `obj`.
- */
-
-function hasOwn(obj, key) {
-  return Object.prototype.hasOwnProperty.call(obj, key);
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/extglob/index.js":
-/*!***********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/extglob/index.js ***!
-  \***********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * extglob <https://github.com/jonschlinkert/extglob>
- *
- * Copyright (c) 2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-/**
- * Module dependencies
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
-var re, cache = {};
-
-/**
- * Expose `extglob`
- */
-
-module.exports = extglob;
-
-/**
- * Convert the given extglob `string` to a regex-compatible
- * string.
- *
- * ```js
- * var extglob = require('extglob');
- * extglob('!(a?(b))');
- * //=> '(?!a(?:b)?)[^/]*?'
- * ```
- *
- * @param {String} `str` The string to convert.
- * @param {Object} `options`
- *   @option {Boolean} [options] `esc` If `false` special characters will not be escaped. Defaults to `true`.
- *   @option {Boolean} [options] `regex` If `true` a regular expression is returned instead of a string.
- * @return {String}
- * @api public
- */
-
-
-function extglob(str, opts) {
-  opts = opts || {};
-  var o = {}, i = 0;
-
-  // fix common character reversals
-  // '*!(.js)' => '*.!(js)'
-  str = str.replace(/!\(([^\w*()])/g, '$1!(');
-
-  // support file extension negation
-  str = str.replace(/([*\/])\.!\([*]\)/g, function (m, ch) {
-    if (ch === '/') {
-      return escape('\\/[^.]+');
-    }
-    return escape('[^.]+');
-  });
-
-  // create a unique key for caching by
-  // combining the string and options
-  var key = str
-    + String(!!opts.regex)
-    + String(!!opts.contains)
-    + String(!!opts.escape);
-
-  if (cache.hasOwnProperty(key)) {
-    return cache[key];
-  }
-
-  if (!(re instanceof RegExp)) {
-    re = regex();
-  }
-
-  opts.negate = false;
-  var m;
-
-  while (m = re.exec(str)) {
-    var prefix = m[1];
-    var inner = m[3];
-    if (prefix === '!') {
-      opts.negate = true;
-    }
-
-    var id = '__EXTGLOB_' + (i++) + '__';
-    // use the prefix of the _last_ (outtermost) pattern
-    o[id] = wrap(inner, prefix, opts.escape);
-    str = str.split(m[0]).join(id);
-  }
-
-  var keys = Object.keys(o);
-  var len = keys.length;
-
-  // we have to loop again to allow us to convert
-  // patterns in reverse order (starting with the
-  // innermost/last pattern first)
-  while (len--) {
-    var prop = keys[len];
-    str = str.split(prop).join(o[prop]);
-  }
-
-  var result = opts.regex
-    ? toRegex(str, opts.contains, opts.negate)
-    : str;
-
-  result = result.split('.').join('\\.');
-
-  // cache the result and return it
-  return (cache[key] = result);
-}
-
-/**
- * Convert `string` to a regex string.
- *
- * @param  {String} `str`
- * @param  {String} `prefix` Character that determines how to wrap the string.
- * @param  {Boolean} `esc` If `false` special characters will not be escaped. Defaults to `true`.
- * @return {String}
- */
-
-function wrap(inner, prefix, esc) {
-  if (esc) inner = escape(inner);
-
-  switch (prefix) {
-    case '!':
-      return '(?!' + inner + ')[^/]' + (esc ? '%%%~' : '*?');
-    case '@':
-      return '(?:' + inner + ')';
-    case '+':
-      return '(?:' + inner + ')+';
-    case '*':
-      return '(?:' + inner + ')' + (esc ? '%%' : '*')
-    case '?':
-      return '(?:' + inner + '|)';
-    default:
-      return inner;
-  }
-}
-
-function escape(str) {
-  str = str.split('*').join('[^/]%%%~');
-  str = str.split('.').join('\\.');
-  return str;
-}
-
-/**
- * extglob regex.
- */
-
-function regex() {
-  return /(\\?[@?!+*$]\\?)(\(([^()]*?)\))/;
-}
-
-/**
- * Negation regex
- */
-
-function negate(str) {
-  return '(?!^' + str + ').*$';
-}
-
-/**
- * Create the regex to do the matching. If
- * the leading character in the `pattern` is `!`
- * a negation regex is returned.
- *
- * @param {String} `pattern`
- * @param {Boolean} `contains` Allow loose matching.
- * @param {Boolean} `isNegated` True if the pattern is a negation pattern.
- */
-
-function toRegex(pattern, contains, isNegated) {
-  var prefix = contains ? '^' : '';
-  var after = contains ? '$' : '';
-  pattern = ('(?:' + pattern + ')' + after);
-  if (isNegated) {
-    pattern = prefix + negate(pattern);
-  }
-  return new RegExp(prefix + pattern);
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/fetch-ponyfill/build/fetch-browser.js":
-/*!********************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/fetch-ponyfill/build/fetch-browser.js ***!
-  \********************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/* WEBPACK VAR INJECTION */(function(global) {var __WEBPACK_AMD_DEFINE_RESULT__;(function (self) {
-  'use strict';
-
-  function fetchPonyfill(options) {
-    var Promise = options && options.Promise || self.Promise;
-    var XMLHttpRequest = options && options.XMLHttpRequest || self.XMLHttpRequest;
-    var global = self;
-
-    return (function () {
-      var self = Object.create(global, {
-        fetch: {
-          value: undefined,
-          writable: true
-        }
-      });
-
-      (function(self) {
-        'use strict';
-
-        if (self.fetch) {
-          return
-        }
-
-        var support = {
-          searchParams: 'URLSearchParams' in self,
-          iterable: 'Symbol' in self && 'iterator' in Symbol,
-          blob: 'FileReader' in self && 'Blob' in self && (function() {
-            try {
-              new Blob()
-              return true
-            } catch(e) {
-              return false
-            }
-          })(),
-          formData: 'FormData' in self,
-          arrayBuffer: 'ArrayBuffer' in self
-        }
-
-        if (support.arrayBuffer) {
-          var viewClasses = [
-            '[object Int8Array]',
-            '[object Uint8Array]',
-            '[object Uint8ClampedArray]',
-            '[object Int16Array]',
-            '[object Uint16Array]',
-            '[object Int32Array]',
-            '[object Uint32Array]',
-            '[object Float32Array]',
-            '[object Float64Array]'
-          ]
-
-          var isDataView = function(obj) {
-            return obj && DataView.prototype.isPrototypeOf(obj)
-          }
-
-          var isArrayBufferView = ArrayBuffer.isView || function(obj) {
-            return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
-          }
-        }
-
-        function normalizeName(name) {
-          if (typeof name !== 'string') {
-            name = String(name)
-          }
-          if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
-            throw new TypeError('Invalid character in header field name')
-          }
-          return name.toLowerCase()
-        }
-
-        function normalizeValue(value) {
-          if (typeof value !== 'string') {
-            value = String(value)
-          }
-          return value
-        }
-
-        // Build a destructive iterator for the value list
-        function iteratorFor(items) {
-          var iterator = {
-            next: function() {
-              var value = items.shift()
-              return {done: value === undefined, value: value}
-            }
-          }
-
-          if (support.iterable) {
-            iterator[Symbol.iterator] = function() {
-              return iterator
-            }
-          }
-
-          return iterator
-        }
-
-        function Headers(headers) {
-          this.map = {}
-
-          if (headers instanceof Headers) {
-            headers.forEach(function(value, name) {
-              this.append(name, value)
-            }, this)
-          } else if (Array.isArray(headers)) {
-            headers.forEach(function(header) {
-              this.append(header[0], header[1])
-            }, this)
-          } else if (headers) {
-            Object.getOwnPropertyNames(headers).forEach(function(name) {
-              this.append(name, headers[name])
-            }, this)
-          }
-        }
-
-        Headers.prototype.append = function(name, value) {
-          name = normalizeName(name)
-          value = normalizeValue(value)
-          var oldValue = this.map[name]
-          this.map[name] = oldValue ? oldValue+','+value : value
-        }
-
-        Headers.prototype['delete'] = function(name) {
-          delete this.map[normalizeName(name)]
-        }
-
-        Headers.prototype.get = function(name) {
-          name = normalizeName(name)
-          return this.has(name) ? this.map[name] : null
-        }
-
-        Headers.prototype.has = function(name) {
-          return this.map.hasOwnProperty(normalizeName(name))
-        }
-
-        Headers.prototype.set = function(name, value) {
-          this.map[normalizeName(name)] = normalizeValue(value)
-        }
-
-        Headers.prototype.forEach = function(callback, thisArg) {
-          for (var name in this.map) {
-            if (this.map.hasOwnProperty(name)) {
-              callback.call(thisArg, this.map[name], name, this)
-            }
-          }
-        }
-
-        Headers.prototype.keys = function() {
-          var items = []
-          this.forEach(function(value, name) { items.push(name) })
-          return iteratorFor(items)
-        }
-
-        Headers.prototype.values = function() {
-          var items = []
-          this.forEach(function(value) { items.push(value) })
-          return iteratorFor(items)
-        }
-
-        Headers.prototype.entries = function() {
-          var items = []
-          this.forEach(function(value, name) { items.push([name, value]) })
-          return iteratorFor(items)
-        }
-
-        if (support.iterable) {
-          Headers.prototype[Symbol.iterator] = Headers.prototype.entries
-        }
-
-        function consumed(body) {
-          if (body.bodyUsed) {
-            return Promise.reject(new TypeError('Already read'))
-          }
-          body.bodyUsed = true
-        }
-
-        function fileReaderReady(reader) {
-          return new Promise(function(resolve, reject) {
-            reader.onload = function() {
-              resolve(reader.result)
-            }
-            reader.onerror = function() {
-              reject(reader.error)
-            }
-          })
-        }
-
-        function readBlobAsArrayBuffer(blob) {
-          var reader = new FileReader()
-          var promise = fileReaderReady(reader)
-          reader.readAsArrayBuffer(blob)
-          return promise
-        }
-
-        function readBlobAsText(blob) {
-          var reader = new FileReader()
-          var promise = fileReaderReady(reader)
-          reader.readAsText(blob)
-          return promise
-        }
-
-        function readArrayBufferAsText(buf) {
-          var view = new Uint8Array(buf)
-          var chars = new Array(view.length)
-
-          for (var i = 0; i < view.length; i++) {
-            chars[i] = String.fromCharCode(view[i])
-          }
-          return chars.join('')
-        }
-
-        function bufferClone(buf) {
-          if (buf.slice) {
-            return buf.slice(0)
-          } else {
-            var view = new Uint8Array(buf.byteLength)
-            view.set(new Uint8Array(buf))
-            return view.buffer
-          }
-        }
-
-        function Body() {
-          this.bodyUsed = false
-
-          this._initBody = function(body) {
-            this._bodyInit = body
-            if (!body) {
-              this._bodyText = ''
-            } else if (typeof body === 'string') {
-              this._bodyText = body
-            } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
-              this._bodyBlob = body
-            } else if (support.formData && FormData.prototype.isPrototypeOf(body)) {
-              this._bodyFormData = body
-            } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
-              this._bodyText = body.toString()
-            } else if (support.arrayBuffer && support.blob && isDataView(body)) {
-              this._bodyArrayBuffer = bufferClone(body.buffer)
-              // IE 10-11 can't handle a DataView body.
-              this._bodyInit = new Blob([this._bodyArrayBuffer])
-            } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
-              this._bodyArrayBuffer = bufferClone(body)
-            } else {
-              throw new Error('unsupported BodyInit type')
-            }
-
-            if (!this.headers.get('content-type')) {
-              if (typeof body === 'string') {
-                this.headers.set('content-type', 'text/plain;charset=UTF-8')
-              } else if (this._bodyBlob && this._bodyBlob.type) {
-                this.headers.set('content-type', this._bodyBlob.type)
-              } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
-                this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
-              }
-            }
-          }
-
-          if (support.blob) {
-            this.blob = function() {
-              var rejected = consumed(this)
-              if (rejected) {
-                return rejected
-              }
-
-              if (this._bodyBlob) {
-                return Promise.resolve(this._bodyBlob)
-              } else if (this._bodyArrayBuffer) {
-                return Promise.resolve(new Blob([this._bodyArrayBuffer]))
-              } else if (this._bodyFormData) {
-                throw new Error('could not read FormData body as blob')
-              } else {
-                return Promise.resolve(new Blob([this._bodyText]))
-              }
-            }
-
-            this.arrayBuffer = function() {
-              if (this._bodyArrayBuffer) {
-                return consumed(this) || Promise.resolve(this._bodyArrayBuffer)
-              } else {
-                return this.blob().then(readBlobAsArrayBuffer)
-              }
-            }
-          }
-
-          this.text = function() {
-            var rejected = consumed(this)
-            if (rejected) {
-              return rejected
-            }
-
-            if (this._bodyBlob) {
-              return readBlobAsText(this._bodyBlob)
-            } else if (this._bodyArrayBuffer) {
-              return Promise.resolve(readArrayBufferAsText(this._bodyArrayBuffer))
-            } else if (this._bodyFormData) {
-              throw new Error('could not read FormData body as text')
-            } else {
-              return Promise.resolve(this._bodyText)
-            }
-          }
-
-          if (support.formData) {
-            this.formData = function() {
-              return this.text().then(decode)
-            }
-          }
-
-          this.json = function() {
-            return this.text().then(JSON.parse)
-          }
-
-          return this
-        }
-
-        // HTTP methods whose capitalization should be normalized
-        var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
-
-        function normalizeMethod(method) {
-          var upcased = method.toUpperCase()
-          return (methods.indexOf(upcased) > -1) ? upcased : method
-        }
-
-        function Request(input, options) {
-          options = options || {}
-          var body = options.body
-
-          if (input instanceof Request) {
-            if (input.bodyUsed) {
-              throw new TypeError('Already read')
-            }
-            this.url = input.url
-            this.credentials = input.credentials
-            if (!options.headers) {
-              this.headers = new Headers(input.headers)
-            }
-            this.method = input.method
-            this.mode = input.mode
-            if (!body && input._bodyInit != null) {
-              body = input._bodyInit
-              input.bodyUsed = true
-            }
-          } else {
-            this.url = String(input)
-          }
-
-          this.credentials = options.credentials || this.credentials || 'omit'
-          if (options.headers || !this.headers) {
-            this.headers = new Headers(options.headers)
-          }
-          this.method = normalizeMethod(options.method || this.method || 'GET')
-          this.mode = options.mode || this.mode || null
-          this.referrer = null
-
-          if ((this.method === 'GET' || this.method === 'HEAD') && body) {
-            throw new TypeError('Body not allowed for GET or HEAD requests')
-          }
-          this._initBody(body)
-        }
-
-        Request.prototype.clone = function() {
-          return new Request(this, { body: this._bodyInit })
-        }
-
-        function decode(body) {
-          var form = new FormData()
-          body.trim().split('&').forEach(function(bytes) {
-            if (bytes) {
-              var split = bytes.split('=')
-              var name = split.shift().replace(/\+/g, ' ')
-              var value = split.join('=').replace(/\+/g, ' ')
-              form.append(decodeURIComponent(name), decodeURIComponent(value))
-            }
-          })
-          return form
-        }
-
-        function parseHeaders(rawHeaders) {
-          var headers = new Headers()
-          // Replace instances of \r\n and \n followed by at least one space or horizontal tab with a space
-          // https://tools.ietf.org/html/rfc7230#section-3.2
-          var preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/g, ' ')
-          preProcessedHeaders.split(/\r?\n/).forEach(function(line) {
-            var parts = line.split(':')
-            var key = parts.shift().trim()
-            if (key) {
-              var value = parts.join(':').trim()
-              headers.append(key, value)
-            }
-          })
-          return headers
-        }
-
-        Body.call(Request.prototype)
-
-        function Response(bodyInit, options) {
-          if (!options) {
-            options = {}
-          }
-
-          this.type = 'default'
-          this.status = options.status === undefined ? 200 : options.status
-          this.ok = this.status >= 200 && this.status < 300
-          this.statusText = 'statusText' in options ? options.statusText : 'OK'
-          this.headers = new Headers(options.headers)
-          this.url = options.url || ''
-          this._initBody(bodyInit)
-        }
-
-        Body.call(Response.prototype)
-
-        Response.prototype.clone = function() {
-          return new Response(this._bodyInit, {
-            status: this.status,
-            statusText: this.statusText,
-            headers: new Headers(this.headers),
-            url: this.url
-          })
-        }
-
-        Response.error = function() {
-          var response = new Response(null, {status: 0, statusText: ''})
-          response.type = 'error'
-          return response
-        }
-
-        var redirectStatuses = [301, 302, 303, 307, 308]
-
-        Response.redirect = function(url, status) {
-          if (redirectStatuses.indexOf(status) === -1) {
-            throw new RangeError('Invalid status code')
-          }
-
-          return new Response(null, {status: status, headers: {location: url}})
-        }
-
-        self.Headers = Headers
-        self.Request = Request
-        self.Response = Response
-
-        self.fetch = function(input, init) {
-          return new Promise(function(resolve, reject) {
-            var request = new Request(input, init)
-            var xhr = new XMLHttpRequest()
-
-            xhr.onload = function() {
-              var options = {
-                status: xhr.status,
-                statusText: xhr.statusText,
-                headers: parseHeaders(xhr.getAllResponseHeaders() || '')
-              }
-              options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
-              var body = 'response' in xhr ? xhr.response : xhr.responseText
-              resolve(new Response(body, options))
-            }
-
-            xhr.onerror = function() {
-              reject(new TypeError('Network request failed'))
-            }
-
-            xhr.ontimeout = function() {
-              reject(new TypeError('Network request failed'))
-            }
-
-            xhr.open(request.method, request.url, true)
-
-            if (request.credentials === 'include') {
-              xhr.withCredentials = true
-            } else if (request.credentials === 'omit') {
-              xhr.withCredentials = false
-            }
-
-            if ('responseType' in xhr && support.blob) {
-              xhr.responseType = 'blob'
-            }
-
-            request.headers.forEach(function(value, name) {
-              xhr.setRequestHeader(name, value)
-            })
-
-            xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)
-          })
-        }
-        self.fetch.polyfill = true
-      })(typeof self !== 'undefined' ? self : this);
-
-
-      return {
-        fetch: self.fetch,
-        Headers: self.Headers,
-        Request: self.Request,
-        Response: self.Response
-      };
-    }());
-  }
-
-  if (true) {
-    !(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {
-      return fetchPonyfill;
-    }).call(exports, __webpack_require__, exports, module),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-  } else {}
-}(typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : this));
-
-
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../sfx/sfx-logic/node_modules/webpack/buildin/global.js */ "./node_modules/webpack/buildin/global.js")))
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/filename-regex/index.js":
-/*!******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/filename-regex/index.js ***!
-  \******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-/*!
- * filename-regex <https://github.com/regexps/filename-regex>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert
- * Licensed under the MIT license.
- */
-
-module.exports = function filenameRegex() {
-  return /([^\\\/]+)$/;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/filter-keys/index.js":
-/*!***************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/filter-keys/index.js ***!
-  \***************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var mm = __webpack_require__(/*! micromatch */ "../../api-javascript/node_modules/micromatch/index.js");
-
-module.exports = function filterKeys(o, patterns, options) {
-  if (o == null) {
-    throw new Error('filter-keys expects an object');
-  }
-
-  var keys = Object.keys(o);
-  if (!patterns || arguments.length === 1) {
-    return keys;
-  }
-
-  return mm(keys, patterns, options);
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/filter-object/index.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/filter-object/index.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/filter-object/node_modules/kind-of/index.js");
-var filterKeys = __webpack_require__(/*! filter-keys */ "../../api-javascript/node_modules/filter-keys/index.js");
-var filterValues = __webpack_require__(/*! filter-values */ "../../api-javascript/node_modules/filter-values/index.js");
-var pick = __webpack_require__(/*! object.pick */ "../../api-javascript/node_modules/object.pick/index.js");
-var extend = __webpack_require__(/*! extend-shallow */ "../../api-javascript/node_modules/extend-shallow/index.js");
-
-module.exports = function filterObject(val, patterns, options) {
-  if (!val || typeof val !== 'object') {
-    throw new Error('filter-object expects an object');
-  }
-
-  if (patterns == null) return val;
-
-  if (typeOf(patterns) === 'function') {
-    return filterValues(val, patterns, options);
-  }
-
-  var keys = filterKeys(val, patterns, options);
-  return pick(val, keys);
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/filter-object/node_modules/kind-of/index.js":
-/*!**************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/filter-object/node_modules/kind-of/index.js ***!
-  \**************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/* WEBPACK VAR INJECTION */(function(Buffer) {var isBuffer = __webpack_require__(/*! is-buffer */ "../../api-javascript/node_modules/is-buffer/index.js");
-var toString = Object.prototype.toString;
-
-/**
- * Get the native `typeof` a value.
- *
- * @param  {*} `val`
- * @return {*} Native javascript type
- */
-
-module.exports = function kindOf(val) {
-  // primitivies
-  if (typeof val === 'undefined') {
-    return 'undefined';
-  }
-  if (val === null) {
-    return 'null';
-  }
-  if (val === true || val === false || val instanceof Boolean) {
-    return 'boolean';
-  }
-  if (typeof val === 'string' || val instanceof String) {
-    return 'string';
-  }
-  if (typeof val === 'number' || val instanceof Number) {
-    return 'number';
-  }
-
-  // functions
-  if (typeof val === 'function' || val instanceof Function) {
-    return 'function';
-  }
-
-  // array
-  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
-    return 'array';
-  }
-
-  // check for instances of RegExp and Date before calling `toString`
-  if (val instanceof RegExp) {
-    return 'regexp';
-  }
-  if (val instanceof Date) {
-    return 'date';
-  }
-
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-
-  // buffer
-  if (typeof Buffer !== 'undefined' && isBuffer(val)) {
-    return 'buffer';
-  }
-
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
-
-  // must be a plain object
-  return 'object';
-};
-
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../../sfx/sfx-logic/node_modules/node-libs-browser/node_modules/buffer/index.js */ "./node_modules/node-libs-browser/node_modules/buffer/index.js").Buffer))
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/filter-values/index.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/filter-values/index.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * filter-values <https://github.com/jonschlinkert/filter-values>
- *
- * Copyright (c) 2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var forOwn = __webpack_require__(/*! for-own */ "../../api-javascript/node_modules/for-own/index.js");
-var matcher = __webpack_require__(/*! is-match */ "../../api-javascript/node_modules/is-match/index.js");
-
-/**
- * Filter an object values using glob patterns
- * or with a `callback` function returns true.
- *
- * @param  {Object} `obj`
- * @param  {Function|Array|String|RegExp} `filter`
- * @param  {Object} `options` pass options to `micromatch`
- * @return {Object}
- */
-
-module.exports = function filterValues(obj, filter, options) {
-  var isMatch = matcher(filter, options);
-  var res = {};
-
-  forOwn(obj, function (val, key) {
-    if (isMatch(val, key, obj)) {
-      res[key] = val;
-    }
-  });
-  return res;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/for-in/index.js":
-/*!**********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/for-in/index.js ***!
-  \**********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * for-in <https://github.com/jonschlinkert/for-in>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-module.exports = function forIn(obj, fn, thisArg) {
-  for (var key in obj) {
-    if (fn.call(thisArg, obj[key], key, obj) === false) {
-      break;
-    }
-  }
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/for-own/index.js":
-/*!***********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/for-own/index.js ***!
-  \***********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * for-own <https://github.com/jonschlinkert/for-own>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-var forIn = __webpack_require__(/*! for-in */ "../../api-javascript/node_modules/for-in/index.js");
-var hasOwn = Object.prototype.hasOwnProperty;
-
-module.exports = function forOwn(obj, fn, thisArg) {
-  forIn(obj, function(val, key) {
-    if (hasOwn.call(obj, key)) {
-      return fn.call(thisArg, obj[key], key, obj);
-    }
-  });
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/glob-base/index.js":
-/*!*************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/glob-base/index.js ***!
-  \*************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * glob-base <https://github.com/jonschlinkert/glob-base>
- *
- * Copyright (c) 2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
-var parent = __webpack_require__(/*! glob-parent */ "../../api-javascript/node_modules/glob-base/node_modules/glob-parent/index.js");
-var isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
-
-module.exports = function globBase(pattern) {
-  if (typeof pattern !== 'string') {
-    throw new TypeError('glob-base expects a string.');
-  }
-
-  var res = {};
-  res.base = parent(pattern);
-  res.isGlob = isGlob(pattern);
-
-  if (res.base !== '.') {
-    res.glob = pattern.substr(res.base.length);
-    if (res.glob.charAt(0) === '/') {
-      res.glob = res.glob.substr(1);
-    }
-  } else {
-    res.glob = pattern;
-  }
-
-  if (!res.isGlob) {
-    res.base = dirname(pattern);
-    res.glob = res.base !== '.'
-      ? pattern.substr(res.base.length)
-      : pattern;
-  }
-
-  if (res.glob.substr(0, 2) === './') {
-    res.glob = res.glob.substr(2);
-  }
-  if (res.glob.charAt(0) === '/') {
-    res.glob = res.glob.substr(1);
-  }
-  return res;
-};
-
-function dirname(glob) {
-  if (glob.slice(-1) === '/') return glob;
-  return path.dirname(glob);
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/glob-base/node_modules/glob-parent/index.js":
-/*!**************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/glob-base/node_modules/glob-parent/index.js ***!
-  \**************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
-var isglob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
-
-module.exports = function globParent(str) {
-	str += 'a'; // preserves full path in case of trailing path separator
-	do {str = path.dirname(str)} while (isglob(str));
-	return str;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-buffer/index.js":
-/*!*************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-buffer/index.js ***!
-  \*************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-/*!
- * Determine if an object is a Buffer
- *
- * @author   Feross Aboukhadijeh <https://feross.org>
- * @license  MIT
- */
-
-// The _isBuffer check is for Safari 5-7 support, because it's missing
-// Object.prototype.constructor. Remove this eventually
-module.exports = function (obj) {
-  return obj != null && (isBuffer(obj) || isSlowBuffer(obj) || !!obj._isBuffer)
-}
-
-function isBuffer (obj) {
-  return !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
-}
-
-// For Node v0.10 support. Remove this eventually.
-function isSlowBuffer (obj) {
-  return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-dotfile/index.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-dotfile/index.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-/*!
- * is-dotfile <https://github.com/jonschlinkert/is-dotfile>
- *
- * Copyright (c) 2015-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-module.exports = function(str) {
-  if (str.charCodeAt(0) === 46 /* . */ && str.indexOf('/', 1) === -1) {
-    return true;
-  }
-  var slash = str.lastIndexOf('/');
-  return slash !== -1 ? str.charCodeAt(slash + 1) === 46  /* . */ : false;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-equal-shallow/index.js":
-/*!********************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-equal-shallow/index.js ***!
-  \********************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * is-equal-shallow <https://github.com/jonschlinkert/is-equal-shallow>
- *
- * Copyright (c) 2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var isPrimitive = __webpack_require__(/*! is-primitive */ "../../api-javascript/node_modules/is-primitive/index.js");
-
-module.exports = function isEqual(a, b) {
-  if (!a && !b) { return true; }
-  if (!a && b || a && !b) { return false; }
-
-  var numKeysA = 0, numKeysB = 0, key;
-  for (key in b) {
-    numKeysB++;
-    if (!isPrimitive(b[key]) || !a.hasOwnProperty(key) || (a[key] !== b[key])) {
-      return false;
-    }
-  }
-  for (key in a) {
-    numKeysA++;
-  }
-  return numKeysA === numKeysB;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-extendable/index.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-extendable/index.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * is-extendable <https://github.com/jonschlinkert/is-extendable>
- *
- * Copyright (c) 2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-module.exports = function isExtendable(val) {
-  return typeof val !== 'undefined' && val !== null
-    && (typeof val === 'object' || typeof val === 'function');
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-extglob/index.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-extglob/index.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-/*!
- * is-extglob <https://github.com/jonschlinkert/is-extglob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-module.exports = function isExtglob(str) {
-  return typeof str === 'string'
-    && /[@?!+*]\(/.test(str);
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-glob/index.js":
-/*!***********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-glob/index.js ***!
-  \***********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * is-glob <https://github.com/jonschlinkert/is-glob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
-
-module.exports = function isGlob(str) {
-  return typeof str === 'string'
-    && (/[*!?{}(|)[\]]/.test(str)
-     || isExtglob(str));
-};
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-match/index.js":
-/*!************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-match/index.js ***!
-  \************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * is-match <https://github.com/jonschlinkert/is-match>
- *
- * Copyright (c) 2015-2016 Jon Schlinkert.
- * Licensed under the MIT license.
- */
-
-
-
-var deepEqual = __webpack_require__(/*! deep-equal */ "../../api-javascript/node_modules/deep-equal/index.js");
-var isObject = __webpack_require__(/*! is-extendable */ "../../api-javascript/node_modules/is-extendable/index.js");
-var isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
-var mm = __webpack_require__(/*! micromatch */ "../../api-javascript/node_modules/micromatch/index.js");
-
-function isMatch(pattern, options) {
-  options = options || {};
-
-  if (typeof pattern === 'function') {
-    return pattern;
-  }
-
-  if (pattern instanceof RegExp) {
-    return function(val) {
-      return pattern.test(val);
-    };
-  }
-
-  if (typeof pattern === 'string') {
-    if (isGlob(pattern)) {
-      return function(val) {
-        return mm(val, pattern, options).length !== 0;
-      };
-    }
-    return function(val) {
-      if (options.strict === true) {
-        return pattern === val;
-      }
-      return val.indexOf(pattern) > -1;
-    };
-  }
-
-  if (Array.isArray(pattern)) {
-    return function(val) {
-      return mm(val, pattern, options).length !== 0;
-    };
-  }
-
-  if (isObject(pattern)) {
-    return function(val) {
-      return deepEqual(val, pattern);
-    };
-  }
-
-  throw new TypeError('isMatch expects a string, array, regex, plain object or function:', arguments);
-}
-
-/**
- * Expose `isMatch`
- */
-
-module.exports = isMatch;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-posix-bracket/index.js":
-/*!********************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-posix-bracket/index.js ***!
-  \********************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-/*!
- * is-posix-bracket <https://github.com/jonschlinkert/is-posix-bracket>
- *
- * Copyright (c) 2015-2016, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-module.exports = function isPosixBracket(str) {
-  return typeof str === 'string' && /\[([:.=+])(?:[^\[\]]|)+\1\]/.test(str);
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/is-primitive/index.js":
-/*!****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/is-primitive/index.js ***!
-  \****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * is-primitive <https://github.com/jonschlinkert/is-primitive>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-// see http://jsperf.com/testing-value-is-primitive/7
-module.exports = function isPrimitive(value) {
-  return value == null || (typeof value !== 'function' && typeof value !== 'object');
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/isobject/index.js":
-/*!************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/isobject/index.js ***!
-  \************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * isobject <https://github.com/jonschlinkert/isobject>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-module.exports = function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/kind-of/index.js":
-/*!***********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/kind-of/index.js ***!
-  \***********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isBuffer = __webpack_require__(/*! is-buffer */ "../../api-javascript/node_modules/is-buffer/index.js");
-var toString = Object.prototype.toString;
-
-/**
- * Get the native `typeof` a value.
- *
- * @param  {*} `val`
- * @return {*} Native javascript type
- */
-
-module.exports = function kindOf(val) {
-  // primitivies
-  if (typeof val === 'undefined') {
-    return 'undefined';
-  }
-  if (val === null) {
-    return 'null';
-  }
-  if (val === true || val === false || val instanceof Boolean) {
-    return 'boolean';
-  }
-  if (typeof val === 'string' || val instanceof String) {
-    return 'string';
-  }
-  if (typeof val === 'number' || val instanceof Number) {
-    return 'number';
-  }
-
-  // functions
-  if (typeof val === 'function' || val instanceof Function) {
-    return 'function';
-  }
-
-  // array
-  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
-    return 'array';
-  }
-
-  // check for instances of RegExp and Date before calling `toString`
-  if (val instanceof RegExp) {
-    return 'regexp';
-  }
-  if (val instanceof Date) {
-    return 'date';
-  }
-
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-  if (type === '[object Error]') {
-    return 'error';
-  }
-
-  // buffer
-  if (isBuffer(val)) {
-    return 'buffer';
-  }
-
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
-
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
-  }
-
-  // must be a plain object
-  return 'object';
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/math-random/browser.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/math-random/browser.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-module.exports = (function (global) {
-  var uint32 = 'Uint32Array' in global
-  var crypto = global.crypto || global.msCrypto
-  var rando = crypto && typeof crypto.getRandomValues === 'function'
-  var good = uint32 && rando
-  if (!good) return Math.random
-
-  var arr = new Uint32Array(1)
-  var max = Math.pow(2, 32)
-  function random () {
-    crypto.getRandomValues(arr)
-    return arr[0] / max
-  }
-
-  random.cryptographic = true
-  return random
-})(typeof self !== 'undefined' ? self : window)
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/index.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/index.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * micromatch <https://github.com/jonschlinkert/micromatch>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var expand = __webpack_require__(/*! ./lib/expand */ "../../api-javascript/node_modules/micromatch/lib/expand.js");
-var utils = __webpack_require__(/*! ./lib/utils */ "../../api-javascript/node_modules/micromatch/lib/utils.js");
-
-/**
- * The main function. Pass an array of filepaths,
- * and a string or array of glob patterns
- *
- * @param  {Array|String} `files`
- * @param  {Array|String} `patterns`
- * @param  {Object} `opts`
- * @return {Array} Array of matches
- */
-
-function micromatch(files, patterns, opts) {
-  if (!files || !patterns) return [];
-  opts = opts || {};
-
-  if (typeof opts.cache === 'undefined') {
-    opts.cache = true;
-  }
-
-  if (!Array.isArray(patterns)) {
-    return match(files, patterns, opts);
-  }
-
-  var len = patterns.length, i = 0;
-  var omit = [], keep = [];
-
-  while (len--) {
-    var glob = patterns[i++];
-    if (typeof glob === 'string' && glob.charCodeAt(0) === 33 /* ! */) {
-      omit.push.apply(omit, match(files, glob.slice(1), opts));
-    } else {
-      keep.push.apply(keep, match(files, glob, opts));
-    }
-  }
-  return utils.diff(keep, omit);
-}
-
-/**
- * Return an array of files that match the given glob pattern.
- *
- * This function is called by the main `micromatch` function If you only
- * need to pass a single pattern you might get very minor speed improvements
- * using this function.
- *
- * @param  {Array} `files`
- * @param  {String} `pattern`
- * @param  {Object} `options`
- * @return {Array}
- */
-
-function match(files, pattern, opts) {
-  if (utils.typeOf(files) !== 'string' && !Array.isArray(files)) {
-    throw new Error(msg('match', 'files', 'a string or array'));
-  }
-
-  files = utils.arrayify(files);
-  opts = opts || {};
-
-  var negate = opts.negate || false;
-  var orig = pattern;
-
-  if (typeof pattern === 'string') {
-    negate = pattern.charAt(0) === '!';
-    if (negate) {
-      pattern = pattern.slice(1);
-    }
-
-    // we need to remove the character regardless,
-    // so the above logic is still needed
-    if (opts.nonegate === true) {
-      negate = false;
-    }
-  }
-
-  var _isMatch = matcher(pattern, opts);
-  var len = files.length, i = 0;
-  var res = [];
-
-  while (i < len) {
-    var file = files[i++];
-    var fp = utils.unixify(file, opts);
-
-    if (!_isMatch(fp)) { continue; }
-    res.push(fp);
-  }
-
-  if (res.length === 0) {
-    if (opts.failglob === true) {
-      throw new Error('micromatch.match() found no matches for: "' + orig + '".');
-    }
-
-    if (opts.nonull || opts.nullglob) {
-      res.push(utils.unescapeGlob(orig));
-    }
-  }
-
-  // if `negate` was defined, diff negated files
-  if (negate) { res = utils.diff(files, res); }
-
-  // if `ignore` was defined, diff ignored filed
-  if (opts.ignore && opts.ignore.length) {
-    pattern = opts.ignore;
-    opts = utils.omit(opts, ['ignore']);
-    res = utils.diff(res, micromatch(res, pattern, opts));
-  }
-
-  if (opts.nodupes) {
-    return utils.unique(res);
-  }
-  return res;
-}
-
-/**
- * Returns a function that takes a glob pattern or array of glob patterns
- * to be used with `Array#filter()`. (Internally this function generates
- * the matching function using the [matcher] method).
- *
- * ```js
- * var fn = mm.filter('[a-c]');
- * ['a', 'b', 'c', 'd', 'e'].filter(fn);
- * //=> ['a', 'b', 'c']
- * ```
- * @param  {String|Array} `patterns` Can be a glob or array of globs.
- * @param  {Options} `opts` Options to pass to the [matcher] method.
- * @return {Function} Filter function to be passed to `Array#filter()`.
- */
-
-function filter(patterns, opts) {
-  if (!Array.isArray(patterns) && typeof patterns !== 'string') {
-    throw new TypeError(msg('filter', 'patterns', 'a string or array'));
-  }
-
-  patterns = utils.arrayify(patterns);
-  var len = patterns.length, i = 0;
-  var patternMatchers = Array(len);
-  while (i < len) {
-    patternMatchers[i] = matcher(patterns[i++], opts);
-  }
-
-  return function(fp) {
-    if (fp == null) return [];
-    var len = patternMatchers.length, i = 0;
-    var res = true;
-
-    fp = utils.unixify(fp, opts);
-    while (i < len) {
-      var fn = patternMatchers[i++];
-      if (!fn(fp)) {
-        res = false;
-        break;
-      }
-    }
-    return res;
-  };
-}
-
-/**
- * Returns true if the filepath contains the given
- * pattern. Can also return a function for matching.
- *
- * ```js
- * isMatch('foo.md', '*.md', {});
- * //=> true
- *
- * isMatch('*.md', {})('foo.md')
- * //=> true
- * ```
- * @param  {String} `fp`
- * @param  {String} `pattern`
- * @param  {Object} `opts`
- * @return {Boolean}
- */
-
-function isMatch(fp, pattern, opts) {
-  if (typeof fp !== 'string') {
-    throw new TypeError(msg('isMatch', 'filepath', 'a string'));
-  }
-
-  fp = utils.unixify(fp, opts);
-  if (utils.typeOf(pattern) === 'object') {
-    return matcher(fp, pattern);
-  }
-  return matcher(pattern, opts)(fp);
-}
-
-/**
- * Returns true if the filepath matches the
- * given pattern.
- */
-
-function contains(fp, pattern, opts) {
-  if (typeof fp !== 'string') {
-    throw new TypeError(msg('contains', 'pattern', 'a string'));
-  }
-
-  opts = opts || {};
-  opts.contains = (pattern !== '');
-  fp = utils.unixify(fp, opts);
-
-  if (opts.contains && !utils.isGlob(pattern)) {
-    return fp.indexOf(pattern) !== -1;
-  }
-  return matcher(pattern, opts)(fp);
-}
-
-/**
- * Returns true if a file path matches any of the
- * given patterns.
- *
- * @param  {String} `fp` The filepath to test.
- * @param  {String|Array} `patterns` Glob patterns to use.
- * @param  {Object} `opts` Options to pass to the `matcher()` function.
- * @return {String}
- */
-
-function any(fp, patterns, opts) {
-  if (!Array.isArray(patterns) && typeof patterns !== 'string') {
-    throw new TypeError(msg('any', 'patterns', 'a string or array'));
-  }
-
-  patterns = utils.arrayify(patterns);
-  var len = patterns.length;
-
-  fp = utils.unixify(fp, opts);
-  while (len--) {
-    var isMatch = matcher(patterns[len], opts);
-    if (isMatch(fp)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Filter the keys of an object with the given `glob` pattern
- * and `options`
- *
- * @param  {Object} `object`
- * @param  {Pattern} `object`
- * @return {Array}
- */
-
-function matchKeys(obj, glob, options) {
-  if (utils.typeOf(obj) !== 'object') {
-    throw new TypeError(msg('matchKeys', 'first argument', 'an object'));
-  }
-
-  var fn = matcher(glob, options);
-  var res = {};
-
-  for (var key in obj) {
-    if (obj.hasOwnProperty(key) && fn(key)) {
-      res[key] = obj[key];
-    }
-  }
-  return res;
-}
-
-/**
- * Return a function for matching based on the
- * given `pattern` and `options`.
- *
- * @param  {String} `pattern`
- * @param  {Object} `options`
- * @return {Function}
- */
-
-function matcher(pattern, opts) {
-  // pattern is a function
-  if (typeof pattern === 'function') {
-    return pattern;
-  }
-  // pattern is a regex
-  if (pattern instanceof RegExp) {
-    return function(fp) {
-      return pattern.test(fp);
-    };
-  }
-
-  if (typeof pattern !== 'string') {
-    throw new TypeError(msg('matcher', 'pattern', 'a string, regex, or function'));
-  }
-
-  // strings, all the way down...
-  pattern = utils.unixify(pattern, opts);
-
-  // pattern is a non-glob string
-  if (!utils.isGlob(pattern)) {
-    return utils.matchPath(pattern, opts);
-  }
-  // pattern is a glob string
-  var re = makeRe(pattern, opts);
-
-  // `matchBase` is defined
-  if (opts && opts.matchBase) {
-    return utils.hasFilename(re, opts);
-  }
-  // `matchBase` is not defined
-  return function(fp) {
-    fp = utils.unixify(fp, opts);
-    return re.test(fp);
-  };
-}
-
-/**
- * Create and cache a regular expression for matching
- * file paths.
- *
- * If the leading character in the `glob` is `!`, a negation
- * regex is returned.
- *
- * @param  {String} `glob`
- * @param  {Object} `options`
- * @return {RegExp}
- */
-
-function toRegex(glob, options) {
-  // clone options to prevent  mutating the original object
-  var opts = Object.create(options || {});
-  var flags = opts.flags || '';
-  if (opts.nocase && flags.indexOf('i') === -1) {
-    flags += 'i';
-  }
-
-  var parsed = expand(glob, opts);
-
-  // pass in tokens to avoid parsing more than once
-  opts.negated = opts.negated || parsed.negated;
-  opts.negate = opts.negated;
-  glob = wrapGlob(parsed.pattern, opts);
-  var re;
-
-  try {
-    re = new RegExp(glob, flags);
-    return re;
-  } catch (err) {
-    err.reason = 'micromatch invalid regex: (' + re + ')';
-    if (opts.strict) throw new SyntaxError(err);
-  }
-
-  // we're only here if a bad pattern was used and the user
-  // passed `options.silent`, so match nothing
-  return /$^/;
-}
-
-/**
- * Create the regex to do the matching. If the leading
- * character in the `glob` is `!` a negation regex is returned.
- *
- * @param {String} `glob`
- * @param {Boolean} `negate`
- */
-
-function wrapGlob(glob, opts) {
-  var prefix = (opts && !opts.contains) ? '^' : '';
-  var after = (opts && !opts.contains) ? '$' : '';
-  glob = ('(?:' + glob + ')' + after);
-  if (opts && opts.negate) {
-    return prefix + ('(?!^' + glob + ').*$');
-  }
-  return prefix + glob;
-}
-
-/**
- * Create and cache a regular expression for matching file paths.
- * If the leading character in the `glob` is `!`, a negation
- * regex is returned.
- *
- * @param  {String} `glob`
- * @param  {Object} `options`
- * @return {RegExp}
- */
-
-function makeRe(glob, opts) {
-  if (utils.typeOf(glob) !== 'string') {
-    throw new Error(msg('makeRe', 'glob', 'a string'));
-  }
-  return utils.cache(toRegex, glob, opts);
-}
-
-/**
- * Make error messages consistent. Follows this format:
- *
- * ```js
- * msg(methodName, argNumber, nativeType);
- * // example:
- * msg('matchKeys', 'first', 'an object');
- * ```
- *
- * @param  {String} `method`
- * @param  {String} `num`
- * @param  {String} `type`
- * @return {String}
- */
-
-function msg(method, what, type) {
-  return 'micromatch.' + method + '(): ' + what + ' should be ' + type + '.';
-}
-
-/**
- * Public methods
- */
-
-/* eslint no-multi-spaces: 0 */
-micromatch.any       = any;
-micromatch.braces    = micromatch.braceExpand = utils.braces;
-micromatch.contains  = contains;
-micromatch.expand    = expand;
-micromatch.filter    = filter;
-micromatch.isMatch   = isMatch;
-micromatch.makeRe    = makeRe;
-micromatch.match     = match;
-micromatch.matcher   = matcher;
-micromatch.matchKeys = matchKeys;
-
-/**
- * Expose `micromatch`
- */
-
-module.exports = micromatch;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/lib/chars.js":
-/*!******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/chars.js ***!
-  \******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var chars = {}, unesc, temp;
-
-function reverse(object, prepender) {
-  return Object.keys(object).reduce(function(reversed, key) {
-    var newKey = prepender ? prepender + key : key; // Optionally prepend a string to key.
-    reversed[object[key]] = newKey; // Swap key and value.
-    return reversed; // Return the result.
-  }, {});
-}
-
-/**
- * Regex for common characters
- */
-
-chars.escapeRegex = {
-  '?': /\?/g,
-  '@': /\@/g,
-  '!': /\!/g,
-  '+': /\+/g,
-  '*': /\*/g,
-  '(': /\(/g,
-  ')': /\)/g,
-  '[': /\[/g,
-  ']': /\]/g
-};
-
-/**
- * Escape characters
- */
-
-chars.ESC = {
-  '?': '__UNESC_QMRK__',
-  '@': '__UNESC_AMPE__',
-  '!': '__UNESC_EXCL__',
-  '+': '__UNESC_PLUS__',
-  '*': '__UNESC_STAR__',
-  ',': '__UNESC_COMMA__',
-  '(': '__UNESC_LTPAREN__',
-  ')': '__UNESC_RTPAREN__',
-  '[': '__UNESC_LTBRACK__',
-  ']': '__UNESC_RTBRACK__'
-};
-
-/**
- * Unescape characters
- */
-
-chars.UNESC = unesc || (unesc = reverse(chars.ESC, '\\'));
-
-chars.ESC_TEMP = {
-  '?': '__TEMP_QMRK__',
-  '@': '__TEMP_AMPE__',
-  '!': '__TEMP_EXCL__',
-  '*': '__TEMP_STAR__',
-  '+': '__TEMP_PLUS__',
-  ',': '__TEMP_COMMA__',
-  '(': '__TEMP_LTPAREN__',
-  ')': '__TEMP_RTPAREN__',
-  '[': '__TEMP_LTBRACK__',
-  ']': '__TEMP_RTBRACK__'
-};
-
-chars.TEMP = temp || (temp = reverse(chars.ESC_TEMP));
-
-module.exports = chars;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/lib/expand.js":
-/*!*******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/expand.js ***!
-  \*******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * micromatch <https://github.com/jonschlinkert/micromatch>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/micromatch/lib/utils.js");
-var Glob = __webpack_require__(/*! ./glob */ "../../api-javascript/node_modules/micromatch/lib/glob.js");
-
-/**
- * Expose `expand`
- */
-
-module.exports = expand;
-
-/**
- * Expand a glob pattern to resolve braces and
- * similar patterns before converting to regex.
- *
- * @param  {String|Array} `pattern`
- * @param  {Array} `files`
- * @param  {Options} `opts`
- * @return {Array}
- */
-
-function expand(pattern, options) {
-  if (typeof pattern !== 'string') {
-    throw new TypeError('micromatch.expand(): argument should be a string.');
-  }
-
-  var glob = new Glob(pattern, options || {});
-  var opts = glob.options;
-
-  if (!utils.isGlob(pattern)) {
-    glob.pattern = glob.pattern.replace(/([\/.])/g, '\\$1');
-    return glob;
-  }
-
-  glob.pattern = glob.pattern.replace(/(\+)(?!\()/g, '\\$1');
-  glob.pattern = glob.pattern.split('$').join('\\$');
-
-  if (typeof opts.braces !== 'boolean' && typeof opts.nobraces !== 'boolean') {
-    opts.braces = true;
-  }
-
-  if (glob.pattern === '.*') {
-    return {
-      pattern: '\\.' + star,
-      tokens: tok,
-      options: opts
-    };
-  }
-
-  if (glob.pattern === '*') {
-    return {
-      pattern: oneStar(opts.dot),
-      tokens: tok,
-      options: opts
-    };
-  }
-
-  // parse the glob pattern into tokens
-  glob.parse();
-  var tok = glob.tokens;
-  tok.is.negated = opts.negated;
-
-  // dotfile handling
-  if ((opts.dotfiles === true || tok.is.dotfile) && opts.dot !== false) {
-    opts.dotfiles = true;
-    opts.dot = true;
-  }
-
-  if ((opts.dotdirs === true || tok.is.dotdir) && opts.dot !== false) {
-    opts.dotdirs = true;
-    opts.dot = true;
-  }
-
-  // check for braces with a dotfile pattern
-  if (/[{,]\./.test(glob.pattern)) {
-    opts.makeRe = false;
-    opts.dot = true;
-  }
-
-  if (opts.nonegate !== true) {
-    opts.negated = glob.negated;
-  }
-
-  // if the leading character is a dot or a slash, escape it
-  if (glob.pattern.charAt(0) === '.' && glob.pattern.charAt(1) !== '/') {
-    glob.pattern = '\\' + glob.pattern;
-  }
-
-  /**
-   * Extended globs
-   */
-
-  // expand braces, e.g `{1..5}`
-  glob.track('before braces');
-  if (tok.is.braces) {
-    glob.braces();
-  }
-  glob.track('after braces');
-
-  // expand extglobs, e.g `foo/!(a|b)`
-  glob.track('before extglob');
-  if (tok.is.extglob) {
-    glob.extglob();
-  }
-  glob.track('after extglob');
-
-  // expand brackets, e.g `[[:alpha:]]`
-  glob.track('before brackets');
-  if (tok.is.brackets) {
-    glob.brackets();
-  }
-  glob.track('after brackets');
-
-  // special patterns
-  glob._replace('[!', '[^');
-  glob._replace('(?', '(%~');
-  glob._replace(/\[\]/, '\\[\\]');
-  glob._replace('/[', '/' + (opts.dot ? dotfiles : nodot) + '[', true);
-  glob._replace('/?', '/' + (opts.dot ? dotfiles : nodot) + '[^/]', true);
-  glob._replace('/.', '/(?=.)\\.', true);
-
-  // windows drives
-  glob._replace(/^(\w):([\\\/]+?)/gi, '(?=.)$1:$2', true);
-
-  // negate slashes in exclusion ranges
-  if (glob.pattern.indexOf('[^') !== -1) {
-    glob.pattern = negateSlash(glob.pattern);
-  }
-
-  if (opts.globstar !== false && glob.pattern === '**') {
-    glob.pattern = globstar(opts.dot);
-
-  } else {
-    glob.pattern = balance(glob.pattern, '[', ']');
-    glob.escape(glob.pattern);
-
-    // if the pattern has `**`
-    if (tok.is.globstar) {
-      glob.pattern = collapse(glob.pattern, '/**');
-      glob.pattern = collapse(glob.pattern, '**/');
-      glob._replace('/**/', '(?:/' + globstar(opts.dot) + '/|/)', true);
-      glob._replace(/\*{2,}/g, '**');
-
-      // 'foo/*'
-      glob._replace(/(\w+)\*(?!\/)/g, '$1[^/]*?', true);
-      glob._replace(/\*\*\/\*(\w)/g, globstar(opts.dot) + '\\/' + (opts.dot ? dotfiles : nodot) + '[^/]*?$1', true);
-
-      if (opts.dot !== true) {
-        glob._replace(/\*\*\/(.)/g, '(?:**\\/|)$1');
-      }
-
-      // 'foo/**' or '{**,*}', but not 'foo**'
-      if (tok.path.dirname !== '' || /,\*\*|\*\*,/.test(glob.orig)) {
-        glob._replace('**', globstar(opts.dot), true);
-      }
-    }
-
-    // ends with /*
-    glob._replace(/\/\*$/, '\\/' + oneStar(opts.dot), true);
-    // ends with *, no slashes
-    glob._replace(/(?!\/)\*$/, star, true);
-    // has 'n*.' (partial wildcard w/ file extension)
-    glob._replace(/([^\/]+)\*/, '$1' + oneStar(true), true);
-    // has '*'
-    glob._replace('*', oneStar(opts.dot), true);
-    glob._replace('?.', '?\\.', true);
-    glob._replace('?:', '?:', true);
-
-    glob._replace(/\?+/g, function(match) {
-      var len = match.length;
-      if (len === 1) {
-        return qmark;
-      }
-      return qmark + '{' + len + '}';
-    });
-
-    // escape '.abc' => '\\.abc'
-    glob._replace(/\.([*\w]+)/g, '\\.$1');
-    // fix '[^\\\\/]'
-    glob._replace(/\[\^[\\\/]+\]/g, qmark);
-    // '///' => '\/'
-    glob._replace(/\/+/g, '\\/');
-    // '\\\\\\' => '\\'
-    glob._replace(/\\{2,}/g, '\\');
-  }
-
-  // unescape previously escaped patterns
-  glob.unescape(glob.pattern);
-  glob._replace('__UNESC_STAR__', '*');
-
-  // escape dots that follow qmarks
-  glob._replace('?.', '?\\.');
-
-  // remove unnecessary slashes in character classes
-  glob._replace('[^\\/]', qmark);
-
-  if (glob.pattern.length > 1) {
-    if (/^[\[?*]/.test(glob.pattern)) {
-      // only prepend the string if we don't want to match dotfiles
-      glob.pattern = (opts.dot ? dotfiles : nodot) + glob.pattern;
-    }
-  }
-
-  return glob;
-}
-
-/**
- * Collapse repeated character sequences.
- *
- * ```js
- * collapse('a/../../../b', '../');
- * //=> 'a/../b'
- * ```
- *
- * @param  {String} `str`
- * @param  {String} `ch` Character sequence to collapse
- * @return {String}
- */
-
-function collapse(str, ch) {
-  var res = str.split(ch);
-  var isFirst = res[0] === '';
-  var isLast = res[res.length - 1] === '';
-  res = res.filter(Boolean);
-  if (isFirst) res.unshift('');
-  if (isLast) res.push('');
-  return res.join(ch);
-}
-
-/**
- * Negate slashes in exclusion ranges, per glob spec:
- *
- * ```js
- * negateSlash('[^foo]');
- * //=> '[^\\/foo]'
- * ```
- *
- * @param  {String} `str` glob pattern
- * @return {String}
- */
-
-function negateSlash(str) {
-  return str.replace(/\[\^([^\]]*?)\]/g, function(match, inner) {
-    if (inner.indexOf('/') === -1) {
-      inner = '\\/' + inner;
-    }
-    return '[^' + inner + ']';
-  });
-}
-
-/**
- * Escape imbalanced braces/bracket. This is a very
- * basic, naive implementation that only does enough
- * to serve the purpose.
- */
-
-function balance(str, a, b) {
-  var aarr = str.split(a);
-  var alen = aarr.join('').length;
-  var blen = str.split(b).join('').length;
-
-  if (alen !== blen) {
-    str = aarr.join('\\' + a);
-    return str.split(b).join('\\' + b);
-  }
-  return str;
-}
-
-/**
- * Special patterns to be converted to regex.
- * Heuristics are used to simplify patterns
- * and speed up processing.
- */
-
-/* eslint no-multi-spaces: 0 */
-var qmark       = '[^/]';
-var star        = qmark + '*?';
-var nodot       = '(?!\\.)(?=.)';
-var dotfileGlob = '(?:\\/|^)\\.{1,2}($|\\/)';
-var dotfiles    = '(?!' + dotfileGlob + ')(?=.)';
-var twoStarDot  = '(?:(?!' + dotfileGlob + ').)*?';
-
-/**
- * Create a regex for `*`.
- *
- * If `dot` is true, or the pattern does not begin with
- * a leading star, then return the simpler regex.
- */
-
-function oneStar(dotfile) {
-  return dotfile ? '(?!' + dotfileGlob + ')(?=.)' + star : (nodot + star);
-}
-
-function globstar(dotfile) {
-  if (dotfile) { return twoStarDot; }
-  return '(?:(?!(?:\\/|^)\\.).)*?';
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/lib/glob.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/glob.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var chars = __webpack_require__(/*! ./chars */ "../../api-javascript/node_modules/micromatch/lib/chars.js");
-var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/micromatch/lib/utils.js");
-
-/**
- * Expose `Glob`
- */
-
-var Glob = module.exports = function Glob(pattern, options) {
-  if (!(this instanceof Glob)) {
-    return new Glob(pattern, options);
-  }
-  this.options = options || {};
-  this.pattern = pattern;
-  this.history = [];
-  this.tokens = {};
-  this.init(pattern);
-};
-
-/**
- * Initialize defaults
- */
-
-Glob.prototype.init = function(pattern) {
-  this.orig = pattern;
-  this.negated = this.isNegated();
-  this.options.track = this.options.track || false;
-  this.options.makeRe = true;
-};
-
-/**
- * Push a change into `glob.history`. Useful
- * for debugging.
- */
-
-Glob.prototype.track = function(msg) {
-  if (this.options.track) {
-    this.history.push({msg: msg, pattern: this.pattern});
-  }
-};
-
-/**
- * Return true if `glob.pattern` was negated
- * with `!`, also remove the `!` from the pattern.
- *
- * @return {Boolean}
- */
-
-Glob.prototype.isNegated = function() {
-  if (this.pattern.charCodeAt(0) === 33 /* '!' */) {
-    this.pattern = this.pattern.slice(1);
-    return true;
-  }
-  return false;
-};
-
-/**
- * Expand braces in the given glob pattern.
- *
- * We only need to use the [braces] lib when
- * patterns are nested.
- */
-
-Glob.prototype.braces = function() {
-  if (this.options.nobraces !== true && this.options.nobrace !== true) {
-    // naive/fast check for imbalanced characters
-    var a = this.pattern.match(/[\{\(\[]/g);
-    var b = this.pattern.match(/[\}\)\]]/g);
-
-    // if imbalanced, don't optimize the pattern
-    if (a && b && (a.length !== b.length)) {
-      this.options.makeRe = false;
-    }
-
-    // expand brace patterns and join the resulting array
-    var expanded = utils.braces(this.pattern, this.options);
-    this.pattern = expanded.join('|');
-  }
-};
-
-/**
- * Expand bracket expressions in `glob.pattern`
- */
-
-Glob.prototype.brackets = function() {
-  if (this.options.nobrackets !== true) {
-    this.pattern = utils.brackets(this.pattern);
-  }
-};
-
-/**
- * Expand bracket expressions in `glob.pattern`
- */
-
-Glob.prototype.extglob = function() {
-  if (this.options.noextglob === true) return;
-
-  if (utils.isExtglob(this.pattern)) {
-    this.pattern = utils.extglob(this.pattern, {escape: true});
-  }
-};
-
-/**
- * Parse the given pattern
- */
-
-Glob.prototype.parse = function(pattern) {
-  this.tokens = utils.parseGlob(pattern || this.pattern, true);
-  return this.tokens;
-};
-
-/**
- * Replace `a` with `b`. Also tracks the change before and
- * after each replacement. This is disabled by default, but
- * can be enabled by setting `options.track` to true.
- *
- * Also, when the pattern is a string, `.split()` is used,
- * because it's much faster than replace.
- *
- * @param  {RegExp|String} `a`
- * @param  {String} `b`
- * @param  {Boolean} `escape` When `true`, escapes `*` and `?` in the replacement.
- * @return {String}
- */
-
-Glob.prototype._replace = function(a, b, escape) {
-  this.track('before (find): "' + a + '" (replace with): "' + b + '"');
-  if (escape) b = esc(b);
-  if (a && b && typeof a === 'string') {
-    this.pattern = this.pattern.split(a).join(b);
-  } else {
-    this.pattern = this.pattern.replace(a, b);
-  }
-  this.track('after');
-};
-
-/**
- * Escape special characters in the given string.
- *
- * @param  {String} `str` Glob pattern
- * @return {String}
- */
-
-Glob.prototype.escape = function(str) {
-  this.track('before escape: ');
-  var re = /["\\](['"]?[^"'\\]['"]?)/g;
-
-  this.pattern = str.replace(re, function($0, $1) {
-    var o = chars.ESC;
-    var ch = o && o[$1];
-    if (ch) {
-      return ch;
-    }
-    if (/[a-z]/i.test($0)) {
-      return $0.split('\\').join('');
-    }
-    return $0;
-  });
-
-  this.track('after escape: ');
-};
-
-/**
- * Unescape special characters in the given string.
- *
- * @param  {String} `str`
- * @return {String}
- */
-
-Glob.prototype.unescape = function(str) {
-  var re = /__([A-Z]+)_([A-Z]+)__/g;
-  this.pattern = str.replace(re, function($0, $1) {
-    return chars[$1][$0];
-  });
-  this.pattern = unesc(this.pattern);
-};
-
-/**
- * Escape/unescape utils
- */
-
-function esc(str) {
-  str = str.split('?').join('%~');
-  str = str.split('*').join('%%');
-  return str;
-}
-
-function unesc(str) {
-  str = str.split('%~').join('?');
-  str = str.split('%%').join('*');
-  return str;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/lib/utils.js":
-/*!******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/utils.js ***!
-  \******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/* WEBPACK VAR INJECTION */(function(process) {
-
-var win32 = process && process.platform === 'win32';
-var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
-var fileRe = __webpack_require__(/*! filename-regex */ "../../api-javascript/node_modules/filename-regex/index.js");
-var utils = module.exports;
-
-/**
- * Module dependencies
- */
-
-utils.diff = __webpack_require__(/*! arr-diff */ "../../api-javascript/node_modules/micromatch/node_modules/arr-diff/index.js");
-utils.unique = __webpack_require__(/*! array-unique */ "../../api-javascript/node_modules/micromatch/node_modules/array-unique/index.js");
-utils.braces = __webpack_require__(/*! braces */ "../../api-javascript/node_modules/micromatch/node_modules/braces/index.js");
-utils.brackets = __webpack_require__(/*! expand-brackets */ "../../api-javascript/node_modules/expand-brackets/index.js");
-utils.extglob = __webpack_require__(/*! extglob */ "../../api-javascript/node_modules/extglob/index.js");
-utils.isExtglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
-utils.isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
-utils.typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/kind-of/index.js");
-utils.normalize = __webpack_require__(/*! normalize-path */ "../../api-javascript/node_modules/normalize-path/index.js");
-utils.omit = __webpack_require__(/*! object.omit */ "../../api-javascript/node_modules/object.omit/index.js");
-utils.parseGlob = __webpack_require__(/*! parse-glob */ "../../api-javascript/node_modules/parse-glob/index.js");
-utils.cache = __webpack_require__(/*! regex-cache */ "../../api-javascript/node_modules/regex-cache/index.js");
-
-/**
- * Get the filename of a filepath
- *
- * @param {String} `string`
- * @return {String}
- */
-
-utils.filename = function filename(fp) {
-  var seg = fp.match(fileRe());
-  return seg && seg[0];
-};
-
-/**
- * Returns a function that returns true if the given
- * pattern is the same as a given `filepath`
- *
- * @param {String} `pattern`
- * @return {Function}
- */
-
-utils.isPath = function isPath(pattern, opts) {
-  opts = opts || {};
-  return function(fp) {
-    var unixified = utils.unixify(fp, opts);
-    if(opts.nocase){
-      return pattern.toLowerCase() === unixified.toLowerCase();
-    }
-    return pattern === unixified;
-  };
-};
-
-/**
- * Returns a function that returns true if the given
- * pattern contains a `filepath`
- *
- * @param {String} `pattern`
- * @return {Function}
- */
-
-utils.hasPath = function hasPath(pattern, opts) {
-  return function(fp) {
-    return utils.unixify(pattern, opts).indexOf(fp) !== -1;
-  };
-};
-
-/**
- * Returns a function that returns true if the given
- * pattern matches or contains a `filepath`
- *
- * @param {String} `pattern`
- * @return {Function}
- */
-
-utils.matchPath = function matchPath(pattern, opts) {
-  var fn = (opts && opts.contains)
-    ? utils.hasPath(pattern, opts)
-    : utils.isPath(pattern, opts);
-  return fn;
-};
-
-/**
- * Returns a function that returns true if the given
- * regex matches the `filename` of a file path.
- *
- * @param {RegExp} `re`
- * @return {Boolean}
- */
-
-utils.hasFilename = function hasFilename(re) {
-  return function(fp) {
-    var name = utils.filename(fp);
-    return name && re.test(name);
-  };
-};
-
-/**
- * Coerce `val` to an array
- *
- * @param  {*} val
- * @return {Array}
- */
-
-utils.arrayify = function arrayify(val) {
-  return !Array.isArray(val)
-    ? [val]
-    : val;
-};
-
-/**
- * Normalize all slashes in a file path or glob pattern to
- * forward slashes.
- */
-
-utils.unixify = function unixify(fp, opts) {
-  if (opts && opts.unixify === false) return fp;
-  if (opts && opts.unixify === true || win32 || path.sep === '\\') {
-    return utils.normalize(fp, false);
-  }
-  if (opts && opts.unescape === true) {
-    return fp ? fp.toString().replace(/\\(\w)/g, '$1') : '';
-  }
-  return fp;
-};
-
-/**
- * Escape/unescape utils
- */
-
-utils.escapePath = function escapePath(fp) {
-  return fp.replace(/[\\.]/g, '\\$&');
-};
-
-utils.unescapeGlob = function unescapeGlob(fp) {
-  return fp.replace(/[\\"']/g, '');
-};
-
-utils.escapeRe = function escapeRe(str) {
-  return str.replace(/[-[\\$*+?.#^\s{}(|)\]]/g, '\\$&');
-};
-
-/**
- * Expose `utils`
- */
-
-module.exports = utils;
-
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../sfx/sfx-logic/node_modules/process/browser.js */ "./node_modules/process/browser.js")))
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/node_modules/arr-diff/index.js":
-/*!************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/node_modules/arr-diff/index.js ***!
-  \************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * arr-diff <https://github.com/jonschlinkert/arr-diff>
- *
- * Copyright (c) 2014 Jon Schlinkert, contributors.
- * Licensed under the MIT License
- */
-
-
-
-var flatten = __webpack_require__(/*! arr-flatten */ "../../api-javascript/node_modules/arr-flatten/index.js");
-var slice = [].slice;
-
-/**
- * Return the difference between the first array and
- * additional arrays.
- *
- * ```js
- * var diff = require('{%= name %}');
- *
- * var a = ['a', 'b', 'c', 'd'];
- * var b = ['b', 'c'];
- *
- * console.log(diff(a, b))
- * //=> ['a', 'd']
- * ```
- *
- * @param  {Array} `a`
- * @param  {Array} `b`
- * @return {Array}
- * @api public
- */
-
-function diff(arr, arrays) {
-  var argsLen = arguments.length;
-  var len = arr.length, i = -1;
-  var res = [], arrays;
-
-  if (argsLen === 1) {
-    return arr;
-  }
-
-  if (argsLen > 2) {
-    arrays = flatten(slice.call(arguments, 1));
-  }
-
-  while (++i < len) {
-    if (!~arrays.indexOf(arr[i])) {
-      res.push(arr[i]);
-    }
-  }
-  return res;
-}
-
-/**
- * Expose `diff`
- */
-
-module.exports = diff;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/node_modules/array-unique/index.js":
-/*!****************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/node_modules/array-unique/index.js ***!
-  \****************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * array-unique <https://github.com/jonschlinkert/array-unique>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-module.exports = function unique(arr) {
-  if (!Array.isArray(arr)) {
-    throw new TypeError('array-unique expects an array.');
-  }
-
-  var len = arr.length;
-  var i = -1;
-
-  while (i++ < len) {
-    var j = i + 1;
-
-    for (; j < arr.length; ++j) {
-      if (arr[i] === arr[j]) {
-        arr.splice(j--, 1);
-      }
-    }
-  }
-  return arr;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/micromatch/node_modules/braces/index.js":
-/*!**********************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/node_modules/braces/index.js ***!
-  \**********************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * braces <https://github.com/jonschlinkert/braces>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT license.
- */
-
-
-
-/**
- * Module dependencies
- */
-
-var expand = __webpack_require__(/*! expand-range */ "../../api-javascript/node_modules/expand-range/index.js");
-var repeat = __webpack_require__(/*! repeat-element */ "../../api-javascript/node_modules/repeat-element/index.js");
-var tokens = __webpack_require__(/*! preserve */ "../../api-javascript/node_modules/preserve/index.js");
-
-/**
- * Expose `braces`
- */
-
-module.exports = function(str, options) {
-  if (typeof str !== 'string') {
-    throw new Error('braces expects a string');
-  }
-  return braces(str, options);
-};
-
-/**
- * Expand `{foo,bar}` or `{1..5}` braces in the
- * given `string`.
- *
- * @param  {String} `str`
- * @param  {Array} `arr`
- * @param  {Object} `options`
- * @return {Array}
- */
-
-function braces(str, arr, options) {
-  if (str === '') {
-    return [];
-  }
-
-  if (!Array.isArray(arr)) {
-    options = arr;
-    arr = [];
-  }
-
-  var opts = options || {};
-  arr = arr || [];
-
-  if (typeof opts.nodupes === 'undefined') {
-    opts.nodupes = true;
-  }
-
-  var fn = opts.fn;
-  var es6;
-
-  if (typeof opts === 'function') {
-    fn = opts;
-    opts = {};
-  }
-
-  if (!(patternRe instanceof RegExp)) {
-    patternRe = patternRegex();
-  }
-
-  var matches = str.match(patternRe) || [];
-  var m = matches[0];
-
-  switch(m) {
-    case '\\,':
-      return escapeCommas(str, arr, opts);
-    case '\\.':
-      return escapeDots(str, arr, opts);
-    case '\/.':
-      return escapePaths(str, arr, opts);
-    case ' ':
-      return splitWhitespace(str);
-    case '{,}':
-      return exponential(str, opts, braces);
-    case '{}':
-      return emptyBraces(str, arr, opts);
-    case '\\{':
-    case '\\}':
-      return escapeBraces(str, arr, opts);
-    case '${':
-      if (!/\{[^{]+\{/.test(str)) {
-        return arr.concat(str);
-      } else {
-        es6 = true;
-        str = tokens.before(str, es6Regex());
-      }
-  }
-
-  if (!(braceRe instanceof RegExp)) {
-    braceRe = braceRegex();
-  }
-
-  var match = braceRe.exec(str);
-  if (match == null) {
-    return [str];
-  }
-
-  var outter = match[1];
-  var inner = match[2];
-  if (inner === '') { return [str]; }
-
-  var segs, segsLength;
-
-  if (inner.indexOf('..') !== -1) {
-    segs = expand(inner, opts, fn) || inner.split(',');
-    segsLength = segs.length;
-
-  } else if (inner[0] === '"' || inner[0] === '\'') {
-    return arr.concat(str.split(/['"]/).join(''));
-
-  } else {
-    segs = inner.split(',');
-    if (opts.makeRe) {
-      return braces(str.replace(outter, wrap(segs, '|')), opts);
-    }
-
-    segsLength = segs.length;
-    if (segsLength === 1 && opts.bash) {
-      segs[0] = wrap(segs[0], '\\');
-    }
-  }
-
-  var len = segs.length;
-  var i = 0, val;
-
-  while (len--) {
-    var path = segs[i++];
-
-    if (/(\.[^.\/])/.test(path)) {
-      if (segsLength > 1) {
-        return segs;
-      } else {
-        return [str];
-      }
-    }
-
-    val = splice(str, outter, path);
-
-    if (/\{[^{}]+?\}/.test(val)) {
-      arr = braces(val, arr, opts);
-    } else if (val !== '') {
-      if (opts.nodupes && arr.indexOf(val) !== -1) { continue; }
-      arr.push(es6 ? tokens.after(val) : val);
-    }
-  }
-
-  if (opts.strict) { return filter(arr, filterEmpty); }
-  return arr;
-}
-
-/**
- * Expand exponential ranges
- *
- *   `a{,}{,}` => ['a', 'a', 'a', 'a']
- */
-
-function exponential(str, options, fn) {
-  if (typeof options === 'function') {
-    fn = options;
-    options = null;
-  }
-
-  var opts = options || {};
-  var esc = '__ESC_EXP__';
-  var exp = 0;
-  var res;
-
-  var parts = str.split('{,}');
-  if (opts.nodupes) {
-    return fn(parts.join(''), opts);
-  }
-
-  exp = parts.length - 1;
-  res = fn(parts.join(esc), opts);
-  var len = res.length;
-  var arr = [];
-  var i = 0;
-
-  while (len--) {
-    var ele = res[i++];
-    var idx = ele.indexOf(esc);
-
-    if (idx === -1) {
-      arr.push(ele);
-
-    } else {
-      ele = ele.split('__ESC_EXP__').join('');
-      if (!!ele && opts.nodupes !== false) {
-        arr.push(ele);
-
-      } else {
-        var num = Math.pow(2, exp);
-        arr.push.apply(arr, repeat(ele, num));
-      }
-    }
-  }
-  return arr;
-}
-
-/**
- * Wrap a value with parens, brackets or braces,
- * based on the given character/separator.
- *
- * @param  {String|Array} `val`
- * @param  {String} `ch`
- * @return {String}
- */
-
-function wrap(val, ch) {
-  if (ch === '|') {
-    return '(' + val.join(ch) + ')';
-  }
-  if (ch === ',') {
-    return '{' + val.join(ch) + '}';
-  }
-  if (ch === '-') {
-    return '[' + val.join(ch) + ']';
-  }
-  if (ch === '\\') {
-    return '\\{' + val + '\\}';
-  }
-}
-
-/**
- * Handle empty braces: `{}`
- */
-
-function emptyBraces(str, arr, opts) {
-  return braces(str.split('{}').join('\\{\\}'), arr, opts);
-}
-
-/**
- * Filter out empty-ish values
- */
-
-function filterEmpty(ele) {
-  return !!ele && ele !== '\\';
-}
-
-/**
- * Handle patterns with whitespace
- */
-
-function splitWhitespace(str) {
-  var segs = str.split(' ');
-  var len = segs.length;
-  var res = [];
-  var i = 0;
-
-  while (len--) {
-    res.push.apply(res, braces(segs[i++]));
-  }
-  return res;
-}
-
-/**
- * Handle escaped braces: `\\{foo,bar}`
- */
-
-function escapeBraces(str, arr, opts) {
-  if (!/\{[^{]+\{/.test(str)) {
-    return arr.concat(str.split('\\').join(''));
-  } else {
-    str = str.split('\\{').join('__LT_BRACE__');
-    str = str.split('\\}').join('__RT_BRACE__');
-    return map(braces(str, arr, opts), function(ele) {
-      ele = ele.split('__LT_BRACE__').join('{');
-      return ele.split('__RT_BRACE__').join('}');
-    });
-  }
-}
-
-/**
- * Handle escaped dots: `{1\\.2}`
- */
-
-function escapeDots(str, arr, opts) {
-  if (!/[^\\]\..+\\\./.test(str)) {
-    return arr.concat(str.split('\\').join(''));
-  } else {
-    str = str.split('\\.').join('__ESC_DOT__');
-    return map(braces(str, arr, opts), function(ele) {
-      return ele.split('__ESC_DOT__').join('.');
-    });
-  }
-}
-
-/**
- * Handle escaped dots: `{1\\.2}`
- */
-
-function escapePaths(str, arr, opts) {
-  str = str.split('\/.').join('__ESC_PATH__');
-  return map(braces(str, arr, opts), function(ele) {
-    return ele.split('__ESC_PATH__').join('\/.');
-  });
-}
-
-/**
- * Handle escaped commas: `{a\\,b}`
- */
-
-function escapeCommas(str, arr, opts) {
-  if (!/\w,/.test(str)) {
-    return arr.concat(str.split('\\').join(''));
-  } else {
-    str = str.split('\\,').join('__ESC_COMMA__');
-    return map(braces(str, arr, opts), function(ele) {
-      return ele.split('__ESC_COMMA__').join(',');
-    });
-  }
-}
-
-/**
- * Regex for common patterns
- */
-
-function patternRegex() {
-  return /\${|( (?=[{,}])|(?=[{,}]) )|{}|{,}|\\,(?=.*[{}])|\/\.(?=.*[{}])|\\\.(?={)|\\{|\\}/;
-}
-
-/**
- * Braces regex.
- */
-
-function braceRegex() {
-  return /.*(\\?\{([^}]+)\})/;
-}
-
-/**
- * es6 delimiter regex.
- */
-
-function es6Regex() {
-  return /\$\{([^}]+)\}/;
-}
-
-var braceRe;
-var patternRe;
-
-/**
- * Faster alternative to `String.replace()` when the
- * index of the token to be replaces can't be supplied
- */
-
-function splice(str, token, replacement) {
-  var i = str.indexOf(token);
-  return str.substr(0, i) + replacement
-    + str.substr(i + token.length);
-}
-
-/**
- * Fast array map
- */
-
-function map(arr, fn) {
-  if (arr == null) {
-    return [];
-  }
-
-  var len = arr.length;
-  var res = new Array(len);
-  var i = -1;
-
-  while (++i < len) {
-    res[i] = fn(arr[i], i, arr);
-  }
-
-  return res;
-}
-
-/**
- * Fast array filter
- */
-
-function filter(arr, cb) {
-  if (arr == null) return [];
-  if (typeof cb !== 'function') {
-    throw new TypeError('braces: filter expects a callback function.');
-  }
-
-  var len = arr.length;
-  var res = arr.slice();
-  var i = 0;
-
-  while (len--) {
-    if (!cb(arr[len], i++)) {
-      res.splice(len, 1);
-    }
-  }
-  return res;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/normalize-path/index.js":
-/*!******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/normalize-path/index.js ***!
-  \******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * normalize-path <https://github.com/jonschlinkert/normalize-path>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "../../api-javascript/node_modules/remove-trailing-separator/index.js");
-
-module.exports = function normalizePath(str, stripTrailing) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expected a string');
-  }
-  str = str.replace(/[\\\/]+/g, '/');
-  if (stripTrailing !== false) {
-    str = removeTrailingSeparator(str);
-  }
-  return str;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/object.omit/index.js":
-/*!***************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/object.omit/index.js ***!
-  \***************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * object.omit <https://github.com/jonschlinkert/object.omit>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var isObject = __webpack_require__(/*! is-extendable */ "../../api-javascript/node_modules/is-extendable/index.js");
-var forOwn = __webpack_require__(/*! for-own */ "../../api-javascript/node_modules/for-own/index.js");
-
-module.exports = function omit(obj, keys) {
-  if (!isObject(obj)) return {};
-
-  keys = [].concat.apply([], [].slice.call(arguments, 1));
-  var last = keys[keys.length - 1];
-  var res = {}, fn;
-
-  if (typeof last === 'function') {
-    fn = keys.pop();
-  }
-
-  var isFunction = typeof fn === 'function';
-  if (!keys.length && !isFunction) {
-    return obj;
-  }
-
-  forOwn(obj, function(value, key) {
-    if (keys.indexOf(key) === -1) {
-
-      if (!isFunction) {
-        res[key] = value;
-      } else if (fn(value, key, obj)) {
-        res[key] = value;
-      }
-    }
-  });
-  return res;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/object.pick/index.js":
-/*!***************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/object.pick/index.js ***!
-  \***************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * object.pick <https://github.com/jonschlinkert/object.pick>
- *
- * Copyright (c) 2014-2015 Jon Schlinkert, contributors.
- * Licensed under the MIT License
- */
-
-
-
-var isObject = __webpack_require__(/*! isobject */ "../../api-javascript/node_modules/isobject/index.js");
-
-module.exports = function pick(obj, keys) {
-  if (!isObject(obj) && typeof obj !== 'function') {
-    return {};
-  }
-
-  var res = {};
-  if (typeof keys === 'string') {
-    if (keys in obj) {
-      res[keys] = obj[keys];
-    }
-    return res;
-  }
-
-  var len = keys.length;
-  var idx = -1;
-
-  while (++idx < len) {
-    var key = keys[idx];
-    if (key in obj) {
-      res[key] = obj[key];
-    }
-  }
-  return res;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/parse-glob/index.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/parse-glob/index.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * parse-glob <https://github.com/jonschlinkert/parse-glob>
- *
- * Copyright (c) 2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-var isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
-var findBase = __webpack_require__(/*! glob-base */ "../../api-javascript/node_modules/glob-base/index.js");
-var extglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
-var dotfile = __webpack_require__(/*! is-dotfile */ "../../api-javascript/node_modules/is-dotfile/index.js");
-
-/**
- * Expose `cache`
- */
-
-var cache = module.exports.cache = {};
-
-/**
- * Parse a glob pattern into tokens.
- *
- * When no paths or '**' are in the glob, we use a
- * different strategy for parsing the filename, since
- * file names can contain braces and other difficult
- * patterns. such as:
- *
- *  - `*.{a,b}`
- *  - `(**|*.js)`
- */
-
-module.exports = function parseGlob(glob) {
-  if (cache.hasOwnProperty(glob)) {
-    return cache[glob];
-  }
-
-  var tok = {};
-  tok.orig = glob;
-  tok.is = {};
-
-  // unescape dots and slashes in braces/brackets
-  glob = escape(glob);
-
-  var parsed = findBase(glob);
-  tok.is.glob = parsed.isGlob;
-
-  tok.glob = parsed.glob;
-  tok.base = parsed.base;
-  var segs = /([^\/]*)$/.exec(glob);
-
-  tok.path = {};
-  tok.path.dirname = '';
-  tok.path.basename = segs[1] || '';
-  tok.path.dirname = glob.split(tok.path.basename).join('') || '';
-  var basename = (tok.path.basename || '').split('.') || '';
-  tok.path.filename = basename[0] || '';
-  tok.path.extname = basename.slice(1).join('.') || '';
-  tok.path.ext = '';
-
-  if (isGlob(tok.path.dirname) && !tok.path.basename) {
-    if (!/\/$/.test(tok.glob)) {
-      tok.path.basename = tok.glob;
-    }
-    tok.path.dirname = tok.base;
-  }
-
-  if (glob.indexOf('/') === -1 && !tok.is.globstar) {
-    tok.path.dirname = '';
-    tok.path.basename = tok.orig;
-  }
-
-  var dot = tok.path.basename.indexOf('.');
-  if (dot !== -1) {
-    tok.path.filename = tok.path.basename.slice(0, dot);
-    tok.path.extname = tok.path.basename.slice(dot);
-  }
-
-  if (tok.path.extname.charAt(0) === '.') {
-    var exts = tok.path.extname.split('.');
-    tok.path.ext = exts[exts.length - 1];
-  }
-
-  // unescape dots and slashes in braces/brackets
-  tok.glob = unescape(tok.glob);
-  tok.path.dirname = unescape(tok.path.dirname);
-  tok.path.basename = unescape(tok.path.basename);
-  tok.path.filename = unescape(tok.path.filename);
-  tok.path.extname = unescape(tok.path.extname);
-
-  // Booleans
-  var is = (glob && tok.is.glob);
-  tok.is.negated  = glob && glob.charAt(0) === '!';
-  tok.is.extglob  = glob && extglob(glob);
-  tok.is.braces   = has(is, glob, '{');
-  tok.is.brackets = has(is, glob, '[:');
-  tok.is.globstar = has(is, glob, '**');
-  tok.is.dotfile  = dotfile(tok.path.basename) || dotfile(tok.path.filename);
-  tok.is.dotdir   = dotdir(tok.path.dirname);
-  return (cache[glob] = tok);
-}
-
-/**
- * Returns true if the glob matches dot-directories.
- *
- * @param  {Object} `tok` The tokens object
- * @param  {Object} `path` The path object
- * @return {Object}
- */
-
-function dotdir(base) {
-  if (base.indexOf('/.') !== -1) {
-    return true;
-  }
-  if (base.charAt(0) === '.' && base.charAt(1) !== '/') {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Returns true if the pattern has the given `ch`aracter(s)
- *
- * @param  {Object} `glob` The glob pattern.
- * @param  {Object} `ch` The character to test for
- * @return {Object}
- */
-
-function has(is, glob, ch) {
-  return is && glob.indexOf(ch) !== -1;
-}
-
-/**
- * Escape/unescape utils
- */
-
-function escape(str) {
-  var re = /\{([^{}]*?)}|\(([^()]*?)\)|\[([^\[\]]*?)\]/g;
-  return str.replace(re, function (outter, braces, parens, brackets) {
-    var inner = braces || parens || brackets;
-    if (!inner) { return outter; }
-    return outter.split(inner).join(esc(inner));
-  });
-}
-
-function esc(str) {
-  str = str.split('/').join('__SLASH__');
-  str = str.split('.').join('__DOT__');
-  return str;
-}
-
-function unescape(str) {
-  str = str.split('__SLASH__').join('/');
-  str = str.split('__DOT__').join('.');
-  return str;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/preserve/index.js":
-/*!************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/preserve/index.js ***!
-  \************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * preserve <https://github.com/jonschlinkert/preserve>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT license.
- */
-
-
-
-/**
- * Replace tokens in `str` with a temporary, heuristic placeholder.
- *
- * ```js
- * tokens.before('{a\\,b}');
- * //=> '{__ID1__}'
- * ```
- *
- * @param  {String} `str`
- * @return {String} String with placeholders.
- * @api public
- */
-
-exports.before = function before(str, re) {
-  return str.replace(re, function (match) {
-    var id = randomize();
-    cache[id] = match;
-    return '__ID' + id + '__';
-  });
-};
-
-/**
- * Replace placeholders in `str` with original tokens.
- *
- * ```js
- * tokens.after('{__ID1__}');
- * //=> '{a\\,b}'
- * ```
- *
- * @param  {String} `str` String with placeholders
- * @return {String} `str` String with original tokens.
- * @api public
- */
-
-exports.after = function after(str) {
-  return str.replace(/__ID(.{5})__/g, function (_, id) {
-    return cache[id];
-  });
-};
-
-function randomize() {
-  return Math.random().toString().slice(2, 7);
-}
-
-var cache = {};
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/qs/lib/formats.js":
-/*!************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/formats.js ***!
-  \************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var replace = String.prototype.replace;
-var percentTwenties = /%20/g;
-
-module.exports = {
-    'default': 'RFC3986',
-    formatters: {
-        RFC1738: function (value) {
-            return replace.call(value, percentTwenties, '+');
-        },
-        RFC3986: function (value) {
-            return value;
-        }
-    },
-    RFC1738: 'RFC1738',
-    RFC3986: 'RFC3986'
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/qs/lib/index.js":
-/*!**********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/index.js ***!
-  \**********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var stringify = __webpack_require__(/*! ./stringify */ "../../api-javascript/node_modules/qs/lib/stringify.js");
-var parse = __webpack_require__(/*! ./parse */ "../../api-javascript/node_modules/qs/lib/parse.js");
-var formats = __webpack_require__(/*! ./formats */ "../../api-javascript/node_modules/qs/lib/formats.js");
-
-module.exports = {
-    formats: formats,
-    parse: parse,
-    stringify: stringify
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/qs/lib/parse.js":
-/*!**********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/parse.js ***!
-  \**********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/qs/lib/utils.js");
-
-var has = Object.prototype.hasOwnProperty;
-
-var defaults = {
-    allowDots: false,
-    allowPrototypes: false,
-    arrayLimit: 20,
-    charset: 'utf-8',
-    charsetSentinel: false,
-    comma: false,
-    decoder: utils.decode,
-    delimiter: '&',
-    depth: 5,
-    ignoreQueryPrefix: false,
-    interpretNumericEntities: false,
-    parameterLimit: 1000,
-    parseArrays: true,
-    plainObjects: false,
-    strictNullHandling: false
-};
-
-var interpretNumericEntities = function (str) {
-    return str.replace(/&#(\d+);/g, function ($0, numberStr) {
-        return String.fromCharCode(parseInt(numberStr, 10));
-    });
-};
-
-// This is what browsers will submit when the ✓ character occurs in an
-// application/x-www-form-urlencoded body and the encoding of the page containing
-// the form is iso-8859-1, or when the submitted form has an accept-charset
-// attribute of iso-8859-1. Presumably also with other charsets that do not contain
-// the ✓ character, such as us-ascii.
-var isoSentinel = 'utf8=%26%2310003%3B'; // encodeURIComponent('&#10003;')
-
-// These are the percent-encoded utf-8 octets representing a checkmark, indicating that the request actually is utf-8 encoded.
-var charsetSentinel = 'utf8=%E2%9C%93'; // encodeURIComponent('✓')
-
-var parseValues = function parseQueryStringValues(str, options) {
-    var obj = {};
-    var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
-    var limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
-    var parts = cleanStr.split(options.delimiter, limit);
-    var skipIndex = -1; // Keep track of where the utf8 sentinel was found
-    var i;
-
-    var charset = options.charset;
-    if (options.charsetSentinel) {
-        for (i = 0; i < parts.length; ++i) {
-            if (parts[i].indexOf('utf8=') === 0) {
-                if (parts[i] === charsetSentinel) {
-                    charset = 'utf-8';
-                } else if (parts[i] === isoSentinel) {
-                    charset = 'iso-8859-1';
-                }
-                skipIndex = i;
-                i = parts.length; // The eslint settings do not allow break;
-            }
-        }
-    }
-
-    for (i = 0; i < parts.length; ++i) {
-        if (i === skipIndex) {
-            continue;
-        }
-        var part = parts[i];
-
-        var bracketEqualsPos = part.indexOf(']=');
-        var pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
-
-        var key, val;
-        if (pos === -1) {
-            key = options.decoder(part, defaults.decoder, charset);
-            val = options.strictNullHandling ? null : '';
-        } else {
-            key = options.decoder(part.slice(0, pos), defaults.decoder, charset);
-            val = options.decoder(part.slice(pos + 1), defaults.decoder, charset);
-        }
-
-        if (val && options.interpretNumericEntities && charset === 'iso-8859-1') {
-            val = interpretNumericEntities(val);
-        }
-
-        if (val && options.comma && val.indexOf(',') > -1) {
-            val = val.split(',');
-        }
-
-        if (has.call(obj, key)) {
-            obj[key] = utils.combine(obj[key], val);
-        } else {
-            obj[key] = val;
-        }
-    }
-
-    return obj;
-};
-
-var parseObject = function (chain, val, options) {
-    var leaf = val;
-
-    for (var i = chain.length - 1; i >= 0; --i) {
-        var obj;
-        var root = chain[i];
-
-        if (root === '[]' && options.parseArrays) {
-            obj = [].concat(leaf);
-        } else {
-            obj = options.plainObjects ? Object.create(null) : {};
-            var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
-            var index = parseInt(cleanRoot, 10);
-            if (!options.parseArrays && cleanRoot === '') {
-                obj = { 0: leaf };
-            } else if (
-                !isNaN(index)
-                && root !== cleanRoot
-                && String(index) === cleanRoot
-                && index >= 0
-                && (options.parseArrays && index <= options.arrayLimit)
-            ) {
-                obj = [];
-                obj[index] = leaf;
-            } else {
-                obj[cleanRoot] = leaf;
-            }
-        }
-
-        leaf = obj;
-    }
-
-    return leaf;
-};
-
-var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
-    if (!givenKey) {
-        return;
-    }
-
-    // Transform dot notation to bracket notation
-    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
-
-    // The regex chunks
-
-    var brackets = /(\[[^[\]]*])/;
-    var child = /(\[[^[\]]*])/g;
-
-    // Get the parent
-
-    var segment = brackets.exec(key);
-    var parent = segment ? key.slice(0, segment.index) : key;
-
-    // Stash the parent if it exists
-
-    var keys = [];
-    if (parent) {
-        // If we aren't using plain objects, optionally prefix keys that would overwrite object prototype properties
-        if (!options.plainObjects && has.call(Object.prototype, parent)) {
-            if (!options.allowPrototypes) {
-                return;
-            }
-        }
-
-        keys.push(parent);
-    }
-
-    // Loop through children appending to the array until we hit depth
-
-    var i = 0;
-    while ((segment = child.exec(key)) !== null && i < options.depth) {
-        i += 1;
-        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
-            if (!options.allowPrototypes) {
-                return;
-            }
-        }
-        keys.push(segment[1]);
-    }
-
-    // If there's a remainder, just add whatever is left
-
-    if (segment) {
-        keys.push('[' + key.slice(segment.index) + ']');
-    }
-
-    return parseObject(keys, val, options);
-};
-
-var normalizeParseOptions = function normalizeParseOptions(opts) {
-    if (!opts) {
-        return defaults;
-    }
-
-    if (opts.decoder !== null && opts.decoder !== undefined && typeof opts.decoder !== 'function') {
-        throw new TypeError('Decoder has to be a function.');
-    }
-
-    if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
-        throw new Error('The charset option must be either utf-8, iso-8859-1, or undefined');
-    }
-    var charset = typeof opts.charset === 'undefined' ? defaults.charset : opts.charset;
-
-    return {
-        allowDots: typeof opts.allowDots === 'undefined' ? defaults.allowDots : !!opts.allowDots,
-        allowPrototypes: typeof opts.allowPrototypes === 'boolean' ? opts.allowPrototypes : defaults.allowPrototypes,
-        arrayLimit: typeof opts.arrayLimit === 'number' ? opts.arrayLimit : defaults.arrayLimit,
-        charset: charset,
-        charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
-        comma: typeof opts.comma === 'boolean' ? opts.comma : defaults.comma,
-        decoder: typeof opts.decoder === 'function' ? opts.decoder : defaults.decoder,
-        delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
-        depth: typeof opts.depth === 'number' ? opts.depth : defaults.depth,
-        ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
-        interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
-        parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,
-        parseArrays: opts.parseArrays !== false,
-        plainObjects: typeof opts.plainObjects === 'boolean' ? opts.plainObjects : defaults.plainObjects,
-        strictNullHandling: typeof opts.strictNullHandling === 'boolean' ? opts.strictNullHandling : defaults.strictNullHandling
-    };
-};
-
-module.exports = function (str, opts) {
-    var options = normalizeParseOptions(opts);
-
-    if (str === '' || str === null || typeof str === 'undefined') {
-        return options.plainObjects ? Object.create(null) : {};
-    }
-
-    var tempObj = typeof str === 'string' ? parseValues(str, options) : str;
-    var obj = options.plainObjects ? Object.create(null) : {};
-
-    // Iterate over the keys and setup the new object
-
-    var keys = Object.keys(tempObj);
-    for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        var newObj = parseKeys(key, tempObj[key], options);
-        obj = utils.merge(obj, newObj, options);
-    }
-
-    return utils.compact(obj);
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/qs/lib/stringify.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/stringify.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/qs/lib/utils.js");
-var formats = __webpack_require__(/*! ./formats */ "../../api-javascript/node_modules/qs/lib/formats.js");
-var has = Object.prototype.hasOwnProperty;
-
-var arrayPrefixGenerators = {
-    brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
-        return prefix + '[]';
-    },
-    comma: 'comma',
-    indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
-        return prefix + '[' + key + ']';
-    },
-    repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
-        return prefix;
-    }
-};
-
-var isArray = Array.isArray;
-var push = Array.prototype.push;
-var pushToArray = function (arr, valueOrArray) {
-    push.apply(arr, isArray(valueOrArray) ? valueOrArray : [valueOrArray]);
-};
-
-var toISO = Date.prototype.toISOString;
-
-var defaults = {
-    addQueryPrefix: false,
-    allowDots: false,
-    charset: 'utf-8',
-    charsetSentinel: false,
-    delimiter: '&',
-    encode: true,
-    encoder: utils.encode,
-    encodeValuesOnly: false,
-    formatter: formats.formatters[formats['default']],
-    // deprecated
-    indices: false,
-    serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
-        return toISO.call(date);
-    },
-    skipNulls: false,
-    strictNullHandling: false
-};
-
-var stringify = function stringify( // eslint-disable-line func-name-matching
-    object,
-    prefix,
-    generateArrayPrefix,
-    strictNullHandling,
-    skipNulls,
-    encoder,
-    filter,
-    sort,
-    allowDots,
-    serializeDate,
-    formatter,
-    encodeValuesOnly,
-    charset
-) {
-    var obj = object;
-    if (typeof filter === 'function') {
-        obj = filter(prefix, obj);
-    } else if (obj instanceof Date) {
-        obj = serializeDate(obj);
-    } else if (generateArrayPrefix === 'comma' && isArray(obj)) {
-        obj = obj.join(',');
-    }
-
-    if (obj === null) {
-        if (strictNullHandling) {
-            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset) : prefix;
-        }
-
-        obj = '';
-    }
-
-    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
-        if (encoder) {
-            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
-            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
-        }
-        return [formatter(prefix) + '=' + formatter(String(obj))];
-    }
-
-    var values = [];
-
-    if (typeof obj === 'undefined') {
-        return values;
-    }
-
-    var objKeys;
-    if (isArray(filter)) {
-        objKeys = filter;
-    } else {
-        var keys = Object.keys(obj);
-        objKeys = sort ? keys.sort(sort) : keys;
-    }
-
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-
-        if (skipNulls && obj[key] === null) {
-            continue;
-        }
-
-        if (isArray(obj)) {
-            pushToArray(values, stringify(
-                obj[key],
-                typeof generateArrayPrefix === 'function' ? generateArrayPrefix(prefix, key) : prefix,
-                generateArrayPrefix,
-                strictNullHandling,
-                skipNulls,
-                encoder,
-                filter,
-                sort,
-                allowDots,
-                serializeDate,
-                formatter,
-                encodeValuesOnly,
-                charset
-            ));
-        } else {
-            pushToArray(values, stringify(
-                obj[key],
-                prefix + (allowDots ? '.' + key : '[' + key + ']'),
-                generateArrayPrefix,
-                strictNullHandling,
-                skipNulls,
-                encoder,
-                filter,
-                sort,
-                allowDots,
-                serializeDate,
-                formatter,
-                encodeValuesOnly,
-                charset
-            ));
-        }
-    }
-
-    return values;
-};
-
-var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
-    if (!opts) {
-        return defaults;
-    }
-
-    if (opts.encoder !== null && opts.encoder !== undefined && typeof opts.encoder !== 'function') {
-        throw new TypeError('Encoder has to be a function.');
-    }
-
-    var charset = opts.charset || defaults.charset;
-    if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
-        throw new TypeError('The charset option must be either utf-8, iso-8859-1, or undefined');
-    }
-
-    var format = formats['default'];
-    if (typeof opts.format !== 'undefined') {
-        if (!has.call(formats.formatters, opts.format)) {
-            throw new TypeError('Unknown format option provided.');
-        }
-        format = opts.format;
-    }
-    var formatter = formats.formatters[format];
-
-    var filter = defaults.filter;
-    if (typeof opts.filter === 'function' || isArray(opts.filter)) {
-        filter = opts.filter;
-    }
-
-    return {
-        addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,
-        allowDots: typeof opts.allowDots === 'undefined' ? defaults.allowDots : !!opts.allowDots,
-        charset: charset,
-        charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
-        delimiter: typeof opts.delimiter === 'undefined' ? defaults.delimiter : opts.delimiter,
-        encode: typeof opts.encode === 'boolean' ? opts.encode : defaults.encode,
-        encoder: typeof opts.encoder === 'function' ? opts.encoder : defaults.encoder,
-        encodeValuesOnly: typeof opts.encodeValuesOnly === 'boolean' ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
-        filter: filter,
-        formatter: formatter,
-        serializeDate: typeof opts.serializeDate === 'function' ? opts.serializeDate : defaults.serializeDate,
-        skipNulls: typeof opts.skipNulls === 'boolean' ? opts.skipNulls : defaults.skipNulls,
-        sort: typeof opts.sort === 'function' ? opts.sort : null,
-        strictNullHandling: typeof opts.strictNullHandling === 'boolean' ? opts.strictNullHandling : defaults.strictNullHandling
-    };
-};
-
-module.exports = function (object, opts) {
-    var obj = object;
-    var options = normalizeStringifyOptions(opts);
-
-    var objKeys;
-    var filter;
-
-    if (typeof options.filter === 'function') {
-        filter = options.filter;
-        obj = filter('', obj);
-    } else if (isArray(options.filter)) {
-        filter = options.filter;
-        objKeys = filter;
-    }
-
-    var keys = [];
-
-    if (typeof obj !== 'object' || obj === null) {
-        return '';
-    }
-
-    var arrayFormat;
-    if (opts && opts.arrayFormat in arrayPrefixGenerators) {
-        arrayFormat = opts.arrayFormat;
-    } else if (opts && 'indices' in opts) {
-        arrayFormat = opts.indices ? 'indices' : 'repeat';
-    } else {
-        arrayFormat = 'indices';
-    }
-
-    var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
-
-    if (!objKeys) {
-        objKeys = Object.keys(obj);
-    }
-
-    if (options.sort) {
-        objKeys.sort(options.sort);
-    }
-
-    for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-
-        if (options.skipNulls && obj[key] === null) {
-            continue;
-        }
-        pushToArray(keys, stringify(
-            obj[key],
-            key,
-            generateArrayPrefix,
-            options.strictNullHandling,
-            options.skipNulls,
-            options.encode ? options.encoder : null,
-            options.filter,
-            options.sort,
-            options.allowDots,
-            options.serializeDate,
-            options.formatter,
-            options.encodeValuesOnly,
-            options.charset
-        ));
-    }
-
-    var joined = keys.join(options.delimiter);
-    var prefix = options.addQueryPrefix === true ? '?' : '';
-
-    if (options.charsetSentinel) {
-        if (options.charset === 'iso-8859-1') {
-            // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
-            prefix += 'utf8=%26%2310003%3B&';
-        } else {
-            // encodeURIComponent('✓')
-            prefix += 'utf8=%E2%9C%93&';
-        }
-    }
-
-    return joined.length > 0 ? prefix + joined : '';
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/qs/lib/utils.js":
-/*!**********************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/utils.js ***!
-  \**********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var has = Object.prototype.hasOwnProperty;
-var isArray = Array.isArray;
-
-var hexTable = (function () {
-    var array = [];
-    for (var i = 0; i < 256; ++i) {
-        array.push('%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase());
-    }
-
-    return array;
-}());
-
-var compactQueue = function compactQueue(queue) {
-    while (queue.length > 1) {
-        var item = queue.pop();
-        var obj = item.obj[item.prop];
-
-        if (isArray(obj)) {
-            var compacted = [];
-
-            for (var j = 0; j < obj.length; ++j) {
-                if (typeof obj[j] !== 'undefined') {
-                    compacted.push(obj[j]);
-                }
-            }
-
-            item.obj[item.prop] = compacted;
-        }
-    }
-};
-
-var arrayToObject = function arrayToObject(source, options) {
-    var obj = options && options.plainObjects ? Object.create(null) : {};
-    for (var i = 0; i < source.length; ++i) {
-        if (typeof source[i] !== 'undefined') {
-            obj[i] = source[i];
-        }
-    }
-
-    return obj;
-};
-
-var merge = function merge(target, source, options) {
-    if (!source) {
-        return target;
-    }
-
-    if (typeof source !== 'object') {
-        if (isArray(target)) {
-            target.push(source);
-        } else if (target && typeof target === 'object') {
-            if ((options && (options.plainObjects || options.allowPrototypes)) || !has.call(Object.prototype, source)) {
-                target[source] = true;
-            }
-        } else {
-            return [target, source];
-        }
-
-        return target;
-    }
-
-    if (!target || typeof target !== 'object') {
-        return [target].concat(source);
-    }
-
-    var mergeTarget = target;
-    if (isArray(target) && !isArray(source)) {
-        mergeTarget = arrayToObject(target, options);
-    }
-
-    if (isArray(target) && isArray(source)) {
-        source.forEach(function (item, i) {
-            if (has.call(target, i)) {
-                var targetItem = target[i];
-                if (targetItem && typeof targetItem === 'object' && item && typeof item === 'object') {
-                    target[i] = merge(targetItem, item, options);
-                } else {
-                    target.push(item);
-                }
-            } else {
-                target[i] = item;
-            }
-        });
-        return target;
-    }
-
-    return Object.keys(source).reduce(function (acc, key) {
-        var value = source[key];
-
-        if (has.call(acc, key)) {
-            acc[key] = merge(acc[key], value, options);
-        } else {
-            acc[key] = value;
-        }
-        return acc;
-    }, mergeTarget);
-};
-
-var assign = function assignSingleSource(target, source) {
-    return Object.keys(source).reduce(function (acc, key) {
-        acc[key] = source[key];
-        return acc;
-    }, target);
-};
-
-var decode = function (str, decoder, charset) {
-    var strWithoutPlus = str.replace(/\+/g, ' ');
-    if (charset === 'iso-8859-1') {
-        // unescape never throws, no try...catch needed:
-        return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
-    }
-    // utf-8
-    try {
-        return decodeURIComponent(strWithoutPlus);
-    } catch (e) {
-        return strWithoutPlus;
-    }
-};
-
-var encode = function encode(str, defaultEncoder, charset) {
-    // This code was originally written by Brian White (mscdex) for the io.js core querystring library.
-    // It has been adapted here for stricter adherence to RFC 3986
-    if (str.length === 0) {
-        return str;
-    }
-
-    var string = typeof str === 'string' ? str : String(str);
-
-    if (charset === 'iso-8859-1') {
-        return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
-            return '%26%23' + parseInt($0.slice(2), 16) + '%3B';
-        });
-    }
-
-    var out = '';
-    for (var i = 0; i < string.length; ++i) {
-        var c = string.charCodeAt(i);
-
-        if (
-            c === 0x2D // -
-            || c === 0x2E // .
-            || c === 0x5F // _
-            || c === 0x7E // ~
-            || (c >= 0x30 && c <= 0x39) // 0-9
-            || (c >= 0x41 && c <= 0x5A) // a-z
-            || (c >= 0x61 && c <= 0x7A) // A-Z
-        ) {
-            out += string.charAt(i);
-            continue;
-        }
-
-        if (c < 0x80) {
-            out = out + hexTable[c];
-            continue;
-        }
-
-        if (c < 0x800) {
-            out = out + (hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)]);
-            continue;
-        }
-
-        if (c < 0xD800 || c >= 0xE000) {
-            out = out + (hexTable[0xE0 | (c >> 12)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)]);
-            continue;
-        }
-
-        i += 1;
-        c = 0x10000 + (((c & 0x3FF) << 10) | (string.charCodeAt(i) & 0x3FF));
-        out += hexTable[0xF0 | (c >> 18)]
-            + hexTable[0x80 | ((c >> 12) & 0x3F)]
-            + hexTable[0x80 | ((c >> 6) & 0x3F)]
-            + hexTable[0x80 | (c & 0x3F)];
-    }
-
-    return out;
-};
-
-var compact = function compact(value) {
-    var queue = [{ obj: { o: value }, prop: 'o' }];
-    var refs = [];
-
-    for (var i = 0; i < queue.length; ++i) {
-        var item = queue[i];
-        var obj = item.obj[item.prop];
-
-        var keys = Object.keys(obj);
-        for (var j = 0; j < keys.length; ++j) {
-            var key = keys[j];
-            var val = obj[key];
-            if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
-                queue.push({ obj: obj, prop: key });
-                refs.push(val);
-            }
-        }
-    }
-
-    compactQueue(queue);
-
-    return value;
-};
-
-var isRegExp = function isRegExp(obj) {
-    return Object.prototype.toString.call(obj) === '[object RegExp]';
-};
-
-var isBuffer = function isBuffer(obj) {
-    if (!obj || typeof obj !== 'object') {
-        return false;
-    }
-
-    return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
-};
-
-var combine = function combine(a, b) {
-    return [].concat(a, b);
-};
-
-module.exports = {
-    arrayToObject: arrayToObject,
-    assign: assign,
-    combine: combine,
-    compact: compact,
-    decode: decode,
-    encode: encode,
-    isBuffer: isBuffer,
-    isRegExp: isRegExp,
-    merge: merge
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/randomatic/index.js":
-/*!**************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/randomatic/index.js ***!
-  \**************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * randomatic <https://github.com/jonschlinkert/randomatic>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-var isNumber = __webpack_require__(/*! is-number */ "../../api-javascript/node_modules/randomatic/node_modules/is-number/index.js");
-var typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/randomatic/node_modules/kind-of/index.js");
-var mathRandom = __webpack_require__(/*! math-random */ "../../api-javascript/node_modules/math-random/browser.js");
-
-/**
- * Expose `randomatic`
- */
-
-module.exports = randomatic;
-module.exports.isCrypto = !!mathRandom.cryptographic;
-
-/**
- * Available mask characters
- */
-
-var type = {
-  lower: 'abcdefghijklmnopqrstuvwxyz',
-  upper: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  number: '0123456789',
-  special: '~!@#$%^&()_+-={}[];\',.'
-};
-
-type.all = type.lower + type.upper + type.number + type.special;
-
-/**
- * Generate random character sequences of a specified `length`,
- * based on the given `pattern`.
- *
- * @param {String} `pattern` The pattern to use for generating the random string.
- * @param {String} `length` The length of the string to generate.
- * @param {String} `options`
- * @return {String}
- * @api public
- */
-
-function randomatic(pattern, length, options) {
-  if (typeof pattern === 'undefined') {
-    throw new Error('randomatic expects a string or number.');
-  }
-
-  var custom = false;
-  if (arguments.length === 1) {
-    if (typeof pattern === 'string') {
-      length = pattern.length;
-
-    } else if (isNumber(pattern)) {
-      options = {};
-      length = pattern;
-      pattern = '*';
-    }
-  }
-
-  if (typeOf(length) === 'object' && length.hasOwnProperty('chars')) {
-    options = length;
-    pattern = options.chars;
-    length = pattern.length;
-    custom = true;
-  }
-
-  var opts = options || {};
-  var mask = '';
-  var res = '';
-
-  // Characters to be used
-  if (pattern.indexOf('?') !== -1) mask += opts.chars;
-  if (pattern.indexOf('a') !== -1) mask += type.lower;
-  if (pattern.indexOf('A') !== -1) mask += type.upper;
-  if (pattern.indexOf('0') !== -1) mask += type.number;
-  if (pattern.indexOf('!') !== -1) mask += type.special;
-  if (pattern.indexOf('*') !== -1) mask += type.all;
-  if (custom) mask += pattern;
-
-  // Characters to exclude
-  if (opts.exclude) {
-    var exclude = typeOf(opts.exclude) === 'string' ? opts.exclude : opts.exclude.join('');
-    exclude = exclude.replace(new RegExp('[\\]]+', 'g'), '');
-    mask = mask.replace(new RegExp('[' + exclude + ']+', 'g'), '');
-    
-    if(opts.exclude.indexOf(']') !== -1) mask = mask.replace(new RegExp('[\\]]+', 'g'), '');
-  }
-
-  while (length--) {
-    res += mask.charAt(parseInt(mathRandom() * mask.length, 10));
-  }
-  return res;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/randomatic/node_modules/is-number/index.js":
-/*!*************************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/randomatic/node_modules/is-number/index.js ***!
-  \*************************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * is-number <https://github.com/jonschlinkert/is-number>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-module.exports = function isNumber(num) {
-  var type = typeof num;
-
-  if (type === 'string' || num instanceof String) {
-    // an empty string would be coerced to true with the below logic
-    if (!num.trim()) return false;
-  } else if (type !== 'number' && !(num instanceof Number)) {
-    return false;
-  }
-
-  return (num - num + 1) >= 0;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/randomatic/node_modules/kind-of/index.js":
-/*!***********************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/randomatic/node_modules/kind-of/index.js ***!
-  \***********************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-var toString = Object.prototype.toString;
-
-module.exports = function kindOf(val) {
-  if (val === void 0) return 'undefined';
-  if (val === null) return 'null';
-
-  var type = typeof val;
-  if (type === 'boolean') return 'boolean';
-  if (type === 'string') return 'string';
-  if (type === 'number') return 'number';
-  if (type === 'symbol') return 'symbol';
-  if (type === 'function') {
-    return isGeneratorFn(val) ? 'generatorfunction' : 'function';
-  }
-
-  if (isArray(val)) return 'array';
-  if (isBuffer(val)) return 'buffer';
-  if (isArguments(val)) return 'arguments';
-  if (isDate(val)) return 'date';
-  if (isError(val)) return 'error';
-  if (isRegexp(val)) return 'regexp';
-
-  switch (ctorName(val)) {
-    case 'Symbol': return 'symbol';
-    case 'Promise': return 'promise';
-
-    // Set, Map, WeakSet, WeakMap
-    case 'WeakMap': return 'weakmap';
-    case 'WeakSet': return 'weakset';
-    case 'Map': return 'map';
-    case 'Set': return 'set';
-
-    // 8-bit typed arrays
-    case 'Int8Array': return 'int8array';
-    case 'Uint8Array': return 'uint8array';
-    case 'Uint8ClampedArray': return 'uint8clampedarray';
-
-    // 16-bit typed arrays
-    case 'Int16Array': return 'int16array';
-    case 'Uint16Array': return 'uint16array';
-
-    // 32-bit typed arrays
-    case 'Int32Array': return 'int32array';
-    case 'Uint32Array': return 'uint32array';
-    case 'Float32Array': return 'float32array';
-    case 'Float64Array': return 'float64array';
-  }
-
-  if (isGeneratorObj(val)) {
-    return 'generator';
-  }
-
-  // Non-plain objects
-  type = toString.call(val);
-  switch (type) {
-    case '[object Object]': return 'object';
-    // iterators
-    case '[object Map Iterator]': return 'mapiterator';
-    case '[object Set Iterator]': return 'setiterator';
-    case '[object String Iterator]': return 'stringiterator';
-    case '[object Array Iterator]': return 'arrayiterator';
-  }
-
-  // other
-  return type.slice(8, -1).toLowerCase().replace(/\s/g, '');
-};
-
-function ctorName(val) {
-  return val.constructor ? val.constructor.name : null;
-}
-
-function isArray(val) {
-  if (Array.isArray) return Array.isArray(val);
-  return val instanceof Array;
-}
-
-function isError(val) {
-  return val instanceof Error || (typeof val.message === 'string' && val.constructor && typeof val.constructor.stackTraceLimit === 'number');
-}
-
-function isDate(val) {
-  if (val instanceof Date) return true;
-  return typeof val.toDateString === 'function'
-    && typeof val.getDate === 'function'
-    && typeof val.setDate === 'function';
-}
-
-function isRegexp(val) {
-  if (val instanceof RegExp) return true;
-  return typeof val.flags === 'string'
-    && typeof val.ignoreCase === 'boolean'
-    && typeof val.multiline === 'boolean'
-    && typeof val.global === 'boolean';
-}
-
-function isGeneratorFn(name, val) {
-  return ctorName(name) === 'GeneratorFunction';
-}
-
-function isGeneratorObj(val) {
-  return typeof val.throw === 'function'
-    && typeof val.return === 'function'
-    && typeof val.next === 'function';
-}
-
-function isArguments(val) {
-  try {
-    if (typeof val.length === 'number' && typeof val.callee === 'function') {
-      return true;
-    }
-  } catch (err) {
-    if (err.message.indexOf('callee') !== -1) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * If you need to support Safari 5-7 (8-10 yr-old browser),
- * take a look at https://github.com/feross/is-buffer
- */
-
-function isBuffer(val) {
-  if (val.constructor && typeof val.constructor.isBuffer === 'function') {
-    return val.constructor.isBuffer(val);
-  }
-  return false;
-}
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/regex-cache/index.js":
-/*!***************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/regex-cache/index.js ***!
-  \***************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * regex-cache <https://github.com/jonschlinkert/regex-cache>
- *
- * Copyright (c) 2015-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-var equal = __webpack_require__(/*! is-equal-shallow */ "../../api-javascript/node_modules/is-equal-shallow/index.js");
-var basic = {};
-var cache = {};
-
-/**
- * Expose `regexCache`
- */
-
-module.exports = regexCache;
-
-/**
- * Memoize the results of a call to the new RegExp constructor.
- *
- * @param  {Function} fn [description]
- * @param  {String} str [description]
- * @param  {Options} options [description]
- * @param  {Boolean} nocompare [description]
- * @return {RegExp}
- */
-
-function regexCache(fn, str, opts) {
-  var key = '_default_', regex, cached;
-
-  if (!str && !opts) {
-    if (typeof fn !== 'function') {
-      return fn;
-    }
-    return basic[key] || (basic[key] = fn(str));
-  }
-
-  var isString = typeof str === 'string';
-  if (isString) {
-    if (!opts) {
-      return basic[str] || (basic[str] = fn(str));
-    }
-    key = str;
-  } else {
-    opts = str;
-  }
-
-  cached = cache[key];
-  if (cached && equal(cached.opts, opts)) {
-    return cached.regex;
-  }
-
-  memo(key, opts, (regex = fn(str, opts)));
-  return regex;
-}
-
-function memo(key, opts, regex) {
-  cache[key] = {regex: regex, opts: opts};
-}
-
-/**
- * Expose `cache`
- */
-
-module.exports.cache = cache;
-module.exports.basic = basic;
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/remove-trailing-separator/index.js":
-/*!*****************************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/remove-trailing-separator/index.js ***!
-  \*****************************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/* WEBPACK VAR INJECTION */(function(process) {var isWin = process.platform === 'win32';
-
-module.exports = function (str) {
-	var i = str.length - 1;
-	if (i < 2) {
-		return str;
-	}
-	while (isSeparator(str, i)) {
-		i--;
-	}
-	return str.substr(0, i + 1);
-};
-
-function isSeparator(str, i) {
-	var char = str[i];
-	return i > 0 && (char === '/' || (isWin && char === '\\'));
-}
-
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../sfx/sfx-logic/node_modules/process/browser.js */ "./node_modules/process/browser.js")))
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/repeat-element/index.js":
-/*!******************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/repeat-element/index.js ***!
-  \******************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * repeat-element <https://github.com/jonschlinkert/repeat-element>
- *
- * Copyright (c) 2015-present, Jon Schlinkert.
- * Licensed under the MIT license.
- */
-
-
-
-module.exports = function repeat(ele, num) {
-  var arr = new Array(num);
-
-  for (var i = 0; i < num; i++) {
-    arr[i] = ele;
-  }
-
-  return arr;
-};
-
-
-/***/ }),
-
-/***/ "../../api-javascript/node_modules/repeat-string/index.js":
-/*!*****************************************************************************!*\
-  !*** /Users/shawna/Work/api-javascript/node_modules/repeat-string/index.js ***!
-  \*****************************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * repeat-string <https://github.com/jonschlinkert/repeat-string>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-
-
-/**
- * Results cache
- */
-
-var res = '';
-var cache;
-
-/**
- * Expose `repeat`
- */
-
-module.exports = repeat;
-
-/**
- * Repeat the given `string` the specified `number`
- * of times.
- *
- * **Example:**
- *
- * ```js
- * var repeat = require('repeat-string');
- * repeat('A', 5);
- * //=> AAAAA
- * ```
- *
- * @param {String} `string` The string to repeat
- * @param {Number} `number` The number of times to repeat the string
- * @return {String} Repeated string
- * @api public
- */
-
-function repeat(str, num) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expected a string');
-  }
-
-  // cover common, quick use cases
-  if (num === 1) return str;
-  if (num === 2) return str + str;
-
-  var max = str.length * num;
-  if (cache !== str || typeof cache === 'undefined') {
-    cache = str;
-    res = '';
-  } else if (res.length >= max) {
-    return res.substr(0, max);
-  }
-
-  while (max > res.length && num > 1) {
-    if (num & 1) {
-      res += str;
-    }
-
-    num >>= 1;
-    str += str;
-  }
-
-  res += str;
-  res = res.substr(0, max);
-  return res;
-}
-
-
-/***/ }),
-
-/***/ "./node_modules/arr-flatten/index.js":
-/*!*******************************************!*\
-  !*** ./node_modules/arr-flatten/index.js ***!
-  \*******************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-/*!
- * arr-flatten <https://github.com/jonschlinkert/arr-flatten>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-
-
-module.exports = function (arr) {
-  return flat(arr, []);
-};
-
-function flat(arr, res) {
-  var i = 0, cur;
-  var len = arr.length;
-  for (; i < len; i++) {
-    cur = arr[i];
-    Array.isArray(cur) ? flat(cur, res) : res.push(cur);
-  }
-  return res;
-}
-
-
-/***/ }),
-
-/***/ "./node_modules/base64-js/index.js":
-/*!*****************************************!*\
-  !*** ./node_modules/base64-js/index.js ***!
-  \*****************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-exports.byteLength = byteLength
-exports.toByteArray = toByteArray
-exports.fromByteArray = fromByteArray
-
-var lookup = []
-var revLookup = []
-var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
-
-var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-for (var i = 0, len = code.length; i < len; ++i) {
-  lookup[i] = code[i]
-  revLookup[code.charCodeAt(i)] = i
-}
-
-// Support decoding URL-safe base64 strings, as Node.js does.
-// See: https://en.wikipedia.org/wiki/Base64#URL_applications
-revLookup['-'.charCodeAt(0)] = 62
-revLookup['_'.charCodeAt(0)] = 63
-
-function getLens (b64) {
-  var len = b64.length
-
-  if (len % 4 > 0) {
-    throw new Error('Invalid string. Length must be a multiple of 4')
-  }
-
-  // Trim off extra bytes after placeholder bytes are found
-  // See: https://github.com/beatgammit/base64-js/issues/42
-  var validLen = b64.indexOf('=')
-  if (validLen === -1) validLen = len
-
-  var placeHoldersLen = validLen === len
-    ? 0
-    : 4 - (validLen % 4)
-
-  return [validLen, placeHoldersLen]
-}
-
-// base64 is 4/3 + up to two characters of the original data
-function byteLength (b64) {
-  var lens = getLens(b64)
-  var validLen = lens[0]
-  var placeHoldersLen = lens[1]
-  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
-}
-
-function _byteLength (b64, validLen, placeHoldersLen) {
-  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
-}
-
-function toByteArray (b64) {
-  var tmp
-  var lens = getLens(b64)
-  var validLen = lens[0]
-  var placeHoldersLen = lens[1]
-
-  var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen))
-
-  var curByte = 0
-
-  // if there are placeholders, only get up to the last complete 4 chars
-  var len = placeHoldersLen > 0
-    ? validLen - 4
-    : validLen
-
-  for (var i = 0; i < len; i += 4) {
-    tmp =
-      (revLookup[b64.charCodeAt(i)] << 18) |
-      (revLookup[b64.charCodeAt(i + 1)] << 12) |
-      (revLookup[b64.charCodeAt(i + 2)] << 6) |
-      revLookup[b64.charCodeAt(i + 3)]
-    arr[curByte++] = (tmp >> 16) & 0xFF
-    arr[curByte++] = (tmp >> 8) & 0xFF
-    arr[curByte++] = tmp & 0xFF
-  }
-
-  if (placeHoldersLen === 2) {
-    tmp =
-      (revLookup[b64.charCodeAt(i)] << 2) |
-      (revLookup[b64.charCodeAt(i + 1)] >> 4)
-    arr[curByte++] = tmp & 0xFF
-  }
-
-  if (placeHoldersLen === 1) {
-    tmp =
-      (revLookup[b64.charCodeAt(i)] << 10) |
-      (revLookup[b64.charCodeAt(i + 1)] << 4) |
-      (revLookup[b64.charCodeAt(i + 2)] >> 2)
-    arr[curByte++] = (tmp >> 8) & 0xFF
-    arr[curByte++] = tmp & 0xFF
-  }
-
-  return arr
-}
-
-function tripletToBase64 (num) {
-  return lookup[num >> 18 & 0x3F] +
-    lookup[num >> 12 & 0x3F] +
-    lookup[num >> 6 & 0x3F] +
-    lookup[num & 0x3F]
-}
-
-function encodeChunk (uint8, start, end) {
-  var tmp
-  var output = []
-  for (var i = start; i < end; i += 3) {
-    tmp =
-      ((uint8[i] << 16) & 0xFF0000) +
-      ((uint8[i + 1] << 8) & 0xFF00) +
-      (uint8[i + 2] & 0xFF)
-    output.push(tripletToBase64(tmp))
-  }
-  return output.join('')
-}
-
-function fromByteArray (uint8) {
-  var tmp
-  var len = uint8.length
-  var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
-  var parts = []
-  var maxChunkLength = 16383 // must be multiple of 3
-
-  // go through the array every three bytes, we'll deal with trailing stuff later
-  for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
-    parts.push(encodeChunk(
-      uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
-    ))
-  }
-
-  // pad the end with zeros, but make sure to not forget the extra bytes
-  if (extraBytes === 1) {
-    tmp = uint8[len - 1]
-    parts.push(
-      lookup[tmp >> 2] +
-      lookup[(tmp << 4) & 0x3F] +
-      '=='
-    )
-  } else if (extraBytes === 2) {
-    tmp = (uint8[len - 2] << 8) + uint8[len - 1]
-    parts.push(
-      lookup[tmp >> 10] +
-      lookup[(tmp >> 4) & 0x3F] +
-      lookup[(tmp << 2) & 0x3F] +
-      '='
-    )
-  }
-
-  return parts.join('')
-}
-
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../node-libs-browser/node_modules/buffer/index.js */ "./node_modules/node-libs-browser/node_modules/buffer/index.js").Buffer))
 
 /***/ }),
 
@@ -7469,151 +1145,188 @@ function coerce(val) {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-var pSlice = Array.prototype.slice;
-var objectKeys = __webpack_require__(/*! ./lib/keys.js */ "./node_modules/deep-equal/lib/keys.js");
-var isArguments = __webpack_require__(/*! ./lib/is_arguments.js */ "./node_modules/deep-equal/lib/is_arguments.js");
+var objectKeys = __webpack_require__(/*! object-keys */ "./node_modules/object-keys/index.js");
+var isArguments = __webpack_require__(/*! is-arguments */ "./node_modules/is-arguments/index.js");
+var is = __webpack_require__(/*! object-is */ "./node_modules/object-is/index.js");
+var isRegex = __webpack_require__(/*! is-regex */ "./node_modules/is-regex/index.js");
+var flags = __webpack_require__(/*! regexp.prototype.flags */ "./node_modules/regexp.prototype.flags/index.js");
+var isDate = __webpack_require__(/*! is-date-object */ "./node_modules/is-date-object/index.js");
 
-var deepEqual = module.exports = function (actual, expected, opts) {
-  if (!opts) opts = {};
+var getTime = Date.prototype.getTime;
+
+function deepEqual(actual, expected, options) {
+  var opts = options || {};
+
   // 7.1. All identical values are equivalent, as determined by ===.
-  if (actual === expected) {
+  if (opts.strict ? is(actual, expected) : actual === expected) {
     return true;
-
-  } else if (actual instanceof Date && expected instanceof Date) {
-    return actual.getTime() === expected.getTime();
-
-  // 7.3. Other pairs that do not both pass typeof value == 'object',
-  // equivalence is determined by ==.
-  } else if (!actual || !expected || typeof actual != 'object' && typeof expected != 'object') {
-    return opts.strict ? actual === expected : actual == expected;
-
-  // 7.4. For all other Object pairs, including Array objects, equivalence is
-  // determined by having the same number of owned properties (as verified
-  // with Object.prototype.hasOwnProperty.call), the same set of keys
-  // (although not necessarily the same order), equivalent values for every
-  // corresponding key, and an identical 'prototype' property. Note: this
-  // accounts for both named and indexed properties on Arrays.
-  } else {
-    return objEquiv(actual, expected, opts);
   }
+
+  // 7.3. Other pairs that do not both pass typeof value == 'object', equivalence is determined by ==.
+  if (!actual || !expected || (typeof actual !== 'object' && typeof expected !== 'object')) {
+    return opts.strict ? is(actual, expected) : actual == expected;
+  }
+
+  /*
+   * 7.4. For all other Object pairs, including Array objects, equivalence is
+   * determined by having the same number of owned properties (as verified
+   * with Object.prototype.hasOwnProperty.call), the same set of keys
+   * (although not necessarily the same order), equivalent values for every
+   * corresponding key, and an identical 'prototype' property. Note: this
+   * accounts for both named and indexed properties on Arrays.
+   */
+  // eslint-disable-next-line no-use-before-define
+  return objEquiv(actual, expected, opts);
 }
 
 function isUndefinedOrNull(value) {
   return value === null || value === undefined;
 }
 
-function isBuffer (x) {
-  if (!x || typeof x !== 'object' || typeof x.length !== 'number') return false;
+function isBuffer(x) {
+  if (!x || typeof x !== 'object' || typeof x.length !== 'number') {
+    return false;
+  }
   if (typeof x.copy !== 'function' || typeof x.slice !== 'function') {
     return false;
   }
-  if (x.length > 0 && typeof x[0] !== 'number') return false;
+  if (x.length > 0 && typeof x[0] !== 'number') {
+    return false;
+  }
   return true;
 }
 
 function objEquiv(a, b, opts) {
+  /* eslint max-statements: [2, 50] */
   var i, key;
-  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
-    return false;
+  if (typeof a !== typeof b) { return false; }
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b)) { return false; }
+
   // an identical 'prototype' property.
-  if (a.prototype !== b.prototype) return false;
-  //~~~I've managed to break Object.keys through screwy arguments passing.
-  //   Converting to array solves the problem.
-  if (isArguments(a)) {
-    if (!isArguments(b)) {
-      return false;
-    }
-    a = pSlice.call(a);
-    b = pSlice.call(b);
-    return deepEqual(a, b, opts);
+  if (a.prototype !== b.prototype) { return false; }
+
+  if (isArguments(a) !== isArguments(b)) { return false; }
+
+  var aIsRegex = isRegex(a);
+  var bIsRegex = isRegex(b);
+  if (aIsRegex !== bIsRegex) { return false; }
+  if (aIsRegex || bIsRegex) {
+    return a.source === b.source && flags(a) === flags(b);
   }
-  if (isBuffer(a)) {
-    if (!isBuffer(b)) {
-      return false;
-    }
-    if (a.length !== b.length) return false;
+
+  if (isDate(a) && isDate(b)) {
+    return getTime.call(a) === getTime.call(b);
+  }
+
+  var aIsBuffer = isBuffer(a);
+  var bIsBuffer = isBuffer(b);
+  if (aIsBuffer !== bIsBuffer) { return false; }
+  if (aIsBuffer || bIsBuffer) { // && would work too, because both are true or both false here
+    if (a.length !== b.length) { return false; }
     for (i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
+      if (a[i] !== b[i]) { return false; }
     }
     return true;
   }
+
+  if (typeof a !== typeof b) { return false; }
+
   try {
-    var ka = objectKeys(a),
-        kb = objectKeys(b);
-  } catch (e) {//happens when one is a string literal and the other isn't
+    var ka = objectKeys(a);
+    var kb = objectKeys(b);
+  } catch (e) { // happens when one is a string literal and the other isn't
     return false;
   }
-  // having the same number of owned properties (keys incorporates
-  // hasOwnProperty)
-  if (ka.length != kb.length)
-    return false;
-  //the same set of keys (although not necessarily the same order),
+  // having the same number of owned properties (keys incorporates hasOwnProperty)
+  if (ka.length !== kb.length) { return false; }
+
+  // the same set of keys (although not necessarily the same order),
   ka.sort();
   kb.sort();
-  //~~~cheap key test
+  // ~~~cheap key test
   for (i = ka.length - 1; i >= 0; i--) {
-    if (ka[i] != kb[i])
-      return false;
+    if (ka[i] != kb[i]) { return false; }
   }
-  //equivalent values for every corresponding key, and
-  //~~~possibly expensive deep test
+  // equivalent values for every corresponding key, and ~~~possibly expensive deep test
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
-    if (!deepEqual(a[key], b[key], opts)) return false;
+    if (!deepEqual(a[key], b[key], opts)) { return false; }
   }
-  return typeof a === typeof b;
+
+  return true;
 }
+
+module.exports = deepEqual;
 
 
 /***/ }),
 
-/***/ "./node_modules/deep-equal/lib/is_arguments.js":
-/*!*****************************************************!*\
-  !*** ./node_modules/deep-equal/lib/is_arguments.js ***!
-  \*****************************************************/
+/***/ "./node_modules/define-properties/index.js":
+/*!*************************************************!*\
+  !*** ./node_modules/define-properties/index.js ***!
+  \*************************************************/
 /*! no static exports found */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-var supportsArgumentsClass = (function(){
-  return Object.prototype.toString.call(arguments)
-})() == '[object Arguments]';
+"use strict";
 
-exports = module.exports = supportsArgumentsClass ? supported : unsupported;
 
-exports.supported = supported;
-function supported(object) {
-  return Object.prototype.toString.call(object) == '[object Arguments]';
+var keys = __webpack_require__(/*! object-keys */ "./node_modules/object-keys/index.js");
+var hasSymbols = typeof Symbol === 'function' && typeof Symbol('foo') === 'symbol';
+
+var toStr = Object.prototype.toString;
+var concat = Array.prototype.concat;
+var origDefineProperty = Object.defineProperty;
+
+var isFunction = function (fn) {
+	return typeof fn === 'function' && toStr.call(fn) === '[object Function]';
 };
 
-exports.unsupported = unsupported;
-function unsupported(object){
-  return object &&
-    typeof object == 'object' &&
-    typeof object.length == 'number' &&
-    Object.prototype.hasOwnProperty.call(object, 'callee') &&
-    !Object.prototype.propertyIsEnumerable.call(object, 'callee') ||
-    false;
+var arePropertyDescriptorsSupported = function () {
+	var obj = {};
+	try {
+		origDefineProperty(obj, 'x', { enumerable: false, value: obj });
+		// eslint-disable-next-line no-unused-vars, no-restricted-syntax
+		for (var _ in obj) { // jscs:ignore disallowUnusedVariables
+			return false;
+		}
+		return obj.x === obj;
+	} catch (e) { /* this is IE 8. */
+		return false;
+	}
+};
+var supportsDescriptors = origDefineProperty && arePropertyDescriptorsSupported();
+
+var defineProperty = function (object, name, value, predicate) {
+	if (name in object && (!isFunction(predicate) || !predicate())) {
+		return;
+	}
+	if (supportsDescriptors) {
+		origDefineProperty(object, name, {
+			configurable: true,
+			enumerable: false,
+			value: value,
+			writable: true
+		});
+	} else {
+		object[name] = value;
+	}
 };
 
+var defineProperties = function (object, map) {
+	var predicates = arguments.length > 2 ? arguments[2] : {};
+	var props = keys(map);
+	if (hasSymbols) {
+		props = concat.call(props, Object.getOwnPropertySymbols(map));
+	}
+	for (var i = 0; i < props.length; i += 1) {
+		defineProperty(object, props[i], map[props[i]], predicates[props[i]]);
+	}
+};
 
-/***/ }),
+defineProperties.supportsDescriptors = !!supportsDescriptors;
 
-/***/ "./node_modules/deep-equal/lib/keys.js":
-/*!*********************************************!*\
-  !*** ./node_modules/deep-equal/lib/keys.js ***!
-  \*********************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-exports = module.exports = typeof Object.keys === 'function'
-  ? Object.keys : shim;
-
-exports.shim = shim;
-function shim (obj) {
-  var keys = [];
-  for (var key in obj) keys.push(key);
-  return keys;
-}
+module.exports = defineProperties;
 
 
 /***/ }),
@@ -9353,7 +3066,7 @@ function length(val) {
 
 
 
-var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
+var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/expand-range/node_modules/kind-of/index.js");
 
 module.exports = function isNumber(num) {
   var type = typeOf(num);
@@ -9388,6 +3101,133 @@ var isArray = __webpack_require__(/*! isarray */ "./node_modules/isarray/index.j
 
 module.exports = function isObject(val) {
   return val != null && typeof val === 'object' && isArray(val) === false;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/expand-range/node_modules/kind-of/index.js":
+/*!*****************************************************************!*\
+  !*** ./node_modules/expand-range/node_modules/kind-of/index.js ***!
+  \*****************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
+var toString = Object.prototype.toString;
+
+/**
+ * Get the native `typeof` a value.
+ *
+ * @param  {*} `val`
+ * @return {*} Native javascript type
+ */
+
+module.exports = function kindOf(val) {
+  // primitivies
+  if (typeof val === 'undefined') {
+    return 'undefined';
+  }
+  if (val === null) {
+    return 'null';
+  }
+  if (val === true || val === false || val instanceof Boolean) {
+    return 'boolean';
+  }
+  if (typeof val === 'string' || val instanceof String) {
+    return 'string';
+  }
+  if (typeof val === 'number' || val instanceof Number) {
+    return 'number';
+  }
+
+  // functions
+  if (typeof val === 'function' || val instanceof Function) {
+    return 'function';
+  }
+
+  // array
+  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
+    return 'array';
+  }
+
+  // check for instances of RegExp and Date before calling `toString`
+  if (val instanceof RegExp) {
+    return 'regexp';
+  }
+  if (val instanceof Date) {
+    return 'date';
+  }
+
+  // other objects
+  var type = toString.call(val);
+
+  if (type === '[object RegExp]') {
+    return 'regexp';
+  }
+  if (type === '[object Date]') {
+    return 'date';
+  }
+  if (type === '[object Arguments]') {
+    return 'arguments';
+  }
+  if (type === '[object Error]') {
+    return 'error';
+  }
+
+  // buffer
+  if (isBuffer(val)) {
+    return 'buffer';
+  }
+
+  // es6: Map, WeakMap, Set, WeakSet
+  if (type === '[object Set]') {
+    return 'set';
+  }
+  if (type === '[object WeakSet]') {
+    return 'weakset';
+  }
+  if (type === '[object Map]') {
+    return 'map';
+  }
+  if (type === '[object WeakMap]') {
+    return 'weakmap';
+  }
+  if (type === '[object Symbol]') {
+    return 'symbol';
+  }
+
+  // typed arrays
+  if (type === '[object Int8Array]') {
+    return 'int8array';
+  }
+  if (type === '[object Uint8Array]') {
+    return 'uint8array';
+  }
+  if (type === '[object Uint8ClampedArray]') {
+    return 'uint8clampedarray';
+  }
+  if (type === '[object Int16Array]') {
+    return 'int16array';
+  }
+  if (type === '[object Uint16Array]') {
+    return 'uint16array';
+  }
+  if (type === '[object Int32Array]') {
+    return 'int32array';
+  }
+  if (type === '[object Uint32Array]') {
+    return 'uint32array';
+  }
+  if (type === '[object Float32Array]') {
+    return 'float32array';
+  }
+  if (type === '[object Float64Array]') {
+    return 'float64array';
+  }
+
+  // must be a plain object
+  return 'object';
 };
 
 
@@ -9435,6 +3275,519 @@ function hasOwn(obj, key) {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
+
+/***/ }),
+
+/***/ "./node_modules/fetch-ponyfill/build/fetch-browser.js":
+/*!************************************************************!*\
+  !*** ./node_modules/fetch-ponyfill/build/fetch-browser.js ***!
+  \************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/* WEBPACK VAR INJECTION */(function(global) {var __WEBPACK_AMD_DEFINE_RESULT__;(function (self) {
+  'use strict';
+
+  function fetchPonyfill(options) {
+    var Promise = options && options.Promise || self.Promise;
+    var XMLHttpRequest = options && options.XMLHttpRequest || self.XMLHttpRequest;
+    var global = self;
+
+    return (function () {
+      var self = Object.create(global, {
+        fetch: {
+          value: undefined,
+          writable: true
+        }
+      });
+
+      (function(self) {
+        'use strict';
+
+        if (self.fetch) {
+          return
+        }
+
+        var support = {
+          searchParams: 'URLSearchParams' in self,
+          iterable: 'Symbol' in self && 'iterator' in Symbol,
+          blob: 'FileReader' in self && 'Blob' in self && (function() {
+            try {
+              new Blob()
+              return true
+            } catch(e) {
+              return false
+            }
+          })(),
+          formData: 'FormData' in self,
+          arrayBuffer: 'ArrayBuffer' in self
+        }
+
+        if (support.arrayBuffer) {
+          var viewClasses = [
+            '[object Int8Array]',
+            '[object Uint8Array]',
+            '[object Uint8ClampedArray]',
+            '[object Int16Array]',
+            '[object Uint16Array]',
+            '[object Int32Array]',
+            '[object Uint32Array]',
+            '[object Float32Array]',
+            '[object Float64Array]'
+          ]
+
+          var isDataView = function(obj) {
+            return obj && DataView.prototype.isPrototypeOf(obj)
+          }
+
+          var isArrayBufferView = ArrayBuffer.isView || function(obj) {
+            return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
+          }
+        }
+
+        function normalizeName(name) {
+          if (typeof name !== 'string') {
+            name = String(name)
+          }
+          if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
+            throw new TypeError('Invalid character in header field name')
+          }
+          return name.toLowerCase()
+        }
+
+        function normalizeValue(value) {
+          if (typeof value !== 'string') {
+            value = String(value)
+          }
+          return value
+        }
+
+        // Build a destructive iterator for the value list
+        function iteratorFor(items) {
+          var iterator = {
+            next: function() {
+              var value = items.shift()
+              return {done: value === undefined, value: value}
+            }
+          }
+
+          if (support.iterable) {
+            iterator[Symbol.iterator] = function() {
+              return iterator
+            }
+          }
+
+          return iterator
+        }
+
+        function Headers(headers) {
+          this.map = {}
+
+          if (headers instanceof Headers) {
+            headers.forEach(function(value, name) {
+              this.append(name, value)
+            }, this)
+          } else if (Array.isArray(headers)) {
+            headers.forEach(function(header) {
+              this.append(header[0], header[1])
+            }, this)
+          } else if (headers) {
+            Object.getOwnPropertyNames(headers).forEach(function(name) {
+              this.append(name, headers[name])
+            }, this)
+          }
+        }
+
+        Headers.prototype.append = function(name, value) {
+          name = normalizeName(name)
+          value = normalizeValue(value)
+          var oldValue = this.map[name]
+          this.map[name] = oldValue ? oldValue+','+value : value
+        }
+
+        Headers.prototype['delete'] = function(name) {
+          delete this.map[normalizeName(name)]
+        }
+
+        Headers.prototype.get = function(name) {
+          name = normalizeName(name)
+          return this.has(name) ? this.map[name] : null
+        }
+
+        Headers.prototype.has = function(name) {
+          return this.map.hasOwnProperty(normalizeName(name))
+        }
+
+        Headers.prototype.set = function(name, value) {
+          this.map[normalizeName(name)] = normalizeValue(value)
+        }
+
+        Headers.prototype.forEach = function(callback, thisArg) {
+          for (var name in this.map) {
+            if (this.map.hasOwnProperty(name)) {
+              callback.call(thisArg, this.map[name], name, this)
+            }
+          }
+        }
+
+        Headers.prototype.keys = function() {
+          var items = []
+          this.forEach(function(value, name) { items.push(name) })
+          return iteratorFor(items)
+        }
+
+        Headers.prototype.values = function() {
+          var items = []
+          this.forEach(function(value) { items.push(value) })
+          return iteratorFor(items)
+        }
+
+        Headers.prototype.entries = function() {
+          var items = []
+          this.forEach(function(value, name) { items.push([name, value]) })
+          return iteratorFor(items)
+        }
+
+        if (support.iterable) {
+          Headers.prototype[Symbol.iterator] = Headers.prototype.entries
+        }
+
+        function consumed(body) {
+          if (body.bodyUsed) {
+            return Promise.reject(new TypeError('Already read'))
+          }
+          body.bodyUsed = true
+        }
+
+        function fileReaderReady(reader) {
+          return new Promise(function(resolve, reject) {
+            reader.onload = function() {
+              resolve(reader.result)
+            }
+            reader.onerror = function() {
+              reject(reader.error)
+            }
+          })
+        }
+
+        function readBlobAsArrayBuffer(blob) {
+          var reader = new FileReader()
+          var promise = fileReaderReady(reader)
+          reader.readAsArrayBuffer(blob)
+          return promise
+        }
+
+        function readBlobAsText(blob) {
+          var reader = new FileReader()
+          var promise = fileReaderReady(reader)
+          reader.readAsText(blob)
+          return promise
+        }
+
+        function readArrayBufferAsText(buf) {
+          var view = new Uint8Array(buf)
+          var chars = new Array(view.length)
+
+          for (var i = 0; i < view.length; i++) {
+            chars[i] = String.fromCharCode(view[i])
+          }
+          return chars.join('')
+        }
+
+        function bufferClone(buf) {
+          if (buf.slice) {
+            return buf.slice(0)
+          } else {
+            var view = new Uint8Array(buf.byteLength)
+            view.set(new Uint8Array(buf))
+            return view.buffer
+          }
+        }
+
+        function Body() {
+          this.bodyUsed = false
+
+          this._initBody = function(body) {
+            this._bodyInit = body
+            if (!body) {
+              this._bodyText = ''
+            } else if (typeof body === 'string') {
+              this._bodyText = body
+            } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
+              this._bodyBlob = body
+            } else if (support.formData && FormData.prototype.isPrototypeOf(body)) {
+              this._bodyFormData = body
+            } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
+              this._bodyText = body.toString()
+            } else if (support.arrayBuffer && support.blob && isDataView(body)) {
+              this._bodyArrayBuffer = bufferClone(body.buffer)
+              // IE 10-11 can't handle a DataView body.
+              this._bodyInit = new Blob([this._bodyArrayBuffer])
+            } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
+              this._bodyArrayBuffer = bufferClone(body)
+            } else {
+              throw new Error('unsupported BodyInit type')
+            }
+
+            if (!this.headers.get('content-type')) {
+              if (typeof body === 'string') {
+                this.headers.set('content-type', 'text/plain;charset=UTF-8')
+              } else if (this._bodyBlob && this._bodyBlob.type) {
+                this.headers.set('content-type', this._bodyBlob.type)
+              } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
+                this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
+              }
+            }
+          }
+
+          if (support.blob) {
+            this.blob = function() {
+              var rejected = consumed(this)
+              if (rejected) {
+                return rejected
+              }
+
+              if (this._bodyBlob) {
+                return Promise.resolve(this._bodyBlob)
+              } else if (this._bodyArrayBuffer) {
+                return Promise.resolve(new Blob([this._bodyArrayBuffer]))
+              } else if (this._bodyFormData) {
+                throw new Error('could not read FormData body as blob')
+              } else {
+                return Promise.resolve(new Blob([this._bodyText]))
+              }
+            }
+
+            this.arrayBuffer = function() {
+              if (this._bodyArrayBuffer) {
+                return consumed(this) || Promise.resolve(this._bodyArrayBuffer)
+              } else {
+                return this.blob().then(readBlobAsArrayBuffer)
+              }
+            }
+          }
+
+          this.text = function() {
+            var rejected = consumed(this)
+            if (rejected) {
+              return rejected
+            }
+
+            if (this._bodyBlob) {
+              return readBlobAsText(this._bodyBlob)
+            } else if (this._bodyArrayBuffer) {
+              return Promise.resolve(readArrayBufferAsText(this._bodyArrayBuffer))
+            } else if (this._bodyFormData) {
+              throw new Error('could not read FormData body as text')
+            } else {
+              return Promise.resolve(this._bodyText)
+            }
+          }
+
+          if (support.formData) {
+            this.formData = function() {
+              return this.text().then(decode)
+            }
+          }
+
+          this.json = function() {
+            return this.text().then(JSON.parse)
+          }
+
+          return this
+        }
+
+        // HTTP methods whose capitalization should be normalized
+        var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+
+        function normalizeMethod(method) {
+          var upcased = method.toUpperCase()
+          return (methods.indexOf(upcased) > -1) ? upcased : method
+        }
+
+        function Request(input, options) {
+          options = options || {}
+          var body = options.body
+
+          if (input instanceof Request) {
+            if (input.bodyUsed) {
+              throw new TypeError('Already read')
+            }
+            this.url = input.url
+            this.credentials = input.credentials
+            if (!options.headers) {
+              this.headers = new Headers(input.headers)
+            }
+            this.method = input.method
+            this.mode = input.mode
+            if (!body && input._bodyInit != null) {
+              body = input._bodyInit
+              input.bodyUsed = true
+            }
+          } else {
+            this.url = String(input)
+          }
+
+          this.credentials = options.credentials || this.credentials || 'omit'
+          if (options.headers || !this.headers) {
+            this.headers = new Headers(options.headers)
+          }
+          this.method = normalizeMethod(options.method || this.method || 'GET')
+          this.mode = options.mode || this.mode || null
+          this.referrer = null
+
+          if ((this.method === 'GET' || this.method === 'HEAD') && body) {
+            throw new TypeError('Body not allowed for GET or HEAD requests')
+          }
+          this._initBody(body)
+        }
+
+        Request.prototype.clone = function() {
+          return new Request(this, { body: this._bodyInit })
+        }
+
+        function decode(body) {
+          var form = new FormData()
+          body.trim().split('&').forEach(function(bytes) {
+            if (bytes) {
+              var split = bytes.split('=')
+              var name = split.shift().replace(/\+/g, ' ')
+              var value = split.join('=').replace(/\+/g, ' ')
+              form.append(decodeURIComponent(name), decodeURIComponent(value))
+            }
+          })
+          return form
+        }
+
+        function parseHeaders(rawHeaders) {
+          var headers = new Headers()
+          // Replace instances of \r\n and \n followed by at least one space or horizontal tab with a space
+          // https://tools.ietf.org/html/rfc7230#section-3.2
+          var preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/g, ' ')
+          preProcessedHeaders.split(/\r?\n/).forEach(function(line) {
+            var parts = line.split(':')
+            var key = parts.shift().trim()
+            if (key) {
+              var value = parts.join(':').trim()
+              headers.append(key, value)
+            }
+          })
+          return headers
+        }
+
+        Body.call(Request.prototype)
+
+        function Response(bodyInit, options) {
+          if (!options) {
+            options = {}
+          }
+
+          this.type = 'default'
+          this.status = options.status === undefined ? 200 : options.status
+          this.ok = this.status >= 200 && this.status < 300
+          this.statusText = 'statusText' in options ? options.statusText : 'OK'
+          this.headers = new Headers(options.headers)
+          this.url = options.url || ''
+          this._initBody(bodyInit)
+        }
+
+        Body.call(Response.prototype)
+
+        Response.prototype.clone = function() {
+          return new Response(this._bodyInit, {
+            status: this.status,
+            statusText: this.statusText,
+            headers: new Headers(this.headers),
+            url: this.url
+          })
+        }
+
+        Response.error = function() {
+          var response = new Response(null, {status: 0, statusText: ''})
+          response.type = 'error'
+          return response
+        }
+
+        var redirectStatuses = [301, 302, 303, 307, 308]
+
+        Response.redirect = function(url, status) {
+          if (redirectStatuses.indexOf(status) === -1) {
+            throw new RangeError('Invalid status code')
+          }
+
+          return new Response(null, {status: status, headers: {location: url}})
+        }
+
+        self.Headers = Headers
+        self.Request = Request
+        self.Response = Response
+
+        self.fetch = function(input, init) {
+          return new Promise(function(resolve, reject) {
+            var request = new Request(input, init)
+            var xhr = new XMLHttpRequest()
+
+            xhr.onload = function() {
+              var options = {
+                status: xhr.status,
+                statusText: xhr.statusText,
+                headers: parseHeaders(xhr.getAllResponseHeaders() || '')
+              }
+              options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
+              var body = 'response' in xhr ? xhr.response : xhr.responseText
+              resolve(new Response(body, options))
+            }
+
+            xhr.onerror = function() {
+              reject(new TypeError('Network request failed'))
+            }
+
+            xhr.ontimeout = function() {
+              reject(new TypeError('Network request failed'))
+            }
+
+            xhr.open(request.method, request.url, true)
+
+            if (request.credentials === 'include') {
+              xhr.withCredentials = true
+            } else if (request.credentials === 'omit') {
+              xhr.withCredentials = false
+            }
+
+            if ('responseType' in xhr && support.blob) {
+              xhr.responseType = 'blob'
+            }
+
+            request.headers.forEach(function(value, name) {
+              xhr.setRequestHeader(name, value)
+            })
+
+            xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)
+          })
+        }
+        self.fetch.polyfill = true
+      })(typeof self !== 'undefined' ? self : this);
+
+
+      return {
+        fetch: self.fetch,
+        Headers: self.Headers,
+        Request: self.Request,
+        Response: self.Response
+      };
+    }());
+  }
+
+  if (true) {
+    !(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {
+      return fetchPonyfill;
+    }).call(exports, __webpack_require__, exports, module),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  } else {}
+}(typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : this));
+
+
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../webpack/buildin/global.js */ "./node_modules/webpack/buildin/global.js")))
 
 /***/ }),
 
@@ -10369,6 +4722,157 @@ function toRegex(pattern, contains, isNegated) {
   }
   return new RegExp(prefix + pattern);
 }
+
+
+/***/ }),
+
+/***/ "./node_modules/filter-keys/node_modules/is-glob/index.js":
+/*!****************************************************************!*\
+  !*** ./node_modules/filter-keys/node_modules/is-glob/index.js ***!
+  \****************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * is-glob <https://github.com/jonschlinkert/is-glob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
+
+module.exports = function isGlob(str) {
+  return typeof str === 'string'
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
+};
+
+/***/ }),
+
+/***/ "./node_modules/filter-keys/node_modules/kind-of/index.js":
+/*!****************************************************************!*\
+  !*** ./node_modules/filter-keys/node_modules/kind-of/index.js ***!
+  \****************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
+var toString = Object.prototype.toString;
+
+/**
+ * Get the native `typeof` a value.
+ *
+ * @param  {*} `val`
+ * @return {*} Native javascript type
+ */
+
+module.exports = function kindOf(val) {
+  // primitivies
+  if (typeof val === 'undefined') {
+    return 'undefined';
+  }
+  if (val === null) {
+    return 'null';
+  }
+  if (val === true || val === false || val instanceof Boolean) {
+    return 'boolean';
+  }
+  if (typeof val === 'string' || val instanceof String) {
+    return 'string';
+  }
+  if (typeof val === 'number' || val instanceof Number) {
+    return 'number';
+  }
+
+  // functions
+  if (typeof val === 'function' || val instanceof Function) {
+    return 'function';
+  }
+
+  // array
+  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
+    return 'array';
+  }
+
+  // check for instances of RegExp and Date before calling `toString`
+  if (val instanceof RegExp) {
+    return 'regexp';
+  }
+  if (val instanceof Date) {
+    return 'date';
+  }
+
+  // other objects
+  var type = toString.call(val);
+
+  if (type === '[object RegExp]') {
+    return 'regexp';
+  }
+  if (type === '[object Date]') {
+    return 'date';
+  }
+  if (type === '[object Arguments]') {
+    return 'arguments';
+  }
+  if (type === '[object Error]') {
+    return 'error';
+  }
+
+  // buffer
+  if (isBuffer(val)) {
+    return 'buffer';
+  }
+
+  // es6: Map, WeakMap, Set, WeakSet
+  if (type === '[object Set]') {
+    return 'set';
+  }
+  if (type === '[object WeakSet]') {
+    return 'weakset';
+  }
+  if (type === '[object Map]') {
+    return 'map';
+  }
+  if (type === '[object WeakMap]') {
+    return 'weakmap';
+  }
+  if (type === '[object Symbol]') {
+    return 'symbol';
+  }
+
+  // typed arrays
+  if (type === '[object Int8Array]') {
+    return 'int8array';
+  }
+  if (type === '[object Uint8Array]') {
+    return 'uint8array';
+  }
+  if (type === '[object Uint8ClampedArray]') {
+    return 'uint8clampedarray';
+  }
+  if (type === '[object Int16Array]') {
+    return 'int16array';
+  }
+  if (type === '[object Uint16Array]') {
+    return 'uint16array';
+  }
+  if (type === '[object Int32Array]') {
+    return 'int32array';
+  }
+  if (type === '[object Uint32Array]') {
+    return 'uint32array';
+  }
+  if (type === '[object Float32Array]') {
+    return 'float32array';
+  }
+  if (type === '[object Float64Array]') {
+    return 'float64array';
+  }
+
+  // must be a plain object
+  return 'object';
+};
 
 
 /***/ }),
@@ -11441,9 +5945,9 @@ utils.braces = __webpack_require__(/*! braces */ "./node_modules/filter-keys/nod
 utils.brackets = __webpack_require__(/*! expand-brackets */ "./node_modules/filter-keys/node_modules/expand-brackets/index.js");
 utils.extglob = __webpack_require__(/*! extglob */ "./node_modules/filter-keys/node_modules/extglob/index.js");
 utils.isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
-utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
-utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/normalize-path/index.js");
+utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/filter-keys/node_modules/is-glob/index.js");
+utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/filter-keys/node_modules/kind-of/index.js");
+utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/filter-keys/node_modules/normalize-path/index.js");
 utils.omit = __webpack_require__(/*! object.omit */ "./node_modules/object.omit/index.js");
 utils.parseGlob = __webpack_require__(/*! parse-glob */ "./node_modules/parse-glob/index.js");
 utils.cache = __webpack_require__(/*! regex-cache */ "./node_modules/regex-cache/index.js");
@@ -11575,6 +6079,36 @@ utils.escapeRe = function escapeRe(str) {
 module.exports = utils;
 
 /* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../process/browser.js */ "./node_modules/process/browser.js")))
+
+/***/ }),
+
+/***/ "./node_modules/filter-keys/node_modules/normalize-path/index.js":
+/*!***********************************************************************!*\
+  !*** ./node_modules/filter-keys/node_modules/normalize-path/index.js ***!
+  \***********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * normalize-path <https://github.com/jonschlinkert/normalize-path>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "./node_modules/remove-trailing-separator/index.js");
+
+module.exports = function normalizePath(str, stripTrailing) {
+  if (typeof str !== 'string') {
+    throw new TypeError('expected a string');
+  }
+  str = str.replace(/[\\\/]+/g, '/');
+  if (stripTrailing !== false) {
+    str = removeTrailingSeparator(str);
+  }
+  return str;
+};
+
 
 /***/ }),
 
@@ -11809,6 +6343,87 @@ module.exports = function forOwn(obj, fn, thisArg) {
 
 /***/ }),
 
+/***/ "./node_modules/function-bind/implementation.js":
+/*!******************************************************!*\
+  !*** ./node_modules/function-bind/implementation.js ***!
+  \******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+/* eslint no-invalid-this: 1 */
+
+var ERROR_MESSAGE = 'Function.prototype.bind called on incompatible ';
+var slice = Array.prototype.slice;
+var toStr = Object.prototype.toString;
+var funcType = '[object Function]';
+
+module.exports = function bind(that) {
+    var target = this;
+    if (typeof target !== 'function' || toStr.call(target) !== funcType) {
+        throw new TypeError(ERROR_MESSAGE + target);
+    }
+    var args = slice.call(arguments, 1);
+
+    var bound;
+    var binder = function () {
+        if (this instanceof bound) {
+            var result = target.apply(
+                this,
+                args.concat(slice.call(arguments))
+            );
+            if (Object(result) === result) {
+                return result;
+            }
+            return this;
+        } else {
+            return target.apply(
+                that,
+                args.concat(slice.call(arguments))
+            );
+        }
+    };
+
+    var boundLength = Math.max(0, target.length - args.length);
+    var boundArgs = [];
+    for (var i = 0; i < boundLength; i++) {
+        boundArgs.push('$' + i);
+    }
+
+    bound = Function('binder', 'return function (' + boundArgs.join(',') + '){ return binder.apply(this,arguments); }')(binder);
+
+    if (target.prototype) {
+        var Empty = function Empty() {};
+        Empty.prototype = target.prototype;
+        bound.prototype = new Empty();
+        Empty.prototype = null;
+    }
+
+    return bound;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/function-bind/index.js":
+/*!*********************************************!*\
+  !*** ./node_modules/function-bind/index.js ***!
+  \*********************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var implementation = __webpack_require__(/*! ./implementation */ "./node_modules/function-bind/implementation.js");
+
+module.exports = Function.prototype.bind || implementation;
+
+
+/***/ }),
+
 /***/ "./node_modules/glob-base/index.js":
 /*!*****************************************!*\
   !*** ./node_modules/glob-base/index.js ***!
@@ -11828,7 +6443,7 @@ module.exports = function forOwn(obj, fn, thisArg) {
 
 var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
 var parent = __webpack_require__(/*! glob-parent */ "./node_modules/glob-base/node_modules/glob-parent/index.js");
-var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/glob-base/node_modules/is-glob/index.js");
 
 module.exports = function globBase(pattern) {
   if (typeof pattern !== 'string') {
@@ -11883,13 +6498,621 @@ function dirname(glob) {
 
 
 var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
-var isglob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
+var isglob = __webpack_require__(/*! is-glob */ "./node_modules/glob-base/node_modules/is-glob/index.js");
 
 module.exports = function globParent(str) {
 	str += 'a'; // preserves full path in case of trailing path separator
 	do {str = path.dirname(str)} while (isglob(str));
 	return str;
 };
+
+
+/***/ }),
+
+/***/ "./node_modules/glob-base/node_modules/is-glob/index.js":
+/*!**************************************************************!*\
+  !*** ./node_modules/glob-base/node_modules/is-glob/index.js ***!
+  \**************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * is-glob <https://github.com/jonschlinkert/is-glob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
+
+module.exports = function isGlob(str) {
+  return typeof str === 'string'
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
+};
+
+/***/ }),
+
+/***/ "./node_modules/groupby-api/dist/core/bridge.js":
+/*!******************************************************!*\
+  !*** ./node_modules/groupby-api/dist/core/bridge.js ***!
+  \******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var clone = __webpack_require__(/*! clone */ "./node_modules/clone/clone.js");
+var fetchPonyfill = __webpack_require__(/*! fetch-ponyfill */ "./node_modules/fetch-ponyfill/build/fetch-browser.js");
+var qs = __webpack_require__(/*! qs */ "./node_modules/qs/lib/index.js");
+var utils_1 = __webpack_require__(/*! ../utils */ "./node_modules/groupby-api/dist/utils/index.js");
+var query_1 = __webpack_require__(/*! ./query */ "./node_modules/groupby-api/dist/core/query.js");
+var SEARCH = '/search';
+var REFINEMENTS = '/refinements';
+var INVALID_QUERY_ERROR = 'query was not of a recognised type';
+var createTimeoutPromise = function (timeout) {
+    return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+            reject(new BridgeTimeout("Timed out in " + timeout + " ms"));
+        }, timeout);
+    });
+};
+var BridgeTimeout = /** @class */ (function (_super) {
+    __extends(BridgeTimeout, _super);
+    /* istanbul ignore next */
+    function BridgeTimeout(err) {
+        return _super.call(this, err) || this;
+    }
+    return BridgeTimeout;
+}(Error));
+exports.BridgeTimeout = BridgeTimeout;
+var BridgeError = /** @class */ (function (_super) {
+    __extends(BridgeError, _super);
+    /* istanbul ignore next */
+    function BridgeError(statusText, status, data) {
+        var _this = _super.call(this, statusText) || this;
+        _this.status = status;
+        _this.data = data;
+        Object.setPrototypeOf(_this, BridgeError.prototype);
+        return _this;
+    }
+    Object.defineProperty(BridgeError.prototype, "statusText", {
+        get: function () {
+            return this.message;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    return BridgeError;
+}(Error));
+exports.BridgeError = BridgeError;
+exports.DEFAULT_CONFIG = {
+    timeout: 1500
+};
+var AbstractBridge = /** @class */ (function () {
+    function AbstractBridge(config) {
+        this.fetch = fetchPonyfill().fetch;
+        this.headers = {};
+        this.config = Object.assign({}, exports.DEFAULT_CONFIG, config);
+    }
+    AbstractBridge.prototype.search = function (query, callback) {
+        var _a = this.extractRequest(query), request = _a.request, queryParams = _a.queryParams;
+        if (request === null)
+            return this.generateError(INVALID_QUERY_ERROR, callback);
+        var response = this.fireRequest(this.bridgeUrl, request, queryParams)
+            .then(AbstractBridge.transformRecords)
+            .then(AbstractBridge.transformRefinements);
+        return this.handleResponse(response, callback);
+    };
+    AbstractBridge.prototype.refinements = function (query, navigationName, callback) {
+        var request = this.extractRequest(query).request;
+        if (request === null)
+            return this.generateError(INVALID_QUERY_ERROR, callback);
+        var refinementsRequest = { originalQuery: request, navigationName: navigationName };
+        var response = this.fireRequest(this.refinementsUrl, refinementsRequest);
+        return this.handleResponse(response, callback);
+    };
+    AbstractBridge.prototype.handleResponse = function (response, callback) {
+        if (callback) {
+            response.then(function (res) { return callback(undefined, res); }, function (err) { return callback(err); });
+        }
+        else {
+            return response;
+        }
+    };
+    AbstractBridge.prototype.extractRequest = function (query) {
+        switch (typeof query) {
+            case 'string': return { request: new query_1.Query(query).build(), queryParams: {} };
+            case 'object': return query instanceof query_1.Query
+                ? { request: query.build(), queryParams: query.queryParams }
+                : { request: clone(query), queryParams: {} };
+            default: return { request: null, queryParams: null };
+        }
+    };
+    AbstractBridge.prototype.generateError = function (error, callback) {
+        var err = new Error(error);
+        if (callback) {
+            callback(err);
+        }
+        else {
+            return Promise.reject(err);
+        }
+    };
+    // tslint:disable-next-line max-line-length
+    AbstractBridge.prototype.fireRequest = function (url, body, queryParams) {
+        var _this = this;
+        if (queryParams === void 0) { queryParams = {}; }
+        var options = {
+            method: 'POST',
+            headers: __assign({ 'Content-Type': 'application/json' }, this.headers),
+            body: JSON.stringify(AbstractBridge.normalizeRequest(this.augmentRequest(body))),
+        };
+        var params = qs.stringify(queryParams);
+        url = params ? url + "?" + params : url;
+        return Promise.race([this.fetch(url, options), createTimeoutPromise(this.config.timeout)])
+            .then(function (res) {
+            if (res.ok) {
+                return res.json();
+            }
+            else {
+                return res.json().then(function (err) {
+                    throw new BridgeError(res.statusText, res.status, err);
+                });
+            }
+        })
+            .catch(function (err) {
+            if (_this.errorHandler) {
+                _this.errorHandler(err);
+            }
+            throw err;
+        });
+    };
+    AbstractBridge.normalizeRequest = function (request) {
+        Object.keys(utils_1.Normalizers).forEach(function (normalize) { return utils_1.Normalizers[normalize](request); });
+        return request;
+    };
+    AbstractBridge.transform = function (response, key, callback) {
+        var _a;
+        if (response[key]) {
+            return Object.assign(response, (_a = {}, _a[key] = response[key].map(callback), _a));
+        }
+        else {
+            return response;
+        }
+    };
+    AbstractBridge.transformRecords = function (response) {
+        return AbstractBridge.transform(response, 'records', AbstractBridge.convertRecordFields);
+    };
+    AbstractBridge.transformRefinements = function (response) {
+        var transformed = AbstractBridge.transform(response, 'availableNavigation', AbstractBridge.convertRefinement);
+        return AbstractBridge.transform(transformed, 'selectedNavigation', AbstractBridge.convertRefinement);
+    };
+    AbstractBridge.convertRecordFields = function (record) {
+        var converted = Object.assign(record, { id: record._id, url: record._u, title: record._t });
+        delete converted._id;
+        delete converted._u;
+        delete converted._t;
+        if (record._snippet) {
+            converted.snippet = record._snippet;
+            delete converted._snippet;
+        }
+        return converted;
+    };
+    AbstractBridge.convertRefinement = function (navigation) {
+        if (navigation.range) {
+            navigation.min = Number.MAX_SAFE_INTEGER;
+            navigation.max = Number.MIN_SAFE_INTEGER;
+            navigation.refinements = navigation.refinements
+                .map(function (ref) {
+                navigation.min = Math.min(navigation.min, ref.low);
+                navigation.max = Math.max(navigation.max, ref.high);
+                return (__assign({}, ref, { high: parseFloat(ref.high), low: parseFloat(ref.low) }));
+            });
+        }
+        return navigation;
+    };
+    return AbstractBridge;
+}());
+exports.AbstractBridge = AbstractBridge;
+var CloudBridge = /** @class */ (function (_super) {
+    __extends(CloudBridge, _super);
+    function CloudBridge(clientKey, customerId, config) {
+        if (config === void 0) { config = {}; }
+        var _this = _super.call(this, config) || this;
+        _this.clientKey = clientKey;
+        _this.baseUrl = "https://" + customerId + ".groupbycloud.com:443/api/v1";
+        _this.bridgeUrl = _this.baseUrl + SEARCH;
+        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
+        return _this;
+    }
+    CloudBridge.prototype.augmentRequest = function (request) {
+        return Object.assign(request, { clientKey: this.clientKey });
+    };
+    return CloudBridge;
+}(AbstractBridge));
+exports.CloudBridge = CloudBridge;
+var BrowserBridge = /** @class */ (function (_super) {
+    __extends(BrowserBridge, _super);
+    function BrowserBridge(customerId, https, config) {
+        if (https === void 0) { https = false; }
+        if (config === void 0) { config = {}; }
+        var _this = _super.call(this, config) || this;
+        var scheme = https ? 'https' : 'http';
+        var port = https ? ':443' : '';
+        _this.baseUrl = config.proxyUrl || scheme + "://" + customerId + "-cors.groupbycloud.com" + port + "/api/v1";
+        _this.bridgeUrl = _this.baseUrl + SEARCH;
+        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
+        return _this;
+    }
+    BrowserBridge.prototype.augmentRequest = function (request) {
+        return request;
+    };
+    return BrowserBridge;
+}(AbstractBridge));
+exports.BrowserBridge = BrowserBridge;
+//# sourceMappingURL=bridge.js.map
+
+/***/ }),
+
+/***/ "./node_modules/groupby-api/dist/core/query.js":
+/*!*****************************************************!*\
+  !*** ./node_modules/groupby-api/dist/core/query.js ***!
+  \*****************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+var clone = __webpack_require__(/*! clone */ "./node_modules/clone/clone.js");
+var deepEqual = __webpack_require__(/*! deep-equal */ "./node_modules/deep-equal/index.js");
+var filterObject = __webpack_require__(/*! filter-object */ "./node_modules/filter-object/index.js");
+var qs = __webpack_require__(/*! qs */ "./node_modules/qs/lib/index.js");
+var utils_1 = __webpack_require__(/*! ../utils */ "./node_modules/groupby-api/dist/utils/index.js");
+var REFINEMENT_MASK = '{navigationName,value,low,high}';
+var Query = /** @class */ (function () {
+    function Query(query) {
+        if (query === void 0) { query = ''; }
+        this.request = {};
+        this.unprocessedNavigations = [];
+        this.queryParams = {};
+        this.request.query = query;
+        this.request.sort = [];
+        this.request.fields = [];
+        this.request.orFields = [];
+        this.request.refinements = [];
+        this.request.customUrlParams = [];
+        this.request.includedNavigations = [];
+        this.request.excludedNavigations = [];
+        this.request.wildcardSearchEnabled = false;
+        this.request.pruneRefinements = true;
+    }
+    Query.prototype.withQuery = function (query) {
+        this.request.query = query;
+        return this;
+    };
+    Query.prototype.withConfiguration = function (configuration, mask) {
+        if (mask === void 0) { mask = '*'; }
+        Object.assign(this.request, filterObject(configuration, mask));
+        return this;
+    };
+    Query.prototype.withSelectedRefinements = function () {
+        var _this = this;
+        var refinements = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            refinements[_i] = arguments[_i];
+        }
+        refinements.forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
+        return this;
+    };
+    Query.prototype.withoutSelectedRefinements = function () {
+        var _this = this;
+        var refinements = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            refinements[_i] = arguments[_i];
+        }
+        refinements.forEach(function (refinement) {
+            var index = _this.request.refinements.findIndex(function (ref) { return deepEqual(ref, refinement); });
+            if (index > -1)
+                _this.request.refinements.splice(index, 1);
+        });
+        return this;
+    };
+    Query.prototype.withRefinements = function (navigationName) {
+        var _this = this;
+        var refinements = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            refinements[_i - 1] = arguments[_i];
+        }
+        var convert = function (refinement) { return Object.assign(refinement, { navigationName: navigationName }); };
+        refinements.map(convert).forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
+        return this;
+    };
+    Query.prototype.withNavigations = function () {
+        var _a;
+        var navigations = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            navigations[_i] = arguments[_i];
+        }
+        (_a = this.unprocessedNavigations).push.apply(_a, navigations);
+        return this;
+    };
+    Query.prototype.withCustomUrlParams = function (customUrlParams) {
+        var _a, _b;
+        if (typeof customUrlParams === 'string') {
+            (_a = this.request.customUrlParams).push.apply(_a, this.convertParamString(customUrlParams));
+        }
+        else if (Array.isArray(customUrlParams)) {
+            (_b = this.request.customUrlParams).push.apply(_b, customUrlParams);
+        }
+        return this;
+    };
+    Query.prototype.withFields = function () {
+        var _a;
+        var fields = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            fields[_i] = arguments[_i];
+        }
+        (_a = this.request.fields).push.apply(_a, fields);
+        return this;
+    };
+    Query.prototype.withOrFields = function () {
+        var _a;
+        var orFields = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            orFields[_i] = arguments[_i];
+        }
+        (_a = this.request.orFields).push.apply(_a, orFields);
+        return this;
+    };
+    Query.prototype.withSorts = function () {
+        var _a;
+        var sorts = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            sorts[_i] = arguments[_i];
+        }
+        (_a = this.request.sort).push.apply(_a, sorts);
+        return this;
+    };
+    Query.prototype.withoutSorts = function () {
+        var sorts = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            sorts[_i] = arguments[_i];
+        }
+        this.request.sort = this.request.sort.filter(function (oldSort) { return !sorts.find(function (sort) {
+            return sort.type === 'ByIds'
+                ? oldSort.type === 'ByIds' && sort.ids.toString() === oldSort.ids.toString()
+                : sort.field === oldSort.field;
+        }); });
+        return this;
+    };
+    Query.prototype.withIncludedNavigations = function () {
+        var _a;
+        var navigationNames = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            navigationNames[_i] = arguments[_i];
+        }
+        (_a = this.request.includedNavigations).push.apply(_a, navigationNames);
+        return this;
+    };
+    Query.prototype.withExcludedNavigations = function () {
+        var _a;
+        var navigationNames = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            navigationNames[_i] = arguments[_i];
+        }
+        (_a = this.request.excludedNavigations).push.apply(_a, navigationNames);
+        return this;
+    };
+    Query.prototype.withQueryParams = function (queryParams) {
+        switch (typeof queryParams) {
+            case 'string':
+                return Object.assign(this, { queryParams: this.convertQueryString(queryParams) });
+            case 'object':
+                return Object.assign(this, { queryParams: queryParams });
+        }
+    };
+    Query.prototype.refineByValue = function (navigationName, value, exclude) {
+        if (exclude === void 0) { exclude = false; }
+        return this.withSelectedRefinements({
+            navigationName: navigationName,
+            value: value,
+            exclude: exclude,
+            type: 'Value'
+        });
+    };
+    Query.prototype.refineByRange = function (navigationName, low, high, exclude) {
+        if (exclude === void 0) { exclude = false; }
+        return this.withSelectedRefinements({
+            navigationName: navigationName,
+            low: low,
+            high: high,
+            exclude: exclude,
+            type: 'Range'
+        });
+    };
+    Query.prototype.restrictNavigation = function (restrictNavigation) {
+        this.request.restrictNavigation = restrictNavigation;
+        return this;
+    };
+    Query.prototype.skip = function (skip) {
+        this.request.skip = skip;
+        return this;
+    };
+    Query.prototype.withPageSize = function (pageSize) {
+        this.request.pageSize = pageSize;
+        return this;
+    };
+    Query.prototype.withMatchStrategy = function (matchStrategy) {
+        this.request.matchStrategy = matchStrategy;
+        return this;
+    };
+    Query.prototype.withBiasing = function (biasing) {
+        this.request.biasing = biasing;
+        return this;
+    };
+    Query.prototype.enableWildcardSearch = function () {
+        this.request.wildcardSearchEnabled = true;
+        return this;
+    };
+    Query.prototype.disableAutocorrection = function () {
+        this.request.disableAutocorrection = true;
+        return this;
+    };
+    Query.prototype.disableBinaryPayload = function () {
+        this.request.returnBinary = false;
+        return this;
+    };
+    Query.prototype.allowPrunedRefinements = function () {
+        this.request.pruneRefinements = false;
+        return this;
+    };
+    Query.prototype.build = function () {
+        var _this = this;
+        var builtRequest = this.raw;
+        utils_1.NavigationConverter.convert(this.unprocessedNavigations)
+            .forEach(function (ref) { return _this.addRefinement(ref, builtRequest.refinements); });
+        return this.clearEmptyArrays(builtRequest);
+    };
+    Object.defineProperty(Query.prototype, "raw", {
+        get: function () {
+            return clone(this.request, false);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(Query.prototype, "rawNavigations", {
+        get: function () {
+            return Object.create(this.unprocessedNavigations);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Query.prototype.addRefinement = function (refinement, refinements) {
+        var _this = this;
+        if (!refinements.find(function (ref) { return _this.refinementMatches(ref, refinement); })) {
+            refinements.push(refinement);
+        }
+    };
+    Query.prototype.refinementMatches = function (target, original) {
+        return deepEqual(filterObject(target, REFINEMENT_MASK), filterObject(original, REFINEMENT_MASK));
+    };
+    Query.prototype.convertParamString = function (customUrlParams) {
+        var parsed = qs.parse(customUrlParams);
+        return Object.keys(parsed).reduce(function (converted, key) { return converted.concat({ key: key, value: parsed[key] }); }, []);
+    };
+    Query.prototype.convertQueryString = function (queryParams) {
+        return qs.parse(queryParams);
+    };
+    Query.prototype.clearEmptyArrays = function (request) {
+        for (var key in request) {
+            if (Array.isArray(request[key]) && request[key].length === 0) {
+                delete request[key];
+            }
+        }
+        return request;
+    };
+    return Query;
+}());
+exports.Query = Query;
+//# sourceMappingURL=query.js.map
+
+/***/ }),
+
+/***/ "./node_modules/groupby-api/dist/index.js":
+/*!************************************************!*\
+  !*** ./node_modules/groupby-api/dist/index.js ***!
+  \************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(__webpack_require__(/*! ./core/query */ "./node_modules/groupby-api/dist/core/query.js"));
+__export(__webpack_require__(/*! ./core/bridge */ "./node_modules/groupby-api/dist/core/bridge.js"));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ "./node_modules/groupby-api/dist/utils/index.js":
+/*!******************************************************!*\
+  !*** ./node_modules/groupby-api/dist/utils/index.js ***!
+  \******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+var NavigationConverter = /** @class */ (function () {
+    function NavigationConverter() {
+    }
+    NavigationConverter.convert = function (navigations) {
+        return navigations.reduce(function (refinements, navigation) {
+            navigation.refinements
+                // tslint:disable-next-line max-line-length
+                .forEach(function (refinement) { return refinements.push(Object.assign(refinement, { navigationName: navigation.name })); });
+            return refinements;
+        }, []);
+    };
+    return NavigationConverter;
+}());
+exports.NavigationConverter = NavigationConverter;
+var Normalizers;
+(function (Normalizers) {
+    function normalizeSort(request) {
+        if (request.sort && !Array.isArray(request.sort) && request.sort.field === '_relevance') {
+            delete request.sort;
+        }
+    }
+    Normalizers.normalizeSort = normalizeSort;
+})(Normalizers = exports.Normalizers || (exports.Normalizers = {}));
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ "./node_modules/has/src/index.js":
+/*!***************************************!*\
+  !*** ./node_modules/has/src/index.js ***!
+  \***************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var bind = __webpack_require__(/*! function-bind */ "./node_modules/function-bind/index.js");
+
+module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
 
 
 /***/ }),
@@ -11989,6 +7212,49 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 
 /***/ }),
 
+/***/ "./node_modules/is-arguments/index.js":
+/*!********************************************!*\
+  !*** ./node_modules/is-arguments/index.js ***!
+  \********************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+var toStr = Object.prototype.toString;
+
+var isStandardArguments = function isArguments(value) {
+	if (hasToStringTag && value && typeof value === 'object' && Symbol.toStringTag in value) {
+		return false;
+	}
+	return toStr.call(value) === '[object Arguments]';
+};
+
+var isLegacyArguments = function isArguments(value) {
+	if (isStandardArguments(value)) {
+		return true;
+	}
+	return value !== null &&
+		typeof value === 'object' &&
+		typeof value.length === 'number' &&
+		value.length >= 0 &&
+		toStr.call(value) !== '[object Array]' &&
+		toStr.call(value.callee) === '[object Function]';
+};
+
+var supportsStandardArguments = (function () {
+	return isStandardArguments(arguments);
+}());
+
+isStandardArguments.isLegacyArguments = isLegacyArguments; // for tests
+
+module.exports = supportsStandardArguments ? isStandardArguments : isLegacyArguments;
+
+
+/***/ }),
+
 /***/ "./node_modules/is-buffer/index.js":
 /*!*****************************************!*\
   !*** ./node_modules/is-buffer/index.js ***!
@@ -12017,6 +7283,38 @@ function isBuffer (obj) {
 function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
+
+
+/***/ }),
+
+/***/ "./node_modules/is-date-object/index.js":
+/*!**********************************************!*\
+  !*** ./node_modules/is-date-object/index.js ***!
+  \**********************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var getDay = Date.prototype.getDay;
+var tryDateObject = function tryDateObject(value) {
+	try {
+		getDay.call(value);
+		return true;
+	} catch (e) {
+		return false;
+	}
+};
+
+var toStr = Object.prototype.toString;
+var dateClass = '[object Date]';
+var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+
+module.exports = function isDateObject(value) {
+	if (typeof value !== 'object' || value === null) { return false; }
+	return hasToStringTag ? tryDateObject(value) : toStr.call(value) === dateClass;
+};
 
 
 /***/ }),
@@ -12132,30 +7430,6 @@ module.exports = function isExtglob(str) {
 
 /***/ }),
 
-/***/ "./node_modules/is-glob/index.js":
-/*!***************************************!*\
-  !*** ./node_modules/is-glob/index.js ***!
-  \***************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * is-glob <https://github.com/jonschlinkert/is-glob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-
-module.exports = function isGlob(str) {
-  return typeof str === 'string'
-    && (/[*!?{}(|)[\]]/.test(str)
-     || isExtglob(str));
-};
-
-/***/ }),
-
 /***/ "./node_modules/is-match/index.js":
 /*!****************************************!*\
   !*** ./node_modules/is-match/index.js ***!
@@ -12175,7 +7449,7 @@ module.exports = function isGlob(str) {
 
 var deepEqual = __webpack_require__(/*! deep-equal */ "./node_modules/deep-equal/index.js");
 var isObject = __webpack_require__(/*! is-extendable */ "./node_modules/is-extendable/index.js");
-var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-match/node_modules/is-glob/index.js");
 var mm = __webpack_require__(/*! micromatch */ "./node_modules/is-match/node_modules/micromatch/index.js");
 
 function isMatch(pattern, options) {
@@ -13111,6 +8385,157 @@ function toRegex(pattern, contains, isNegated) {
   }
   return new RegExp(prefix + pattern);
 }
+
+
+/***/ }),
+
+/***/ "./node_modules/is-match/node_modules/is-glob/index.js":
+/*!*************************************************************!*\
+  !*** ./node_modules/is-match/node_modules/is-glob/index.js ***!
+  \*************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * is-glob <https://github.com/jonschlinkert/is-glob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
+
+module.exports = function isGlob(str) {
+  return typeof str === 'string'
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
+};
+
+/***/ }),
+
+/***/ "./node_modules/is-match/node_modules/kind-of/index.js":
+/*!*************************************************************!*\
+  !*** ./node_modules/is-match/node_modules/kind-of/index.js ***!
+  \*************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
+var toString = Object.prototype.toString;
+
+/**
+ * Get the native `typeof` a value.
+ *
+ * @param  {*} `val`
+ * @return {*} Native javascript type
+ */
+
+module.exports = function kindOf(val) {
+  // primitivies
+  if (typeof val === 'undefined') {
+    return 'undefined';
+  }
+  if (val === null) {
+    return 'null';
+  }
+  if (val === true || val === false || val instanceof Boolean) {
+    return 'boolean';
+  }
+  if (typeof val === 'string' || val instanceof String) {
+    return 'string';
+  }
+  if (typeof val === 'number' || val instanceof Number) {
+    return 'number';
+  }
+
+  // functions
+  if (typeof val === 'function' || val instanceof Function) {
+    return 'function';
+  }
+
+  // array
+  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
+    return 'array';
+  }
+
+  // check for instances of RegExp and Date before calling `toString`
+  if (val instanceof RegExp) {
+    return 'regexp';
+  }
+  if (val instanceof Date) {
+    return 'date';
+  }
+
+  // other objects
+  var type = toString.call(val);
+
+  if (type === '[object RegExp]') {
+    return 'regexp';
+  }
+  if (type === '[object Date]') {
+    return 'date';
+  }
+  if (type === '[object Arguments]') {
+    return 'arguments';
+  }
+  if (type === '[object Error]') {
+    return 'error';
+  }
+
+  // buffer
+  if (isBuffer(val)) {
+    return 'buffer';
+  }
+
+  // es6: Map, WeakMap, Set, WeakSet
+  if (type === '[object Set]') {
+    return 'set';
+  }
+  if (type === '[object WeakSet]') {
+    return 'weakset';
+  }
+  if (type === '[object Map]') {
+    return 'map';
+  }
+  if (type === '[object WeakMap]') {
+    return 'weakmap';
+  }
+  if (type === '[object Symbol]') {
+    return 'symbol';
+  }
+
+  // typed arrays
+  if (type === '[object Int8Array]') {
+    return 'int8array';
+  }
+  if (type === '[object Uint8Array]') {
+    return 'uint8array';
+  }
+  if (type === '[object Uint8ClampedArray]') {
+    return 'uint8clampedarray';
+  }
+  if (type === '[object Int16Array]') {
+    return 'int16array';
+  }
+  if (type === '[object Uint16Array]') {
+    return 'uint16array';
+  }
+  if (type === '[object Int32Array]') {
+    return 'int32array';
+  }
+  if (type === '[object Uint32Array]') {
+    return 'uint32array';
+  }
+  if (type === '[object Float32Array]') {
+    return 'float32array';
+  }
+  if (type === '[object Float64Array]') {
+    return 'float64array';
+  }
+
+  // must be a plain object
+  return 'object';
+};
 
 
 /***/ }),
@@ -14183,9 +9608,9 @@ utils.braces = __webpack_require__(/*! braces */ "./node_modules/is-match/node_m
 utils.brackets = __webpack_require__(/*! expand-brackets */ "./node_modules/is-match/node_modules/expand-brackets/index.js");
 utils.extglob = __webpack_require__(/*! extglob */ "./node_modules/is-match/node_modules/extglob/index.js");
 utils.isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
-utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
-utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/normalize-path/index.js");
+utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-match/node_modules/is-glob/index.js");
+utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/is-match/node_modules/kind-of/index.js");
+utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/is-match/node_modules/normalize-path/index.js");
 utils.omit = __webpack_require__(/*! object.omit */ "./node_modules/object.omit/index.js");
 utils.parseGlob = __webpack_require__(/*! parse-glob */ "./node_modules/parse-glob/index.js");
 utils.cache = __webpack_require__(/*! regex-cache */ "./node_modules/regex-cache/index.js");
@@ -14320,6 +9745,36 @@ module.exports = utils;
 
 /***/ }),
 
+/***/ "./node_modules/is-match/node_modules/normalize-path/index.js":
+/*!********************************************************************!*\
+  !*** ./node_modules/is-match/node_modules/normalize-path/index.js ***!
+  \********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * normalize-path <https://github.com/jonschlinkert/normalize-path>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "./node_modules/remove-trailing-separator/index.js");
+
+module.exports = function normalizePath(str, stripTrailing) {
+  if (typeof str !== 'string') {
+    throw new TypeError('expected a string');
+  }
+  str = str.replace(/[\\\/]+/g, '/');
+  if (stripTrailing !== false) {
+    str = removeTrailingSeparator(str);
+  }
+  return str;
+};
+
+
+/***/ }),
+
 /***/ "./node_modules/is-posix-bracket/index.js":
 /*!************************************************!*\
   !*** ./node_modules/is-posix-bracket/index.js ***!
@@ -14361,6 +9816,57 @@ module.exports = function isPosixBracket(str) {
 // see http://jsperf.com/testing-value-is-primitive/7
 module.exports = function isPrimitive(value) {
   return value == null || (typeof value !== 'function' && typeof value !== 'object');
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/is-regex/index.js":
+/*!****************************************!*\
+  !*** ./node_modules/is-regex/index.js ***!
+  \****************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var has = __webpack_require__(/*! has */ "./node_modules/has/src/index.js");
+var regexExec = RegExp.prototype.exec;
+var gOPD = Object.getOwnPropertyDescriptor;
+
+var tryRegexExecCall = function tryRegexExec(value) {
+	try {
+		var lastIndex = value.lastIndex;
+		value.lastIndex = 0;
+
+		regexExec.call(value);
+		return true;
+	} catch (e) {
+		return false;
+	} finally {
+		value.lastIndex = lastIndex;
+	}
+};
+var toStr = Object.prototype.toString;
+var regexClass = '[object RegExp]';
+var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+
+module.exports = function isRegex(value) {
+	if (!value || typeof value !== 'object') {
+		return false;
+	}
+	if (!hasToStringTag) {
+		return toStr.call(value) === regexClass;
+	}
+
+	var descriptor = gOPD(value, 'lastIndex');
+	var hasLastIndexDataProperty = descriptor && has(descriptor, 'value');
+	if (!hasLastIndexDataProperty) {
+		return false;
+	}
+
+	return tryRegexExecCall(value);
 };
 
 
@@ -14519,124 +10025,137 @@ function jsonp(url, opts, fn){
   !*** ./node_modules/kind-of/index.js ***!
   \***************************************/
 /*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
 var toString = Object.prototype.toString;
 
+module.exports = function kindOf(val) {
+  if (val === void 0) return 'undefined';
+  if (val === null) return 'null';
+
+  var type = typeof val;
+  if (type === 'boolean') return 'boolean';
+  if (type === 'string') return 'string';
+  if (type === 'number') return 'number';
+  if (type === 'symbol') return 'symbol';
+  if (type === 'function') {
+    return isGeneratorFn(val) ? 'generatorfunction' : 'function';
+  }
+
+  if (isArray(val)) return 'array';
+  if (isBuffer(val)) return 'buffer';
+  if (isArguments(val)) return 'arguments';
+  if (isDate(val)) return 'date';
+  if (isError(val)) return 'error';
+  if (isRegexp(val)) return 'regexp';
+
+  switch (ctorName(val)) {
+    case 'Symbol': return 'symbol';
+    case 'Promise': return 'promise';
+
+    // Set, Map, WeakSet, WeakMap
+    case 'WeakMap': return 'weakmap';
+    case 'WeakSet': return 'weakset';
+    case 'Map': return 'map';
+    case 'Set': return 'set';
+
+    // 8-bit typed arrays
+    case 'Int8Array': return 'int8array';
+    case 'Uint8Array': return 'uint8array';
+    case 'Uint8ClampedArray': return 'uint8clampedarray';
+
+    // 16-bit typed arrays
+    case 'Int16Array': return 'int16array';
+    case 'Uint16Array': return 'uint16array';
+
+    // 32-bit typed arrays
+    case 'Int32Array': return 'int32array';
+    case 'Uint32Array': return 'uint32array';
+    case 'Float32Array': return 'float32array';
+    case 'Float64Array': return 'float64array';
+  }
+
+  if (isGeneratorObj(val)) {
+    return 'generator';
+  }
+
+  // Non-plain objects
+  type = toString.call(val);
+  switch (type) {
+    case '[object Object]': return 'object';
+    // iterators
+    case '[object Map Iterator]': return 'mapiterator';
+    case '[object Set Iterator]': return 'setiterator';
+    case '[object String Iterator]': return 'stringiterator';
+    case '[object Array Iterator]': return 'arrayiterator';
+  }
+
+  // other
+  return type.slice(8, -1).toLowerCase().replace(/\s/g, '');
+};
+
+function ctorName(val) {
+  return val.constructor ? val.constructor.name : null;
+}
+
+function isArray(val) {
+  if (Array.isArray) return Array.isArray(val);
+  return val instanceof Array;
+}
+
+function isError(val) {
+  return val instanceof Error || (typeof val.message === 'string' && val.constructor && typeof val.constructor.stackTraceLimit === 'number');
+}
+
+function isDate(val) {
+  if (val instanceof Date) return true;
+  return typeof val.toDateString === 'function'
+    && typeof val.getDate === 'function'
+    && typeof val.setDate === 'function';
+}
+
+function isRegexp(val) {
+  if (val instanceof RegExp) return true;
+  return typeof val.flags === 'string'
+    && typeof val.ignoreCase === 'boolean'
+    && typeof val.multiline === 'boolean'
+    && typeof val.global === 'boolean';
+}
+
+function isGeneratorFn(name, val) {
+  return ctorName(name) === 'GeneratorFunction';
+}
+
+function isGeneratorObj(val) {
+  return typeof val.throw === 'function'
+    && typeof val.return === 'function'
+    && typeof val.next === 'function';
+}
+
+function isArguments(val) {
+  try {
+    if (typeof val.length === 'number' && typeof val.callee === 'function') {
+      return true;
+    }
+  } catch (err) {
+    if (err.message.indexOf('callee') !== -1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
- * Get the native `typeof` a value.
- *
- * @param  {*} `val`
- * @return {*} Native javascript type
+ * If you need to support Safari 5-7 (8-10 yr-old browser),
+ * take a look at https://github.com/feross/is-buffer
  */
 
-module.exports = function kindOf(val) {
-  // primitivies
-  if (typeof val === 'undefined') {
-    return 'undefined';
+function isBuffer(val) {
+  if (val.constructor && typeof val.constructor.isBuffer === 'function') {
+    return val.constructor.isBuffer(val);
   }
-  if (val === null) {
-    return 'null';
-  }
-  if (val === true || val === false || val instanceof Boolean) {
-    return 'boolean';
-  }
-  if (typeof val === 'string' || val instanceof String) {
-    return 'string';
-  }
-  if (typeof val === 'number' || val instanceof Number) {
-    return 'number';
-  }
-
-  // functions
-  if (typeof val === 'function' || val instanceof Function) {
-    return 'function';
-  }
-
-  // array
-  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
-    return 'array';
-  }
-
-  // check for instances of RegExp and Date before calling `toString`
-  if (val instanceof RegExp) {
-    return 'regexp';
-  }
-  if (val instanceof Date) {
-    return 'date';
-  }
-
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-  if (type === '[object Error]') {
-    return 'error';
-  }
-
-  // buffer
-  if (isBuffer(val)) {
-    return 'buffer';
-  }
-
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
-
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
-  }
-
-  // must be a plain object
-  return 'object';
-};
+  return false;
+}
 
 
 /***/ }),
@@ -16948,31 +12467,239 @@ var substr = 'ab'.substr(-1) === 'b'
 
 /***/ }),
 
-/***/ "./node_modules/normalize-path/index.js":
-/*!**********************************************!*\
-  !*** ./node_modules/normalize-path/index.js ***!
-  \**********************************************/
+/***/ "./node_modules/object-is/index.js":
+/*!*****************************************!*\
+  !*** ./node_modules/object-is/index.js ***!
+  \*****************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-/*!
- * normalize-path <https://github.com/jonschlinkert/normalize-path>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
+"use strict";
 
-var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "./node_modules/remove-trailing-separator/index.js");
 
-module.exports = function normalizePath(str, stripTrailing) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expected a string');
-  }
-  str = str.replace(/[\\\/]+/g, '/');
-  if (stripTrailing !== false) {
-    str = removeTrailingSeparator(str);
-  }
-  return str;
+/* https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.is */
+
+var NumberIsNaN = function (value) {
+	return value !== value;
+};
+
+module.exports = function is(a, b) {
+	if (a === 0 && b === 0) {
+		return 1 / a === 1 / b;
+	} else if (a === b) {
+		return true;
+	} else if (NumberIsNaN(a) && NumberIsNaN(b)) {
+		return true;
+	}
+	return false;
+};
+
+
+
+/***/ }),
+
+/***/ "./node_modules/object-keys/implementation.js":
+/*!****************************************************!*\
+  !*** ./node_modules/object-keys/implementation.js ***!
+  \****************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var keysShim;
+if (!Object.keys) {
+	// modified from https://github.com/es-shims/es5-shim
+	var has = Object.prototype.hasOwnProperty;
+	var toStr = Object.prototype.toString;
+	var isArgs = __webpack_require__(/*! ./isArguments */ "./node_modules/object-keys/isArguments.js"); // eslint-disable-line global-require
+	var isEnumerable = Object.prototype.propertyIsEnumerable;
+	var hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
+	var hasProtoEnumBug = isEnumerable.call(function () {}, 'prototype');
+	var dontEnums = [
+		'toString',
+		'toLocaleString',
+		'valueOf',
+		'hasOwnProperty',
+		'isPrototypeOf',
+		'propertyIsEnumerable',
+		'constructor'
+	];
+	var equalsConstructorPrototype = function (o) {
+		var ctor = o.constructor;
+		return ctor && ctor.prototype === o;
+	};
+	var excludedKeys = {
+		$applicationCache: true,
+		$console: true,
+		$external: true,
+		$frame: true,
+		$frameElement: true,
+		$frames: true,
+		$innerHeight: true,
+		$innerWidth: true,
+		$onmozfullscreenchange: true,
+		$onmozfullscreenerror: true,
+		$outerHeight: true,
+		$outerWidth: true,
+		$pageXOffset: true,
+		$pageYOffset: true,
+		$parent: true,
+		$scrollLeft: true,
+		$scrollTop: true,
+		$scrollX: true,
+		$scrollY: true,
+		$self: true,
+		$webkitIndexedDB: true,
+		$webkitStorageInfo: true,
+		$window: true
+	};
+	var hasAutomationEqualityBug = (function () {
+		/* global window */
+		if (typeof window === 'undefined') { return false; }
+		for (var k in window) {
+			try {
+				if (!excludedKeys['$' + k] && has.call(window, k) && window[k] !== null && typeof window[k] === 'object') {
+					try {
+						equalsConstructorPrototype(window[k]);
+					} catch (e) {
+						return true;
+					}
+				}
+			} catch (e) {
+				return true;
+			}
+		}
+		return false;
+	}());
+	var equalsConstructorPrototypeIfNotBuggy = function (o) {
+		/* global window */
+		if (typeof window === 'undefined' || !hasAutomationEqualityBug) {
+			return equalsConstructorPrototype(o);
+		}
+		try {
+			return equalsConstructorPrototype(o);
+		} catch (e) {
+			return false;
+		}
+	};
+
+	keysShim = function keys(object) {
+		var isObject = object !== null && typeof object === 'object';
+		var isFunction = toStr.call(object) === '[object Function]';
+		var isArguments = isArgs(object);
+		var isString = isObject && toStr.call(object) === '[object String]';
+		var theKeys = [];
+
+		if (!isObject && !isFunction && !isArguments) {
+			throw new TypeError('Object.keys called on a non-object');
+		}
+
+		var skipProto = hasProtoEnumBug && isFunction;
+		if (isString && object.length > 0 && !has.call(object, 0)) {
+			for (var i = 0; i < object.length; ++i) {
+				theKeys.push(String(i));
+			}
+		}
+
+		if (isArguments && object.length > 0) {
+			for (var j = 0; j < object.length; ++j) {
+				theKeys.push(String(j));
+			}
+		} else {
+			for (var name in object) {
+				if (!(skipProto && name === 'prototype') && has.call(object, name)) {
+					theKeys.push(String(name));
+				}
+			}
+		}
+
+		if (hasDontEnumBug) {
+			var skipConstructor = equalsConstructorPrototypeIfNotBuggy(object);
+
+			for (var k = 0; k < dontEnums.length; ++k) {
+				if (!(skipConstructor && dontEnums[k] === 'constructor') && has.call(object, dontEnums[k])) {
+					theKeys.push(dontEnums[k]);
+				}
+			}
+		}
+		return theKeys;
+	};
+}
+module.exports = keysShim;
+
+
+/***/ }),
+
+/***/ "./node_modules/object-keys/index.js":
+/*!*******************************************!*\
+  !*** ./node_modules/object-keys/index.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var slice = Array.prototype.slice;
+var isArgs = __webpack_require__(/*! ./isArguments */ "./node_modules/object-keys/isArguments.js");
+
+var origKeys = Object.keys;
+var keysShim = origKeys ? function keys(o) { return origKeys(o); } : __webpack_require__(/*! ./implementation */ "./node_modules/object-keys/implementation.js");
+
+var originalKeys = Object.keys;
+
+keysShim.shim = function shimObjectKeys() {
+	if (Object.keys) {
+		var keysWorksWithArguments = (function () {
+			// Safari 5.0 bug
+			var args = Object.keys(arguments);
+			return args && args.length === arguments.length;
+		}(1, 2));
+		if (!keysWorksWithArguments) {
+			Object.keys = function keys(object) { // eslint-disable-line func-name-matching
+				if (isArgs(object)) {
+					return originalKeys(slice.call(object));
+				}
+				return originalKeys(object);
+			};
+		}
+	} else {
+		Object.keys = keysShim;
+	}
+	return Object.keys || keysShim;
+};
+
+module.exports = keysShim;
+
+
+/***/ }),
+
+/***/ "./node_modules/object-keys/isArguments.js":
+/*!*************************************************!*\
+  !*** ./node_modules/object-keys/isArguments.js ***!
+  \*************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var toStr = Object.prototype.toString;
+
+module.exports = function isArguments(value) {
+	var str = toStr.call(value);
+	var isArgs = str === '[object Arguments]';
+	if (!isArgs) {
+		isArgs = str !== '[object Array]' &&
+			value !== null &&
+			typeof value === 'object' &&
+			typeof value.length === 'number' &&
+			value.length >= 0 &&
+			toStr.call(value.callee) === '[object Function]';
+	}
+	return isArgs;
 };
 
 
@@ -17094,7 +12821,7 @@ module.exports = function pick(obj, keys) {
 
 
 
-var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/parse-glob/node_modules/is-glob/index.js");
 var findBase = __webpack_require__(/*! glob-base */ "./node_modules/glob-base/index.js");
 var extglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
 var dotfile = __webpack_require__(/*! is-dotfile */ "./node_modules/is-dotfile/index.js");
@@ -17242,6 +12969,30 @@ function unescape(str) {
   return str;
 }
 
+
+/***/ }),
+
+/***/ "./node_modules/parse-glob/node_modules/is-glob/index.js":
+/*!***************************************************************!*\
+  !*** ./node_modules/parse-glob/node_modules/is-glob/index.js ***!
+  \***************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * is-glob <https://github.com/jonschlinkert/is-glob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
+
+module.exports = function isGlob(str) {
+  return typeof str === 'string'
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
+};
 
 /***/ }),
 
@@ -17518,19 +13269,27 @@ process.umask = function() { return 0; };
 var replace = String.prototype.replace;
 var percentTwenties = /%20/g;
 
-module.exports = {
-    'default': 'RFC3986',
-    formatters: {
-        RFC1738: function (value) {
-            return replace.call(value, percentTwenties, '+');
-        },
-        RFC3986: function (value) {
-            return value;
-        }
-    },
+var util = __webpack_require__(/*! ./utils */ "./node_modules/qs/lib/utils.js");
+
+var Format = {
     RFC1738: 'RFC1738',
     RFC3986: 'RFC3986'
 };
+
+module.exports = util.assign(
+    {
+        'default': Format.RFC3986,
+        formatters: {
+            RFC1738: function (value) {
+                return replace.call(value, percentTwenties, '+');
+            },
+            RFC3986: function (value) {
+                return String(value);
+            }
+        }
+    },
+    Format
+);
 
 
 /***/ }),
@@ -17640,11 +13399,11 @@ var parseValues = function parseQueryStringValues(str, options) {
 
         var key, val;
         if (pos === -1) {
-            key = options.decoder(part, defaults.decoder, charset);
+            key = options.decoder(part, defaults.decoder, charset, 'key');
             val = options.strictNullHandling ? null : '';
         } else {
-            key = options.decoder(part.slice(0, pos), defaults.decoder, charset);
-            val = options.decoder(part.slice(pos + 1), defaults.decoder, charset);
+            key = options.decoder(part.slice(0, pos), defaults.decoder, charset, 'key');
+            val = options.decoder(part.slice(pos + 1), defaults.decoder, charset, 'value');
         }
 
         if (val && options.interpretNumericEntities && charset === 'iso-8859-1') {
@@ -17715,7 +13474,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
 
     // Get the parent
 
-    var segment = brackets.exec(key);
+    var segment = options.depth > 0 && brackets.exec(key);
     var parent = segment ? key.slice(0, segment.index) : key;
 
     // Stash the parent if it exists
@@ -17735,7 +13494,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     // Loop through children appending to the array until we hit depth
 
     var i = 0;
-    while ((segment = child.exec(key)) !== null && i < options.depth) {
+    while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
         i += 1;
         if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
             if (!options.allowPrototypes) {
@@ -17777,7 +13536,8 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         comma: typeof opts.comma === 'boolean' ? opts.comma : defaults.comma,
         decoder: typeof opts.decoder === 'function' ? opts.decoder : defaults.decoder,
         delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
-        depth: typeof opts.depth === 'number' ? opts.depth : defaults.depth,
+        // eslint-disable-next-line no-implicit-coercion, no-extra-parens
+        depth: (typeof opts.depth === 'number' || opts.depth === false) ? +opts.depth : defaults.depth,
         ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
         interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
         parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,
@@ -17827,14 +13587,14 @@ var formats = __webpack_require__(/*! ./formats */ "./node_modules/qs/lib/format
 var has = Object.prototype.hasOwnProperty;
 
 var arrayPrefixGenerators = {
-    brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
+    brackets: function brackets(prefix) {
         return prefix + '[]';
     },
     comma: 'comma',
-    indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
+    indices: function indices(prefix, key) {
         return prefix + '[' + key + ']';
     },
-    repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
+    repeat: function repeat(prefix) {
         return prefix;
     }
 };
@@ -17847,6 +13607,7 @@ var pushToArray = function (arr, valueOrArray) {
 
 var toISO = Date.prototype.toISOString;
 
+var defaultFormat = formats['default'];
 var defaults = {
     addQueryPrefix: false,
     allowDots: false,
@@ -17856,17 +13617,26 @@ var defaults = {
     encode: true,
     encoder: utils.encode,
     encodeValuesOnly: false,
-    formatter: formats.formatters[formats['default']],
+    format: defaultFormat,
+    formatter: formats.formatters[defaultFormat],
     // deprecated
     indices: false,
-    serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
+    serializeDate: function serializeDate(date) {
         return toISO.call(date);
     },
     skipNulls: false,
     strictNullHandling: false
 };
 
-var stringify = function stringify( // eslint-disable-line func-name-matching
+var isNonNullishPrimitive = function isNonNullishPrimitive(v) {
+    return typeof v === 'string'
+        || typeof v === 'number'
+        || typeof v === 'boolean'
+        || typeof v === 'symbol'
+        || typeof v === 'bigint';
+};
+
+var stringify = function stringify(
     object,
     prefix,
     generateArrayPrefix,
@@ -17892,16 +13662,16 @@ var stringify = function stringify( // eslint-disable-line func-name-matching
 
     if (obj === null) {
         if (strictNullHandling) {
-            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset) : prefix;
+            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key') : prefix;
         }
 
         obj = '';
     }
 
-    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
+    if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
         if (encoder) {
-            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
-            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
+            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, 'key');
+            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset, 'value'))];
         }
         return [formatter(prefix) + '=' + formatter(String(obj))];
     }
@@ -18229,7 +13999,12 @@ var encode = function encode(str, defaultEncoder, charset) {
         return str;
     }
 
-    var string = typeof str === 'string' ? str : String(str);
+    var string = str;
+    if (typeof str === 'symbol') {
+        string = Symbol.prototype.toString.call(str);
+    } else if (typeof str !== 'string') {
+        string = String(str);
+    }
 
     if (charset === 'iso-8859-1') {
         return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
@@ -18353,7 +14128,7 @@ module.exports = {
 
 
 var isNumber = __webpack_require__(/*! is-number */ "./node_modules/randomatic/node_modules/is-number/index.js");
-var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/randomatic/node_modules/kind-of/index.js");
+var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
 var mathRandom = __webpack_require__(/*! math-random */ "./node_modules/math-random/browser.js");
 
 /**
@@ -18475,146 +14250,6 @@ module.exports = function isNumber(num) {
 
 /***/ }),
 
-/***/ "./node_modules/randomatic/node_modules/kind-of/index.js":
-/*!***************************************************************!*\
-  !*** ./node_modules/randomatic/node_modules/kind-of/index.js ***!
-  \***************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports) {
-
-var toString = Object.prototype.toString;
-
-module.exports = function kindOf(val) {
-  if (val === void 0) return 'undefined';
-  if (val === null) return 'null';
-
-  var type = typeof val;
-  if (type === 'boolean') return 'boolean';
-  if (type === 'string') return 'string';
-  if (type === 'number') return 'number';
-  if (type === 'symbol') return 'symbol';
-  if (type === 'function') {
-    return isGeneratorFn(val) ? 'generatorfunction' : 'function';
-  }
-
-  if (isArray(val)) return 'array';
-  if (isBuffer(val)) return 'buffer';
-  if (isArguments(val)) return 'arguments';
-  if (isDate(val)) return 'date';
-  if (isError(val)) return 'error';
-  if (isRegexp(val)) return 'regexp';
-
-  switch (ctorName(val)) {
-    case 'Symbol': return 'symbol';
-    case 'Promise': return 'promise';
-
-    // Set, Map, WeakSet, WeakMap
-    case 'WeakMap': return 'weakmap';
-    case 'WeakSet': return 'weakset';
-    case 'Map': return 'map';
-    case 'Set': return 'set';
-
-    // 8-bit typed arrays
-    case 'Int8Array': return 'int8array';
-    case 'Uint8Array': return 'uint8array';
-    case 'Uint8ClampedArray': return 'uint8clampedarray';
-
-    // 16-bit typed arrays
-    case 'Int16Array': return 'int16array';
-    case 'Uint16Array': return 'uint16array';
-
-    // 32-bit typed arrays
-    case 'Int32Array': return 'int32array';
-    case 'Uint32Array': return 'uint32array';
-    case 'Float32Array': return 'float32array';
-    case 'Float64Array': return 'float64array';
-  }
-
-  if (isGeneratorObj(val)) {
-    return 'generator';
-  }
-
-  // Non-plain objects
-  type = toString.call(val);
-  switch (type) {
-    case '[object Object]': return 'object';
-    // iterators
-    case '[object Map Iterator]': return 'mapiterator';
-    case '[object Set Iterator]': return 'setiterator';
-    case '[object String Iterator]': return 'stringiterator';
-    case '[object Array Iterator]': return 'arrayiterator';
-  }
-
-  // other
-  return type.slice(8, -1).toLowerCase().replace(/\s/g, '');
-};
-
-function ctorName(val) {
-  return val.constructor ? val.constructor.name : null;
-}
-
-function isArray(val) {
-  if (Array.isArray) return Array.isArray(val);
-  return val instanceof Array;
-}
-
-function isError(val) {
-  return val instanceof Error || (typeof val.message === 'string' && val.constructor && typeof val.constructor.stackTraceLimit === 'number');
-}
-
-function isDate(val) {
-  if (val instanceof Date) return true;
-  return typeof val.toDateString === 'function'
-    && typeof val.getDate === 'function'
-    && typeof val.setDate === 'function';
-}
-
-function isRegexp(val) {
-  if (val instanceof RegExp) return true;
-  return typeof val.flags === 'string'
-    && typeof val.ignoreCase === 'boolean'
-    && typeof val.multiline === 'boolean'
-    && typeof val.global === 'boolean';
-}
-
-function isGeneratorFn(name, val) {
-  return ctorName(name) === 'GeneratorFunction';
-}
-
-function isGeneratorObj(val) {
-  return typeof val.throw === 'function'
-    && typeof val.return === 'function'
-    && typeof val.next === 'function';
-}
-
-function isArguments(val) {
-  try {
-    if (typeof val.length === 'number' && typeof val.callee === 'function') {
-      return true;
-    }
-  } catch (err) {
-    if (err.message.indexOf('callee') !== -1) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * If you need to support Safari 5-7 (8-10 yr-old browser),
- * take a look at https://github.com/feross/is-buffer
- */
-
-function isBuffer(val) {
-  if (val.constructor && typeof val.constructor.isBuffer === 'function') {
-    return val.constructor.isBuffer(val);
-  }
-  return false;
-}
-
-
-/***/ }),
-
 /***/ "./node_modules/regex-cache/index.js":
 /*!*******************************************!*\
   !*** ./node_modules/regex-cache/index.js ***!
@@ -18691,6 +14326,147 @@ function memo(key, opts, regex) {
 
 module.exports.cache = cache;
 module.exports.basic = basic;
+
+
+/***/ }),
+
+/***/ "./node_modules/regexp.prototype.flags/implementation.js":
+/*!***************************************************************!*\
+  !*** ./node_modules/regexp.prototype.flags/implementation.js ***!
+  \***************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var toObject = Object;
+var TypeErr = TypeError;
+
+module.exports = function flags() {
+	if (this != null && this !== toObject(this)) {
+		throw new TypeErr('RegExp.prototype.flags getter called on non-object');
+	}
+	var result = '';
+	if (this.global) {
+		result += 'g';
+	}
+	if (this.ignoreCase) {
+		result += 'i';
+	}
+	if (this.multiline) {
+		result += 'm';
+	}
+	if (this.dotAll) {
+		result += 's';
+	}
+	if (this.unicode) {
+		result += 'u';
+	}
+	if (this.sticky) {
+		result += 'y';
+	}
+	return result;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/regexp.prototype.flags/index.js":
+/*!******************************************************!*\
+  !*** ./node_modules/regexp.prototype.flags/index.js ***!
+  \******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var define = __webpack_require__(/*! define-properties */ "./node_modules/define-properties/index.js");
+
+var implementation = __webpack_require__(/*! ./implementation */ "./node_modules/regexp.prototype.flags/implementation.js");
+var getPolyfill = __webpack_require__(/*! ./polyfill */ "./node_modules/regexp.prototype.flags/polyfill.js");
+var shim = __webpack_require__(/*! ./shim */ "./node_modules/regexp.prototype.flags/shim.js");
+
+var flagsBound = Function.call.bind(implementation);
+
+define(flagsBound, {
+	getPolyfill: getPolyfill,
+	implementation: implementation,
+	shim: shim
+});
+
+module.exports = flagsBound;
+
+
+/***/ }),
+
+/***/ "./node_modules/regexp.prototype.flags/polyfill.js":
+/*!*********************************************************!*\
+  !*** ./node_modules/regexp.prototype.flags/polyfill.js ***!
+  \*********************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var implementation = __webpack_require__(/*! ./implementation */ "./node_modules/regexp.prototype.flags/implementation.js");
+
+var supportsDescriptors = __webpack_require__(/*! define-properties */ "./node_modules/define-properties/index.js").supportsDescriptors;
+var gOPD = Object.getOwnPropertyDescriptor;
+var TypeErr = TypeError;
+
+module.exports = function getPolyfill() {
+	if (!supportsDescriptors) {
+		throw new TypeErr('RegExp.prototype.flags requires a true ES5 environment that supports property descriptors');
+	}
+	if (/a/mig.flags === 'gim') {
+		var descriptor = gOPD(RegExp.prototype, 'flags');
+		if (descriptor && typeof descriptor.get === 'function' && typeof (/a/).dotAll === 'boolean') {
+			return descriptor.get;
+		}
+	}
+	return implementation;
+};
+
+
+/***/ }),
+
+/***/ "./node_modules/regexp.prototype.flags/shim.js":
+/*!*****************************************************!*\
+  !*** ./node_modules/regexp.prototype.flags/shim.js ***!
+  \*****************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var supportsDescriptors = __webpack_require__(/*! define-properties */ "./node_modules/define-properties/index.js").supportsDescriptors;
+var getPolyfill = __webpack_require__(/*! ./polyfill */ "./node_modules/regexp.prototype.flags/polyfill.js");
+var gOPD = Object.getOwnPropertyDescriptor;
+var defineProperty = Object.defineProperty;
+var TypeErr = TypeError;
+var getProto = Object.getPrototypeOf;
+var regex = /a/;
+
+module.exports = function shimFlags() {
+	if (!supportsDescriptors || !getProto) {
+		throw new TypeErr('RegExp.prototype.flags requires a true ES5 environment that supports property descriptors');
+	}
+	var polyfill = getPolyfill();
+	var proto = getProto(regex);
+	var descriptor = gOPD(proto, 'flags');
+	if (!descriptor || descriptor.get !== polyfill) {
+		defineProperty(proto, 'flags', {
+			configurable: true,
+			enumerable: false,
+			get: polyfill
+		});
+	}
+	return polyfill;
+};
 
 
 /***/ }),
@@ -19005,7 +14781,7 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! @sfx/core */ "./packages/@sfx/core/src/index.ts"));
+__export(__webpack_require__(/*! @sfx/core */ "./packages/@sfx/core/dist/index.js"));
 
 
 /***/ }),
@@ -19023,11 +14799,11 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! @sfx/dom-events-plugin */ "./packages/@sfx/dom-events-plugin/src/index.ts"));
-__export(__webpack_require__(/*! @sfx/sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/src/index.ts"));
-__export(__webpack_require__(/*! @sfx/sayt-plugin */ "./packages/@sfx/sayt-plugin/src/index.ts"));
-__export(__webpack_require__(/*! @sfx/search-driver-plugin */ "./packages/@sfx/search-driver-plugin/src/index.ts"));
-__export(__webpack_require__(/*! @sfx/search-plugin */ "./packages/@sfx/search-plugin/src/index.ts"));
+__export(__webpack_require__(/*! @sfx/dom-events-plugin */ "./packages/@sfx/dom-events-plugin/dist/index.js"));
+__export(__webpack_require__(/*! @sfx/sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/dist/index.js"));
+__export(__webpack_require__(/*! @sfx/sayt-plugin */ "./packages/@sfx/sayt-plugin/dist/index.js"));
+__export(__webpack_require__(/*! @sfx/search-driver-plugin */ "./packages/@sfx/search-driver-plugin/dist/index.js"));
+__export(__webpack_require__(/*! @sfx/search-plugin */ "./packages/@sfx/search-plugin/dist/index.js"));
 
 
 /***/ }),
@@ -19063,17 +14839,18 @@ module.exports = g;
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/src/core.ts":
-/*!****************************************!*\
-  !*** ./packages/@sfx/core/src/core.ts ***!
-  \****************************************/
+/***/ "./packages/@sfx/core/dist/core.js":
+/*!*****************************************!*\
+  !*** ./packages/@sfx/core/dist/core.js ***!
+  \*****************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var core_1 = __webpack_require__(/*! ./utils/core */ "./packages/@sfx/core/src/utils/core.ts");
+var core_1 = __webpack_require__(/*! ./utils/core */ "./packages/@sfx/core/dist/utils/core.js");
+var dependencies_1 = __webpack_require__(/*! ./utils/dependencies */ "./packages/@sfx/core/dist/utils/dependencies.js");
 /**
  * The core of the SF-X plugin system. This entity is responsible for
  * managing plugins and provides a mechanism for plugins to communicate
@@ -19097,6 +14874,12 @@ var Core = /** @class */ (function () {
          * Plugins do not have access to this directory.
          */
         this.directory = Object.create(null);
+        /**
+         * An object with plugin names mapped to the names of the plugins that
+         * depend on it. This dependency graph is represented as an adjacency
+         * list.
+         */
+        this.dependencyGraph = dependencies_1.createDependencyGraph();
     }
     /**
      * Register one or more plugins with Core.
@@ -19126,53 +14909,76 @@ var Core = /** @class */ (function () {
     Core.prototype.register = function (plugins) {
         var missingDependencies = core_1.calculateMissingDependencies(plugins, this.registry);
         if (missingDependencies.length) {
-            throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
+            throw new Error("Missing dependencies: " + missingDependencies.join(', '));
         }
         core_1.registerPlugins(plugins, this.registry, this.directory);
+        this.dependencyGraph = dependencies_1.mergeDependencyGraphs(this.dependencyGraph, dependencies_1.createDependencyGraph(plugins));
         core_1.initPlugins(plugins);
         core_1.readyPlugins(plugins);
     };
     /**
-     * Unregisters all plugins. The plugin registry and directory are both
-     * cleared. The optional `unregister` function of each plugin is
-     * called when the plugin is unregistered. The order in which the
-     * plugins are unregistered is unspecified.
+     * Unregisters the given plugins. The plugin registry, directory and
+     * dependency graph are all updated. The optional `unregister`
+     * function of each plugin is called when the plugin is unregistered.
+     * The order in which the plugins are unregistered is unspecified.
+     *
+     * @param plugins The names of the plugins to unregister.
+     * @throws If unregistering a plugin will break a dependency.
+     */
+    Core.prototype.unregister = function (plugins) {
+        var updatedGraph = dependencies_1.removeFromDependencyGraph(this.dependencyGraph, plugins);
+        core_1.unregisterPlugins(plugins, this.registry, this.directory);
+        this.dependencyGraph = updatedGraph;
+    };
+    /**
+     * Unregisters all plugins. The plugin registry, directory and
+     * dependency graph are all cleared. The optional `unregister`
+     * function of each plugin is called when the plugin is unregistered.
+     * The order in which the plugins are unregistered is unspecified.
      */
     Core.prototype.unregisterAll = function () {
         core_1.unregisterPlugins(Object.keys(this.directory), this.registry, this.directory);
+        this.dependencyGraph = dependencies_1.createDependencyGraph();
     };
     return Core;
 }());
 exports.default = Core;
-
+//# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/src/index.ts":
-/*!*****************************************!*\
-  !*** ./packages/@sfx/core/src/index.ts ***!
-  \*****************************************/
+/***/ "./packages/@sfx/core/dist/index.js":
+/*!******************************************!*\
+  !*** ./packages/@sfx/core/dist/index.js ***!
+  \******************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var core_1 = __webpack_require__(/*! ./core */ "./packages/@sfx/core/src/core.ts");
+var core_1 = __webpack_require__(/*! ./core */ "./packages/@sfx/core/dist/core.js");
 exports.Core = core_1.default;
-
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/src/utils/core.ts":
-/*!**********************************************!*\
-  !*** ./packages/@sfx/core/src/utils/core.ts ***!
-  \**********************************************/
+/***/ "./packages/@sfx/core/dist/utils/core.js":
+/*!***********************************************!*\
+  !*** ./packages/@sfx/core/dist/utils/core.js ***!
+  \***********************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * Calculates the missing dependencies of the given plugins. The given
@@ -19184,13 +14990,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * @returns An array of names of missing plugins.
  */
 function calculateMissingDependencies(plugins, registry) {
-    var available = Object.keys(registry).concat(plugins.map(function (_a) {
+    var available = __spreadArrays(Object.keys(registry), plugins.map(function (_a) {
         var name = _a.metadata.name;
         return name;
     }));
-    var required = plugins.reduce(function (memo, plugin) {
-        return memo.concat(plugin.metadata.depends);
-    }, []);
+    var required = plugins.reduce(function (memo, plugin) { return __spreadArrays(memo, plugin.metadata.depends); }, []);
     var availableSet = new Set(available);
     var requiredSet = new Set(required);
     var difference = new Set(Array.from(requiredSet).filter(function (p) { return !availableSet.has(p); }));
@@ -19249,7 +15053,8 @@ function readyPlugins(plugins) {
 exports.readyPlugins = readyPlugins;
 /**
  * Unregisters the plugins with the given names from the given registry
- * and directory.
+ * and directory. It is safe to attempt to unregister a plugin that is
+ * not registered.
  *
  * @param names The names of the plugins to unregister.
  * @param registry The registry from which to unregister the plugin's
@@ -19259,7 +15064,7 @@ exports.readyPlugins = readyPlugins;
 function unregisterPlugins(names, registry, directory) {
     names.forEach(function (name) {
         var plugin = directory[name];
-        if (typeof plugin.unregister === 'function') {
+        if (plugin && typeof plugin.unregister === 'function') {
             plugin.unregister();
         }
     });
@@ -19269,14 +15074,110 @@ function unregisterPlugins(names, registry, directory) {
     });
 }
 exports.unregisterPlugins = unregisterPlugins;
-
+//# sourceMappingURL=core.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/dom-events-plugin/src/dom-events-plugin.ts":
-/*!******************************************************************!*\
-  !*** ./packages/@sfx/dom-events-plugin/src/dom-events-plugin.ts ***!
-  \******************************************************************/
+/***/ "./packages/@sfx/core/dist/utils/dependencies.js":
+/*!*******************************************************!*\
+  !*** ./packages/@sfx/core/dist/utils/dependencies.js ***!
+  \*******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Creates an empty dependency graph.
+ *
+ * @returns An empty dependency graph.
+ * @hidden
+ */
+function createEmptyGraph() {
+    return Object.create(null);
+}
+/**
+ * Builds a dependency graph from the given plugins.
+ *
+ * @param plugins The plugins from which to build the graph.
+ * @returns The completed dependency graph.
+ */
+function createDependencyGraph(plugins) {
+    if (plugins === void 0) { plugins = []; }
+    var dependencyGraph = createEmptyGraph();
+    plugins.forEach(function (_a) {
+        var _b = _a.metadata, name = _b.name, depends = _b.depends;
+        if (!dependencyGraph[name])
+            dependencyGraph[name] = [];
+        depends.forEach(function (dependency) {
+            if (!dependencyGraph[dependency])
+                dependencyGraph[dependency] = [];
+            dependencyGraph[dependency].push(name);
+        });
+    });
+    return dependencyGraph;
+}
+exports.createDependencyGraph = createDependencyGraph;
+/**
+ * Deeply merges the given dependency graphs without modifying the
+ * original graphs. When a property exists in more than one graph, the
+ * corresponding arrays are concatenated.
+ *
+ * @param graphs The dependency graphs to merge.
+ * @returns The merged dependency graph.
+ */
+function mergeDependencyGraphs() {
+    var graphs = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        graphs[_i] = arguments[_i];
+    }
+    return graphs.reduce(function (merged, graph) {
+        Object.keys(graph).forEach(function (key) {
+            var _a;
+            if (!merged[key])
+                merged[key] = [];
+            (_a = merged[key]).push.apply(_a, graph[key]);
+        });
+        return merged;
+    }, createEmptyGraph());
+}
+exports.mergeDependencyGraphs = mergeDependencyGraphs;
+/**
+ * Removes the specified names from the given dependency graph. The
+ * corresponding properties are deleted and the dependency lists are
+ * updated. The original graph is not modified. It is safe to attempt to
+ * remove a name that is not in the graph.
+ *
+ * @param graph The graph to remove plugins from.
+ * @param names The names of the plugins to remove from the graph.
+ * @returns The resulting graph with the given names removed.
+ * @throws If one or more names cannot be removed from the graph without
+ *         breaking a dependency.
+ */
+function removeFromDependencyGraph(graph, names) {
+    var namesSet = new Set(names);
+    var newGraph = Object.keys(graph).reduce(function (clone, plugin) {
+        clone[plugin] = graph[plugin].filter(function (depender) { return !namesSet.has(depender); });
+        return clone;
+    }, createEmptyGraph());
+    var errors = names
+        .filter(function (name) { return newGraph[name] && newGraph[name].length > 0; })
+        .map(function (name) { return name + " is required by: " + newGraph[name].join(', ') + "."; });
+    if (errors.length > 0)
+        throw new Error("Failed to remove dependencies.\n" + errors.join('\n'));
+    names.forEach(function (name) { delete newGraph[name]; });
+    return newGraph;
+}
+exports.removeFromDependencyGraph = removeFromDependencyGraph;
+//# sourceMappingURL=dependencies.js.map
+
+/***/ }),
+
+/***/ "./packages/@sfx/dom-events-plugin/dist/dom-events-plugin.js":
+/*!*******************************************************************!*\
+  !*** ./packages/@sfx/dom-events-plugin/dist/dom-events-plugin.js ***!
+  \*******************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -19319,7 +15220,7 @@ var DomEventsPlugin = /** @class */ (function () {
             window: typeof window !== 'undefined' ? window : undefined,
             CustomEvent: typeof CustomEvent !== 'undefined' ? CustomEvent : undefined,
         };
-        this.options = __assign({}, this.options, options);
+        this.options = __assign(__assign({}, this.options), options);
         this.window = this.options.window;
         this.CustomEvent = this.options.CustomEvent;
         if (!this.window) {
@@ -19374,6 +15275,7 @@ var DomEventsPlugin = /** @class */ (function () {
     /**
      * @see [[DomEventsPluginExposedValue.dispatchEvent]]
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     DomEventsPlugin.prototype.dispatchEvent = function (eventName, payload) {
         var eventToDispatch = new this.CustomEvent(eventName, { detail: payload });
         this.window.dispatchEvent(eventToDispatch);
@@ -19381,29 +15283,13 @@ var DomEventsPlugin = /** @class */ (function () {
     return DomEventsPlugin;
 }());
 exports.default = DomEventsPlugin;
-
-
-/***/ }),
-
-/***/ "./packages/@sfx/dom-events-plugin/src/index.ts":
-/*!******************************************************!*\
-  !*** ./packages/@sfx/dom-events-plugin/src/index.ts ***!
-  \******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-var dom_events_plugin_1 = __webpack_require__(/*! ./dom-events-plugin */ "./packages/@sfx/dom-events-plugin/src/dom-events-plugin.ts");
-exports.DomEventsPlugin = dom_events_plugin_1.default;
-
+//# sourceMappingURL=dom-events-plugin.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-driver-plugin/src/index.ts":
+/***/ "./packages/@sfx/dom-events-plugin/dist/index.js":
 /*!*******************************************************!*\
-  !*** ./packages/@sfx/sayt-driver-plugin/src/index.ts ***!
+  !*** ./packages/@sfx/dom-events-plugin/dist/index.js ***!
   \*******************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
@@ -19411,22 +15297,51 @@ exports.DomEventsPlugin = dom_events_plugin_1.default;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var sayt_driver_plugin_1 = __webpack_require__(/*! ./sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts");
-exports.SaytDriverPlugin = sayt_driver_plugin_1.default;
-
+var dom_events_plugin_1 = __webpack_require__(/*! ./dom-events-plugin */ "./packages/@sfx/dom-events-plugin/dist/dom-events-plugin.js");
+exports.DomEventsPlugin = dom_events_plugin_1.default;
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts":
-/*!********************************************************************!*\
-  !*** ./packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts ***!
-  \********************************************************************/
+/***/ "./packages/@sfx/sayt-driver-plugin/dist/index.js":
+/*!********************************************************!*\
+  !*** ./packages/@sfx/sayt-driver-plugin/dist/index.js ***!
+  \********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+// eslint-disable-next-line import/prefer-default-export
+var sayt_driver_plugin_1 = __webpack_require__(/*! ./sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/dist/sayt-driver-plugin.js");
+exports.SaytDriverPlugin = sayt_driver_plugin_1.default;
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ "./packages/@sfx/sayt-driver-plugin/dist/sayt-driver-plugin.js":
+/*!*********************************************************************!*\
+  !*** ./packages/@sfx/sayt-driver-plugin/dist/sayt-driver-plugin.js ***!
+  \*********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var events_1 = __webpack_require__(/*! @sfx/events */ "../sfx-events/dist/index.js");
 /**
  * Driver plugin that serves as the link between the Sayt data source
  * and the View layer. This plugin is responsible for listening to events,
@@ -19434,25 +15349,35 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * and then emitting the API response back in an event.
  */
 var SaytDriverPlugin = /** @class */ (function () {
-    function SaytDriverPlugin() {
+    /**
+     * Binds relevant functions. Sets transformProduct property if a
+     * product transformer function is passed.
+     */
+    function SaytDriverPlugin(options) {
         /**
          * Name of the events plugin.
          */
         this.eventsPluginName = 'dom_events';
         /**
-         * Event name to listen for Sayt autocomplete requests.
+         * Provide default configuration for SAYT product searches.
          */
-        this.saytDataEvent = 'sfx::autocomplete_fetch_data';
+        this.defaultSearchConfig = {
+            fields: ['*'],
+        };
         /**
-         * Event name for sending Sayt autocomplete responses.
+         * Default product transformer identity function.
+         * Intended to be overwritten by passing a custom product transformer.
+         *
+         * @param product The product to be returned as-is.
          */
-        this.saytResponseEvent = 'sfx::autocomplete_received_results';
-        /**
-         * Event name to listen for Sayt autocomplete errors.
-         */
-        this.saytErrorEvent = 'sfx::autocomplete_sayt_error';
-        this.fetchSaytData = this.fetchSaytData.bind(this);
+        this.transformProduct = (function (product) { return product; });
+        this.fetchAutocompleteTerms = this.fetchAutocompleteTerms.bind(this);
+        this.fetchProductData = this.fetchProductData.bind(this);
         this.autocompleteCallback = this.autocompleteCallback.bind(this);
+        this.searchCallback = this.searchCallback.bind(this);
+        if (options && options.productTransformer) {
+            this.transformProduct = options.productTransformer;
+        }
     }
     Object.defineProperty(SaytDriverPlugin.prototype, "metadata", {
         get: function () {
@@ -19461,6 +15386,7 @@ var SaytDriverPlugin = /** @class */ (function () {
                 depends: [
                     this.eventsPluginName,
                     'sayt',
+                    'search',
                 ],
             };
         },
@@ -19478,49 +15404,84 @@ var SaytDriverPlugin = /** @class */ (function () {
     };
     /**
      * Lifecycle event where the plugin can first safely interact with the registry.
-     * The method will register an event listener for listening to Sayt data requests
-     * and trigger its callback for making search requests.
+     * The method will register an event listener for Sayt and product data requests.
      */
     SaytDriverPlugin.prototype.ready = function () {
-        this.core[this.eventsPluginName].registerListener(this.saytDataEvent, this.fetchSaytData);
+        this.core[this.eventsPluginName].registerListener(events_1.AUTOCOMPLETE_REQUEST, this.fetchAutocompleteTerms);
+        this.core[this.eventsPluginName].registerListener(events_1.SAYT_PRODUCTS_REQUEST, this.fetchProductData);
     };
     /**
      * Lifecycle event where the plugin will unregister all event listeners.
      */
     SaytDriverPlugin.prototype.unregister = function () {
-        this.core[this.eventsPluginName].unregisterListener(this.saytDataEvent, this.fetchSaytData);
+        this.core[this.eventsPluginName].unregisterListener(events_1.AUTOCOMPLETE_REQUEST, this.fetchAutocompleteTerms);
+        this.core[this.eventsPluginName].unregisterListener(events_1.SAYT_PRODUCTS_REQUEST, this.fetchProductData);
     };
     /**
-     * Dispatches an event with the response from the sayt data plugin and the associated searchbox ID.
-     * Callback for the Sayt data request event listener.
+     * Sends a request to the Sayt API for autocomplete terms and dispatches
+     * events on success and failure.
      *
      * @param event Event that contains the Sayt API request payload.
      */
-    SaytDriverPlugin.prototype.fetchSaytData = function (event) {
+    SaytDriverPlugin.prototype.fetchAutocompleteTerms = function (event) {
         var _this = this;
-        var _a = event.detail, query = _a.query, searchbox = _a.searchbox, config = _a.config;
-        this.sendSaytApiRequest(query, config)
+        var _a = event.detail, query = _a.query, group = _a.group, config = _a.config;
+        this.sendAutocompleteApiRequest(query, config)
             .then(function (results) {
-            _this.core[_this.eventsPluginName].dispatchEvent(_this.saytResponseEvent, { results: results, searchbox: searchbox });
+            var payload = { results: results, group: group };
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.AUTOCOMPLETE_RESPONSE, payload);
         })
-            .catch(function (e) {
-            _this.core[_this.eventsPluginName].dispatchEvent(_this.saytErrorEvent, e);
+            .catch(function (error) {
+            var payload = { error: error, group: group };
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.AUTOCOMPLETE_ERROR, payload);
+        });
+    };
+    /**
+     * Sends a request to the Search API for product data and dispatches
+     * events on success and failure.
+     *
+     * @param event Event that contains the Search API request payload.
+     */
+    SaytDriverPlugin.prototype.fetchProductData = function (event) {
+        var _this = this;
+        var _a = event.detail, query = _a.query, group = _a.group, config = _a.config;
+        this.sendSearchApiRequest(query, config)
+            .then(function (results) {
+            var payload = __assign(__assign({}, results), { group: group });
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SAYT_PRODUCTS_RESPONSE, payload);
+        })
+            .catch(function (error) {
+            var payload = { error: error, group: group };
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SAYT_PRODUCTS_ERROR, payload);
         });
     };
     /**
      * Sends a request to the SAYT API with the given query and config object.
      *
-     * @param saytDataQuery Request object received from the event listener.
+     * @param query The search term to send.
+     * @param config Extra query-time configuration to customize the SAYT request.
      * @returns A promise from the Sayt API that has been reformatted
      * with the passed callback.
      */
-    SaytDriverPlugin.prototype.sendSaytApiRequest = function (query, config) {
+    SaytDriverPlugin.prototype.sendAutocompleteApiRequest = function (query, config) {
         return this.core.sayt.autocomplete(query, config).then(this.autocompleteCallback);
+    };
+    /**
+     * Sends a request to the Search API with the given query and config object.
+     *
+     * @param query The search term to send.
+     * @param config Extra query-time configuration to customize the Search request.
+     * @returns A promise from the Search API that has been reformatted
+     * with the passed callback.
+     */
+    SaytDriverPlugin.prototype.sendSearchApiRequest = function (query, config) {
+        return this.core.search.search(__assign(__assign(__assign({}, this.defaultSearchConfig), { query: query }), config))
+            .then(this.searchCallback);
     };
     /**
      * Extracts search terms from the given response.
      *
-     * @param response An array search term strings.
+     * @param response An array of search term strings.
      * @returns An array of search term strings.
      */
     SaytDriverPlugin.prototype.autocompleteCallback = function (response) {
@@ -19533,6 +15494,24 @@ var SaytDriverPlugin = /** @class */ (function () {
         return [searchTerms];
     };
     /**
+     * Extracts query and products from the given response.
+     * Calls `this.transformProduct` on each product found in the response.
+     * Filters out any products that map to a falsy value.
+     *
+     * @param response An object containing the original search response.
+     * @returns An object containing an array of valid simplified products and the original response.
+     */
+    SaytDriverPlugin.prototype.searchCallback = function (searchResponse) {
+        var records = searchResponse.records;
+        var mappedRecords = records
+            .map(this.transformProduct)
+            .filter(Boolean);
+        return {
+            products: mappedRecords,
+            originalResponse: searchResponse,
+        };
+    };
+    /**
      * Formats a given list of search terms.
      *
      * @param terms An array of search terms.
@@ -19540,21 +15519,19 @@ var SaytDriverPlugin = /** @class */ (function () {
      */
     SaytDriverPlugin.prototype.constructSearchTerms = function (terms) {
         return terms.filter(function (term) { return term.value; })
-            .map(function (term) {
-            return { label: term.value };
-        });
+            .map(function (term) { return ({ label: term.value }); });
     };
     return SaytDriverPlugin;
 }());
 exports.default = SaytDriverPlugin;
-
+//# sourceMappingURL=sayt-driver-plugin.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-plugin/src/index.ts":
-/*!************************************************!*\
-  !*** ./packages/@sfx/sayt-plugin/src/index.ts ***!
-  \************************************************/
+/***/ "./packages/@sfx/sayt-plugin/dist/index.js":
+/*!*************************************************!*\
+  !*** ./packages/@sfx/sayt-plugin/dist/index.js ***!
+  \*************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -19564,17 +15541,17 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-var sayt_plugin_1 = __webpack_require__(/*! ./sayt-plugin */ "./packages/@sfx/sayt-plugin/src/sayt-plugin.ts");
+var sayt_plugin_1 = __webpack_require__(/*! ./sayt-plugin */ "./packages/@sfx/sayt-plugin/dist/sayt-plugin.js");
 exports.SaytPlugin = sayt_plugin_1.default;
 __export(__webpack_require__(/*! sayt */ "./node_modules/sayt/index.js"));
-
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-plugin/src/sayt-plugin.ts":
-/*!******************************************************!*\
-  !*** ./packages/@sfx/sayt-plugin/src/sayt-plugin.ts ***!
-  \******************************************************/
+/***/ "./packages/@sfx/sayt-plugin/dist/sayt-plugin.js":
+/*!*******************************************************!*\
+  !*** ./packages/@sfx/sayt-plugin/dist/sayt-plugin.js ***!
+  \*******************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -19615,13 +15592,13 @@ var SaytPlugin = /** @class */ (function () {
     return SaytPlugin;
 }());
 exports.default = SaytPlugin;
-
+//# sourceMappingURL=sayt-plugin.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-driver-plugin/src/events.ts":
+/***/ "./packages/@sfx/search-driver-plugin/dist/index.js":
 /*!**********************************************************!*\
-  !*** ./packages/@sfx/search-driver-plugin/src/events.ts ***!
+  !*** ./packages/@sfx/search-driver-plugin/dist/index.js ***!
   \**********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
@@ -19629,50 +15606,35 @@ exports.default = SaytPlugin;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * Fired to request a search. Its payload is the search term to use.
- */
-exports.SEARCH_REQUEST_EVENT = 'sfx::search_request';
-/**
- * Fired when a search response has been received from the server.
- * The payload is the search response.
- */
-exports.SEARCH_RESPONSE_EVENT = 'sfx::search_response';
-/**
- * Fired when an error has occurred during a search request.
- */
-exports.SEARCH_ERROR_EVENT = 'sfx::search_error';
-
-
-/***/ }),
-
-/***/ "./packages/@sfx/search-driver-plugin/src/index.ts":
-/*!*********************************************************!*\
-  !*** ./packages/@sfx/search-driver-plugin/src/index.ts ***!
-  \*********************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-var search_driver_plugin_1 = __webpack_require__(/*! ./search-driver-plugin */ "./packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts");
+// eslint-disable-next-line import/prefer-default-export
+var search_driver_plugin_1 = __webpack_require__(/*! ./search-driver-plugin */ "./packages/@sfx/search-driver-plugin/dist/search-driver-plugin.js");
 exports.SearchDriverPlugin = search_driver_plugin_1.default;
-
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts":
-/*!************************************************************************!*\
-  !*** ./packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts ***!
-  \************************************************************************/
+/***/ "./packages/@sfx/search-driver-plugin/dist/search-driver-plugin.js":
+/*!*************************************************************************!*\
+  !*** ./packages/@sfx/search-driver-plugin/dist/search-driver-plugin.js ***!
+  \*************************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-var events_1 = __webpack_require__(/*! ./events */ "./packages/@sfx/search-driver-plugin/src/events.ts");
+var events_1 = __webpack_require__(/*! @sfx/events */ "../sfx-events/dist/index.js");
 /**
  * This plugin is responsible for exposing events that allow
  * for interacting with GroupBy's Search API.
@@ -19682,12 +15644,29 @@ var SearchDriverPlugin = /** @class */ (function () {
      * Constructs a new instance of the plugin and binds the necessary
      * callbacks.
      */
-    function SearchDriverPlugin() {
+    function SearchDriverPlugin(options) {
         /**
          * Name of the events plugin.
          */
         this.eventsPluginName = 'dom_events';
+        /**
+         * Default configuration for all searches.
+         */
+        this.defaultSearchConfig = {
+            fields: ['*'],
+        };
+        /**
+         * Default product transformer identity function.
+         * Intended to be overwritten by passing a custom product transformer.
+         *
+         * @param product The product to be returned as-is.
+         */
+        this.transformProduct = (function (product) { return product; });
         this.fetchSearchData = this.fetchSearchData.bind(this);
+        this.searchCallback = this.searchCallback.bind(this);
+        if (options && options.productTransformer) {
+            this.transformProduct = options.productTransformer;
+        }
     }
     Object.defineProperty(SearchDriverPlugin.prototype, "metadata", {
         get: function () {
@@ -19711,34 +15690,36 @@ var SearchDriverPlugin = /** @class */ (function () {
     /**
      * Registers event listeners. The following events are listened for:
      *
-     * - [[SEARCH_REQUEST_EVENT]]
+     * - [[SEARCH_REQUEST]]
      */
     SearchDriverPlugin.prototype.ready = function () {
-        this.core[this.eventsPluginName].registerListener(events_1.SEARCH_REQUEST_EVENT, this.fetchSearchData);
+        this.core[this.eventsPluginName].registerListener(events_1.SEARCH_REQUEST, this.fetchSearchData);
     };
     /**
      * Unregisters event listeners.
      */
     SearchDriverPlugin.prototype.unregister = function () {
-        this.core[this.eventsPluginName].unregisterListener(events_1.SEARCH_REQUEST_EVENT, this.fetchSearchData);
+        this.core[this.eventsPluginName].unregisterListener(events_1.SEARCH_REQUEST, this.fetchSearchData);
     };
     /**
      * Performs a search with the given search term and emits the result
      * through an event. The result is emitted in a
-     * [[SEARCH_RESPONSE_EVENT]] event. If the search fails for any
-     * reason, a [[SEARCH_ERROR_EVENT]] is dispatched with the error.
+     * [[SEARCH_RESPONSE]] event. If the search fails for any
+     * reason, a [[SEARCH_ERROR]] is dispatched with the error.
      *
      * @param event the event whose payload is the search term.
      */
     SearchDriverPlugin.prototype.fetchSearchData = function (event) {
         var _this = this;
-        var searchTerm = event.detail;
-        this.sendSearchApiRequest(searchTerm)
+        var _a = event.detail, query = _a.query, group = _a.group;
+        this.sendSearchApiRequest(query)
             .then(function (results) {
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_RESPONSE_EVENT, results);
+            var payload = { results: results, group: group };
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_RESPONSE, payload);
         })
-            .catch(function (e) {
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_ERROR_EVENT, e);
+            .catch(function (error) {
+            var payload = { error: error, group: group };
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_ERROR, payload);
         });
     };
     /**
@@ -19747,19 +15728,39 @@ var SearchDriverPlugin = /** @class */ (function () {
      * @param query the query to send.
      */
     SearchDriverPlugin.prototype.sendSearchApiRequest = function (query) {
-        return this.core.search.search(query);
+        var fullQuery = __assign(__assign({}, this.defaultSearchConfig), { query: query });
+        return this.core.search.search(fullQuery)
+            .then(this.searchCallback);
+    };
+    /**
+     * Extracts query and products from the given response.
+     * Calls `this.transformProduct` on each product found in the response.
+     * Filters out any products that map to a falsy value.
+     *
+     * @param response An object containing the original query and product records.
+     * @returns An object containing the query and an array of valid simplified products.
+     */
+    SearchDriverPlugin.prototype.searchCallback = function (response) {
+        var records = response.records;
+        var mappedRecords = records
+            .map(this.transformProduct)
+            .filter(Boolean);
+        return {
+            originalResponse: response,
+            products: mappedRecords,
+        };
     };
     return SearchDriverPlugin;
 }());
 exports.default = SearchDriverPlugin;
-
+//# sourceMappingURL=search-driver-plugin.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-plugin/src/index.ts":
-/*!**************************************************!*\
-  !*** ./packages/@sfx/search-plugin/src/index.ts ***!
-  \**************************************************/
+/***/ "./packages/@sfx/search-plugin/dist/index.js":
+/*!***************************************************!*\
+  !*** ./packages/@sfx/search-plugin/dist/index.js ***!
+  \***************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -19769,17 +15770,17 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-var search_plugin_1 = __webpack_require__(/*! ./search-plugin */ "./packages/@sfx/search-plugin/src/search-plugin.ts");
+var search_plugin_1 = __webpack_require__(/*! ./search-plugin */ "./packages/@sfx/search-plugin/dist/search-plugin.js");
 exports.SearchPlugin = search_plugin_1.default;
-__export(__webpack_require__(/*! groupby-api */ "../../api-javascript/dist/index.js"));
-
+__export(__webpack_require__(/*! groupby-api */ "./node_modules/groupby-api/dist/index.js"));
+//# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-plugin/src/search-plugin.ts":
-/*!**********************************************************!*\
-  !*** ./packages/@sfx/search-plugin/src/search-plugin.ts ***!
-  \**********************************************************/
+/***/ "./packages/@sfx/search-plugin/dist/search-plugin.js":
+/*!***********************************************************!*\
+  !*** ./packages/@sfx/search-plugin/dist/search-plugin.js ***!
+  \***********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -19797,7 +15798,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-var groupby_api_1 = __webpack_require__(/*! groupby-api */ "../../api-javascript/dist/index.js");
+var groupby_api_1 = __webpack_require__(/*! groupby-api */ "./node_modules/groupby-api/dist/index.js");
 /**
  * This plugin exposes an instance of the GroupBy search client.
  */
@@ -19835,7 +15836,7 @@ var SearchPlugin = /** @class */ (function () {
     return SearchPlugin;
 }());
 exports.default = SearchPlugin;
-
+//# sourceMappingURL=search-plugin.js.map
 
 /***/ }),
 

--- a/demo/temp/sfx-all-plugins-bundle.js
+++ b/demo/temp/sfx-all-plugins-bundle.js
@@ -86,185 +86,600 @@
 /************************************************************************/
 /******/ ({
 
-/***/ "../sfx-events/dist/index.js":
-/*!***********************************!*\
-  !*** ../sfx-events/dist/index.js ***!
-  \***********************************/
+/***/ "../../api-javascript/dist/core/bridge.js":
+/*!*************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/dist/core/bridge.js ***!
+  \*************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b)
+                if (b.hasOwnProperty(p))
+                    d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s)
+                if (Object.prototype.hasOwnProperty.call(s, p))
+                    t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var clone = __webpack_require__(/*! clone */ "../../api-javascript/node_modules/clone/clone.js");
+var fetchPonyfill = __webpack_require__(/*! fetch-ponyfill */ "../../api-javascript/node_modules/fetch-ponyfill/build/fetch-browser.js");
+var qs = __webpack_require__(/*! qs */ "../../api-javascript/node_modules/qs/lib/index.js");
+var utils_1 = __webpack_require__(/*! ../utils */ "../../api-javascript/dist/utils/index.js");
+var query_1 = __webpack_require__(/*! ./query */ "../../api-javascript/dist/core/query.js");
+var SEARCH = '/search';
+var REFINEMENTS = '/refinements';
+var INVALID_QUERY_ERROR = 'query was not of a recognised type';
+var createTimeoutPromise = function (timeout) {
+    return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+            reject(new BridgeTimeout("Timed out in " + timeout + " ms"));
+        }, timeout);
+    });
+};
+var BridgeTimeout = /** @class */ (function (_super) {
+    __extends(BridgeTimeout, _super);
+    /* istanbul ignore next */
+    function BridgeTimeout(err) {
+        return _super.call(this, err) || this;
+    }
+    return BridgeTimeout;
+}(Error));
+exports.BridgeTimeout = BridgeTimeout;
+var BridgeError = /** @class */ (function (_super) {
+    __extends(BridgeError, _super);
+    /* istanbul ignore next */
+    function BridgeError(statusText, status, data) {
+        var _this = _super.call(this, statusText) || this;
+        _this.status = status;
+        _this.data = data;
+        Object.setPrototypeOf(_this, BridgeError.prototype);
+        return _this;
+    }
+    Object.defineProperty(BridgeError.prototype, "statusText", {
+        get: function () {
+            return this.message;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    return BridgeError;
+}(Error));
+exports.BridgeError = BridgeError;
+exports.DEFAULT_CONFIG = {
+    timeout: 1500
+};
+var AbstractBridge = /** @class */ (function () {
+    function AbstractBridge(config) {
+        this.fetch = fetchPonyfill().fetch;
+        this.headers = {};
+        this.config = Object.assign({}, exports.DEFAULT_CONFIG, config);
+    }
+    AbstractBridge.prototype.search = function (query, callback) {
+        var _a = this.extractRequest(query), request = _a.request, queryParams = _a.queryParams;
+        if (request === null)
+            return this.generateError(INVALID_QUERY_ERROR, callback);
+        var response = this.fireRequest(this.bridgeUrl, request, queryParams)
+            .then(AbstractBridge.transformRecords)
+            .then(AbstractBridge.transformRefinements);
+        return this.handleResponse(response, callback);
+    };
+    AbstractBridge.prototype.refinements = function (query, navigationName, callback) {
+        var request = this.extractRequest(query).request;
+        if (request === null)
+            return this.generateError(INVALID_QUERY_ERROR, callback);
+        var refinementsRequest = { originalQuery: request, navigationName: navigationName };
+        var response = this.fireRequest(this.refinementsUrl, refinementsRequest);
+        return this.handleResponse(response, callback);
+    };
+    AbstractBridge.prototype.handleResponse = function (response, callback) {
+        if (callback) {
+            response.then(function (res) { return callback(undefined, res); }, function (err) { return callback(err); });
+        }
+        else {
+            return response;
+        }
+    };
+    AbstractBridge.prototype.extractRequest = function (query) {
+        switch (typeof query) {
+            case 'string': return { request: new query_1.Query(query).build(), queryParams: {} };
+            case 'object': return query instanceof query_1.Query
+                ? { request: query.build(), queryParams: query.queryParams }
+                : { request: clone(query), queryParams: {} };
+            default: return { request: null, queryParams: null };
+        }
+    };
+    AbstractBridge.prototype.generateError = function (error, callback) {
+        var err = new Error(error);
+        if (callback) {
+            callback(err);
+        }
+        else {
+            return Promise.reject(err);
+        }
+    };
+    // tslint:disable-next-line max-line-length
+    AbstractBridge.prototype.fireRequest = function (url, body, queryParams) {
+        var _this = this;
+        if (queryParams === void 0) {
+            queryParams = {};
+        }
+        var options = {
+            method: 'POST',
+            headers: __assign({ 'Content-Type': 'application/json' }, this.headers),
+            body: JSON.stringify(AbstractBridge.normalizeRequest(this.augmentRequest(body))),
+        };
+        var params = qs.stringify(queryParams);
+        url = params ? url + "?" + params : url;
+        return Promise.race([this.fetch(url, options), createTimeoutPromise(this.config.timeout)])
+            .then(function (res) {
+            if (res.ok) {
+                return res.json();
+            }
+            else {
+                return res.json().then(function (err) {
+                    throw new BridgeError(res.statusText, res.status, err);
+                });
+            }
+        })
+            .catch(function (err) {
+            if (_this.errorHandler) {
+                _this.errorHandler(err);
+            }
+            throw err;
+        });
+    };
+    AbstractBridge.normalizeRequest = function (request) {
+        Object.keys(utils_1.Normalizers).forEach(function (normalize) { return utils_1.Normalizers[normalize](request); });
+        return request;
+    };
+    AbstractBridge.transform = function (response, key, callback) {
+        var _a;
+        if (response[key]) {
+            return Object.assign(response, (_a = {}, _a[key] = response[key].map(callback), _a));
+        }
+        else {
+            return response;
+        }
+    };
+    AbstractBridge.transformRecords = function (response) {
+        return AbstractBridge.transform(response, 'records', AbstractBridge.convertRecordFields);
+    };
+    AbstractBridge.transformRefinements = function (response) {
+        var transformed = AbstractBridge.transform(response, 'availableNavigation', AbstractBridge.convertRefinement);
+        return AbstractBridge.transform(transformed, 'selectedNavigation', AbstractBridge.convertRefinement);
+    };
+    AbstractBridge.convertRecordFields = function (record) {
+        var converted = Object.assign(record, { id: record._id, url: record._u, title: record._t });
+        delete converted._id;
+        delete converted._u;
+        delete converted._t;
+        if (record._snippet) {
+            converted.snippet = record._snippet;
+            delete converted._snippet;
+        }
+        return converted;
+    };
+    AbstractBridge.convertRefinement = function (navigation) {
+        if (navigation.range) {
+            navigation.min = Number.MAX_SAFE_INTEGER;
+            navigation.max = Number.MIN_SAFE_INTEGER;
+            navigation.refinements = navigation.refinements
+                .map(function (ref) {
+                navigation.min = Math.min(navigation.min, ref.low);
+                navigation.max = Math.max(navigation.max, ref.high);
+                return (__assign({}, ref, { high: parseFloat(ref.high), low: parseFloat(ref.low) }));
+            });
+        }
+        return navigation;
+    };
+    return AbstractBridge;
+}());
+exports.AbstractBridge = AbstractBridge;
+var CloudBridge = /** @class */ (function (_super) {
+    __extends(CloudBridge, _super);
+    function CloudBridge(clientKey, customerId, config) {
+        if (config === void 0) {
+            config = {};
+        }
+        var _this = _super.call(this, config) || this;
+        _this.clientKey = clientKey;
+        _this.baseUrl = "https://" + customerId + ".groupbycloud.com:443/api/v1";
+        _this.bridgeUrl = _this.baseUrl + SEARCH;
+        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
+        return _this;
+    }
+    CloudBridge.prototype.augmentRequest = function (request) {
+        return Object.assign(request, { clientKey: this.clientKey });
+    };
+    return CloudBridge;
+}(AbstractBridge));
+exports.CloudBridge = CloudBridge;
+var BrowserBridge = /** @class */ (function (_super) {
+    __extends(BrowserBridge, _super);
+    function BrowserBridge(customerId, https, config) {
+        if (https === void 0) {
+            https = false;
+        }
+        if (config === void 0) {
+            config = {};
+        }
+        var _this = _super.call(this, config) || this;
+        var scheme = https ? 'https' : 'http';
+        var port = https ? ':443' : '';
+        _this.baseUrl = config.proxyUrl || scheme + "://" + customerId + "-cors.groupbycloud.com" + port + "/api/v1";
+        _this.bridgeUrl = _this.baseUrl + SEARCH;
+        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
+        return _this;
+    }
+    BrowserBridge.prototype.augmentRequest = function (request) {
+        return request;
+    };
+    return BrowserBridge;
+}(AbstractBridge));
+exports.BrowserBridge = BrowserBridge;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/dist/core/query.js":
+/*!************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/dist/core/query.js ***!
+  \************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+var clone = __webpack_require__(/*! clone */ "../../api-javascript/node_modules/clone/clone.js");
+var deepEqual = __webpack_require__(/*! deep-equal */ "../../api-javascript/node_modules/deep-equal/index.js");
+var filterObject = __webpack_require__(/*! filter-object */ "../../api-javascript/node_modules/filter-object/index.js");
+var qs = __webpack_require__(/*! qs */ "../../api-javascript/node_modules/qs/lib/index.js");
+var utils_1 = __webpack_require__(/*! ../utils */ "../../api-javascript/dist/utils/index.js");
+var REFINEMENT_MASK = '{navigationName,value,low,high}';
+var Query = /** @class */ (function () {
+    function Query(query) {
+        if (query === void 0) {
+            query = '';
+        }
+        this.request = {};
+        this.unprocessedNavigations = [];
+        this.queryParams = {};
+        this.request.query = query;
+        this.request.sort = [];
+        this.request.fields = [];
+        this.request.orFields = [];
+        this.request.refinements = [];
+        this.request.customUrlParams = [];
+        this.request.includedNavigations = [];
+        this.request.excludedNavigations = [];
+        this.request.wildcardSearchEnabled = false;
+        this.request.pruneRefinements = true;
+    }
+    Query.prototype.withQuery = function (query) {
+        this.request.query = query;
+        return this;
+    };
+    Query.prototype.withConfiguration = function (configuration, mask) {
+        if (mask === void 0) {
+            mask = '*';
+        }
+        Object.assign(this.request, filterObject(configuration, mask));
+        return this;
+    };
+    Query.prototype.withSelectedRefinements = function () {
+        var _this = this;
+        var refinements = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            refinements[_i] = arguments[_i];
+        }
+        refinements.forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
+        return this;
+    };
+    Query.prototype.withoutSelectedRefinements = function () {
+        var _this = this;
+        var refinements = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            refinements[_i] = arguments[_i];
+        }
+        refinements.forEach(function (refinement) {
+            var index = _this.request.refinements.findIndex(function (ref) { return deepEqual(ref, refinement); });
+            if (index > -1)
+                _this.request.refinements.splice(index, 1);
+        });
+        return this;
+    };
+    Query.prototype.withRefinements = function (navigationName) {
+        var _this = this;
+        var refinements = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            refinements[_i - 1] = arguments[_i];
+        }
+        var convert = function (refinement) { return Object.assign(refinement, { navigationName: navigationName }); };
+        refinements.map(convert).forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
+        return this;
+    };
+    Query.prototype.withNavigations = function () {
+        var _a;
+        var navigations = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            navigations[_i] = arguments[_i];
+        }
+        (_a = this.unprocessedNavigations).push.apply(_a, navigations);
+        return this;
+    };
+    Query.prototype.withCustomUrlParams = function (customUrlParams) {
+        var _a, _b;
+        if (typeof customUrlParams === 'string') {
+            (_a = this.request.customUrlParams).push.apply(_a, this.convertParamString(customUrlParams));
+        }
+        else if (Array.isArray(customUrlParams)) {
+            (_b = this.request.customUrlParams).push.apply(_b, customUrlParams);
+        }
+        return this;
+    };
+    Query.prototype.withFields = function () {
+        var _a;
+        var fields = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            fields[_i] = arguments[_i];
+        }
+        (_a = this.request.fields).push.apply(_a, fields);
+        return this;
+    };
+    Query.prototype.withOrFields = function () {
+        var _a;
+        var orFields = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            orFields[_i] = arguments[_i];
+        }
+        (_a = this.request.orFields).push.apply(_a, orFields);
+        return this;
+    };
+    Query.prototype.withSorts = function () {
+        var _a;
+        var sorts = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            sorts[_i] = arguments[_i];
+        }
+        (_a = this.request.sort).push.apply(_a, sorts);
+        return this;
+    };
+    Query.prototype.withoutSorts = function () {
+        var sorts = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            sorts[_i] = arguments[_i];
+        }
+        this.request.sort = this.request.sort.filter(function (oldSort) {
+            return !sorts.find(function (sort) {
+                return sort.type === 'ByIds'
+                    ? oldSort.type === 'ByIds' && sort.ids.toString() === oldSort.ids.toString()
+                    : sort.field === oldSort.field;
+            });
+        });
+        return this;
+    };
+    Query.prototype.withIncludedNavigations = function () {
+        var _a;
+        var navigationNames = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            navigationNames[_i] = arguments[_i];
+        }
+        (_a = this.request.includedNavigations).push.apply(_a, navigationNames);
+        return this;
+    };
+    Query.prototype.withExcludedNavigations = function () {
+        var _a;
+        var navigationNames = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            navigationNames[_i] = arguments[_i];
+        }
+        (_a = this.request.excludedNavigations).push.apply(_a, navigationNames);
+        return this;
+    };
+    Query.prototype.withQueryParams = function (queryParams) {
+        switch (typeof queryParams) {
+            case 'string':
+                return Object.assign(this, { queryParams: this.convertQueryString(queryParams) });
+            case 'object':
+                return Object.assign(this, { queryParams: queryParams });
+        }
+    };
+    Query.prototype.refineByValue = function (navigationName, value, exclude) {
+        if (exclude === void 0) {
+            exclude = false;
+        }
+        return this.withSelectedRefinements({
+            navigationName: navigationName,
+            value: value,
+            exclude: exclude,
+            type: 'Value'
+        });
+    };
+    Query.prototype.refineByRange = function (navigationName, low, high, exclude) {
+        if (exclude === void 0) {
+            exclude = false;
+        }
+        return this.withSelectedRefinements({
+            navigationName: navigationName,
+            low: low,
+            high: high,
+            exclude: exclude,
+            type: 'Range'
+        });
+    };
+    Query.prototype.restrictNavigation = function (restrictNavigation) {
+        this.request.restrictNavigation = restrictNavigation;
+        return this;
+    };
+    Query.prototype.skip = function (skip) {
+        this.request.skip = skip;
+        return this;
+    };
+    Query.prototype.withPageSize = function (pageSize) {
+        this.request.pageSize = pageSize;
+        return this;
+    };
+    Query.prototype.withMatchStrategy = function (matchStrategy) {
+        this.request.matchStrategy = matchStrategy;
+        return this;
+    };
+    Query.prototype.withBiasing = function (biasing) {
+        this.request.biasing = biasing;
+        return this;
+    };
+    Query.prototype.enableWildcardSearch = function () {
+        this.request.wildcardSearchEnabled = true;
+        return this;
+    };
+    Query.prototype.disableAutocorrection = function () {
+        this.request.disableAutocorrection = true;
+        return this;
+    };
+    Query.prototype.disableBinaryPayload = function () {
+        this.request.returnBinary = false;
+        return this;
+    };
+    Query.prototype.allowPrunedRefinements = function () {
+        this.request.pruneRefinements = false;
+        return this;
+    };
+    Query.prototype.build = function () {
+        var _this = this;
+        var builtRequest = this.raw;
+        utils_1.NavigationConverter.convert(this.unprocessedNavigations)
+            .forEach(function (ref) { return _this.addRefinement(ref, builtRequest.refinements); });
+        return this.clearEmptyArrays(builtRequest);
+    };
+    Object.defineProperty(Query.prototype, "raw", {
+        get: function () {
+            return clone(this.request, false);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(Query.prototype, "rawNavigations", {
+        get: function () {
+            return Object.create(this.unprocessedNavigations);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Query.prototype.addRefinement = function (refinement, refinements) {
+        var _this = this;
+        if (!refinements.find(function (ref) { return _this.refinementMatches(ref, refinement); })) {
+            refinements.push(refinement);
+        }
+    };
+    Query.prototype.refinementMatches = function (target, original) {
+        return deepEqual(filterObject(target, REFINEMENT_MASK), filterObject(original, REFINEMENT_MASK));
+    };
+    Query.prototype.convertParamString = function (customUrlParams) {
+        var parsed = qs.parse(customUrlParams);
+        return Object.keys(parsed).reduce(function (converted, key) { return converted.concat({ key: key, value: parsed[key] }); }, []);
+    };
+    Query.prototype.convertQueryString = function (queryParams) {
+        return qs.parse(queryParams);
+    };
+    Query.prototype.clearEmptyArrays = function (request) {
+        for (var key in request) {
+            if (Array.isArray(request[key]) && request[key].length === 0) {
+                delete request[key];
+            }
+        }
+        return request;
+    };
+    return Query;
+}());
+exports.Query = Query;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/dist/index.js":
+/*!*******************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/dist/index.js ***!
+  \*******************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+    for (var p in m)
+        if (!exports.hasOwnProperty(p))
+            exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! ./sayt */ "../sfx-events/dist/sayt/index.js"));
-__export(__webpack_require__(/*! ./search */ "../sfx-events/dist/search/index.js"));
-//# sourceMappingURL=index.js.map
+__export(__webpack_require__(/*! ./core/query */ "../../api-javascript/dist/core/query.js"));
+__export(__webpack_require__(/*! ./core/bridge */ "../../api-javascript/dist/core/bridge.js"));
+
 
 /***/ }),
 
-/***/ "../sfx-events/dist/sayt/autocomplete-list.js":
-/*!****************************************************!*\
-  !*** ../sfx-events/dist/sayt/autocomplete-list.js ***!
-  \****************************************************/
+/***/ "../../api-javascript/dist/utils/index.js":
+/*!*************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/dist/utils/index.js ***!
+  \*************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-/** The name of the event fired to change the active query term. */
-exports.AUTOCOMPLETE_ACTIVE_TERM = 'sfx::autocomplete_active_term';
-//# sourceMappingURL=autocomplete-list.js.map
+var NavigationConverter = /** @class */ (function () {
+    function NavigationConverter() {
+    }
+    NavigationConverter.convert = function (navigations) {
+        return navigations.reduce(function (refinements, navigation) {
+            navigation.refinements
+                // tslint:disable-next-line max-line-length
+                .forEach(function (refinement) { return refinements.push(Object.assign(refinement, { navigationName: navigation.name })); });
+            return refinements;
+        }, []);
+    };
+    return NavigationConverter;
+}());
+exports.NavigationConverter = NavigationConverter;
+var Normalizers;
+(function (Normalizers) {
+    function normalizeSort(request) {
+        if (request.sort && !Array.isArray(request.sort) && request.sort.field === '_relevance') {
+            delete request.sort;
+        }
+    }
+    Normalizers.normalizeSort = normalizeSort;
+})(Normalizers = exports.Normalizers || (exports.Normalizers = {}));
+
 
 /***/ }),
 
-/***/ "../sfx-events/dist/sayt/autocomplete.js":
-/*!***********************************************!*\
-  !*** ../sfx-events/dist/sayt/autocomplete.js ***!
-  \***********************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-/** The name of the event fired to request autocomplete data. */
-exports.AUTOCOMPLETE_REQUEST = 'sfx::autocomplete_request';
-/** The name of the event fired when the results of an autocomplete request have been received. */
-exports.AUTOCOMPLETE_RESPONSE = 'sfx::autocomplete_response';
-/** The name of the event fired when an autocomplete request fails. */
-exports.AUTOCOMPLETE_ERROR = 'sfx::autocomplete_error';
-//# sourceMappingURL=autocomplete.js.map
-
-/***/ }),
-
-/***/ "../sfx-events/dist/sayt/index.js":
-/*!****************************************!*\
-  !*** ../sfx-events/dist/sayt/index.js ***!
-  \****************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
-Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! ./autocomplete */ "../sfx-events/dist/sayt/autocomplete.js"));
-__export(__webpack_require__(/*! ./autocomplete-list */ "../sfx-events/dist/sayt/autocomplete-list.js"));
-__export(__webpack_require__(/*! ./products */ "../sfx-events/dist/sayt/products.js"));
-__export(__webpack_require__(/*! ./sayt */ "../sfx-events/dist/sayt/sayt.js"));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ "../sfx-events/dist/sayt/products.js":
-/*!*******************************************!*\
-  !*** ../sfx-events/dist/sayt/products.js ***!
-  \*******************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-/** The name of the event fired to request SAYT products. */
-exports.SAYT_PRODUCTS_REQUEST = 'sfx::sayt_products_request';
-/** The name of the event fired when the results of a SAYT products request have been received. */
-exports.SAYT_PRODUCTS_RESPONSE = 'sfx::sayt_products_response';
-/** The name of the event fired when a SAYT products request fails. */
-exports.SAYT_PRODUCTS_ERROR = 'sfx::sayt_products_error';
-//# sourceMappingURL=products.js.map
-
-/***/ }),
-
-/***/ "../sfx-events/dist/sayt/sayt.js":
-/*!***************************************!*\
-  !*** ../sfx-events/dist/sayt/sayt.js ***!
-  \***************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-/** The name of the event fired when SAYT should be hidden. */
-exports.SAYT_HIDE = 'sfx::sayt_hide';
-/** The name of the event fired when SAYT should be shown. */
-exports.SAYT_SHOW = 'sfx::sayt_show';
-//# sourceMappingURL=sayt.js.map
-
-/***/ }),
-
-/***/ "../sfx-events/dist/search/index.js":
-/*!******************************************!*\
-  !*** ../sfx-events/dist/search/index.js ***!
-  \******************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
-Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! ./search */ "../sfx-events/dist/search/search.js"));
-__export(__webpack_require__(/*! ./searchbox */ "../sfx-events/dist/search/searchbox.js"));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ "../sfx-events/dist/search/search.js":
-/*!*******************************************!*\
-  !*** ../sfx-events/dist/search/search.js ***!
-  \*******************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-/** The name of the event fired to request a search. */
-exports.SEARCH_REQUEST = 'sfx::search_request';
-/** The name of the event fired when the results of a search request have been received.  */
-exports.SEARCH_RESPONSE = 'sfx::search_response';
-/** The name of the event fired when a search request fails. */
-exports.SEARCH_ERROR = 'sfx::search_error';
-//# sourceMappingURL=search.js.map
-
-/***/ }),
-
-/***/ "../sfx-events/dist/search/searchbox.js":
-/*!**********************************************!*\
-  !*** ../sfx-events/dist/search/searchbox.js ***!
-  \**********************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-/** The name of the event fired when the search term is to be updated. */
-exports.UPDATE_SEARCH_TERM = 'sfx::update_search_term';
-/** The name of the event fired when the user has changed the text in the search box. */
-exports.SEARCHBOX_INPUT = 'sfx::searchbox_input';
-/** The name of the event fired when the search box is clicked. */
-exports.SEARCHBOX_CLICK = 'sfx::searchbox_click';
-/** The name of the event fired when the search box is cleared. */
-exports.SEARCHBOX_CLEAR = 'sfx::searchbox_clear';
-//# sourceMappingURL=searchbox.js.map
-
-/***/ }),
-
-/***/ "./node_modules/arr-flatten/index.js":
-/*!*******************************************!*\
-  !*** ./node_modules/arr-flatten/index.js ***!
-  \*******************************************/
+/***/ "../../api-javascript/node_modules/arr-flatten/index.js":
+/*!***************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/arr-flatten/index.js ***!
+  \***************************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -295,174 +710,10 @@ function flat(arr, res) {
 
 /***/ }),
 
-/***/ "./node_modules/base64-js/index.js":
-/*!*****************************************!*\
-  !*** ./node_modules/base64-js/index.js ***!
-  \*****************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-exports.byteLength = byteLength
-exports.toByteArray = toByteArray
-exports.fromByteArray = fromByteArray
-
-var lookup = []
-var revLookup = []
-var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
-
-var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-for (var i = 0, len = code.length; i < len; ++i) {
-  lookup[i] = code[i]
-  revLookup[code.charCodeAt(i)] = i
-}
-
-// Support decoding URL-safe base64 strings, as Node.js does.
-// See: https://en.wikipedia.org/wiki/Base64#URL_applications
-revLookup['-'.charCodeAt(0)] = 62
-revLookup['_'.charCodeAt(0)] = 63
-
-function getLens (b64) {
-  var len = b64.length
-
-  if (len % 4 > 0) {
-    throw new Error('Invalid string. Length must be a multiple of 4')
-  }
-
-  // Trim off extra bytes after placeholder bytes are found
-  // See: https://github.com/beatgammit/base64-js/issues/42
-  var validLen = b64.indexOf('=')
-  if (validLen === -1) validLen = len
-
-  var placeHoldersLen = validLen === len
-    ? 0
-    : 4 - (validLen % 4)
-
-  return [validLen, placeHoldersLen]
-}
-
-// base64 is 4/3 + up to two characters of the original data
-function byteLength (b64) {
-  var lens = getLens(b64)
-  var validLen = lens[0]
-  var placeHoldersLen = lens[1]
-  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
-}
-
-function _byteLength (b64, validLen, placeHoldersLen) {
-  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
-}
-
-function toByteArray (b64) {
-  var tmp
-  var lens = getLens(b64)
-  var validLen = lens[0]
-  var placeHoldersLen = lens[1]
-
-  var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen))
-
-  var curByte = 0
-
-  // if there are placeholders, only get up to the last complete 4 chars
-  var len = placeHoldersLen > 0
-    ? validLen - 4
-    : validLen
-
-  var i
-  for (i = 0; i < len; i += 4) {
-    tmp =
-      (revLookup[b64.charCodeAt(i)] << 18) |
-      (revLookup[b64.charCodeAt(i + 1)] << 12) |
-      (revLookup[b64.charCodeAt(i + 2)] << 6) |
-      revLookup[b64.charCodeAt(i + 3)]
-    arr[curByte++] = (tmp >> 16) & 0xFF
-    arr[curByte++] = (tmp >> 8) & 0xFF
-    arr[curByte++] = tmp & 0xFF
-  }
-
-  if (placeHoldersLen === 2) {
-    tmp =
-      (revLookup[b64.charCodeAt(i)] << 2) |
-      (revLookup[b64.charCodeAt(i + 1)] >> 4)
-    arr[curByte++] = tmp & 0xFF
-  }
-
-  if (placeHoldersLen === 1) {
-    tmp =
-      (revLookup[b64.charCodeAt(i)] << 10) |
-      (revLookup[b64.charCodeAt(i + 1)] << 4) |
-      (revLookup[b64.charCodeAt(i + 2)] >> 2)
-    arr[curByte++] = (tmp >> 8) & 0xFF
-    arr[curByte++] = tmp & 0xFF
-  }
-
-  return arr
-}
-
-function tripletToBase64 (num) {
-  return lookup[num >> 18 & 0x3F] +
-    lookup[num >> 12 & 0x3F] +
-    lookup[num >> 6 & 0x3F] +
-    lookup[num & 0x3F]
-}
-
-function encodeChunk (uint8, start, end) {
-  var tmp
-  var output = []
-  for (var i = start; i < end; i += 3) {
-    tmp =
-      ((uint8[i] << 16) & 0xFF0000) +
-      ((uint8[i + 1] << 8) & 0xFF00) +
-      (uint8[i + 2] & 0xFF)
-    output.push(tripletToBase64(tmp))
-  }
-  return output.join('')
-}
-
-function fromByteArray (uint8) {
-  var tmp
-  var len = uint8.length
-  var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
-  var parts = []
-  var maxChunkLength = 16383 // must be multiple of 3
-
-  // go through the array every three bytes, we'll deal with trailing stuff later
-  for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
-    parts.push(encodeChunk(
-      uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
-    ))
-  }
-
-  // pad the end with zeros, but make sure to not forget the extra bytes
-  if (extraBytes === 1) {
-    tmp = uint8[len - 1]
-    parts.push(
-      lookup[tmp >> 2] +
-      lookup[(tmp << 4) & 0x3F] +
-      '=='
-    )
-  } else if (extraBytes === 2) {
-    tmp = (uint8[len - 2] << 8) + uint8[len - 1]
-    parts.push(
-      lookup[tmp >> 10] +
-      lookup[(tmp >> 4) & 0x3F] +
-      lookup[(tmp << 2) & 0x3F] +
-      '='
-    )
-  }
-
-  return parts.join('')
-}
-
-
-/***/ }),
-
-/***/ "./node_modules/clone/clone.js":
-/*!*************************************!*\
-  !*** ./node_modules/clone/clone.js ***!
-  \*************************************/
+/***/ "../../api-javascript/node_modules/clone/clone.js":
+/*!*********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/clone/clone.js ***!
+  \*********************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -724,7 +975,6080 @@ if ( true && module.exports) {
   module.exports = clone;
 }
 
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../node-libs-browser/node_modules/buffer/index.js */ "./node_modules/node-libs-browser/node_modules/buffer/index.js").Buffer))
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../sfx/sfx-logic/node_modules/node-libs-browser/node_modules/buffer/index.js */ "./node_modules/node-libs-browser/node_modules/buffer/index.js").Buffer))
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/deep-equal/index.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/deep-equal/index.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+var pSlice = Array.prototype.slice;
+var objectKeys = __webpack_require__(/*! ./lib/keys.js */ "../../api-javascript/node_modules/deep-equal/lib/keys.js");
+var isArguments = __webpack_require__(/*! ./lib/is_arguments.js */ "../../api-javascript/node_modules/deep-equal/lib/is_arguments.js");
+
+var deepEqual = module.exports = function (actual, expected, opts) {
+  if (!opts) opts = {};
+  // 7.1. All identical values are equivalent, as determined by ===.
+  if (actual === expected) {
+    return true;
+
+  } else if (actual instanceof Date && expected instanceof Date) {
+    return actual.getTime() === expected.getTime();
+
+  // 7.3. Other pairs that do not both pass typeof value == 'object',
+  // equivalence is determined by ==.
+  } else if (!actual || !expected || typeof actual != 'object' && typeof expected != 'object') {
+    return opts.strict ? actual === expected : actual == expected;
+
+  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // determined by having the same number of owned properties (as verified
+  // with Object.prototype.hasOwnProperty.call), the same set of keys
+  // (although not necessarily the same order), equivalent values for every
+  // corresponding key, and an identical 'prototype' property. Note: this
+  // accounts for both named and indexed properties on Arrays.
+  } else {
+    return objEquiv(actual, expected, opts);
+  }
+}
+
+function isUndefinedOrNull(value) {
+  return value === null || value === undefined;
+}
+
+function isBuffer (x) {
+  if (!x || typeof x !== 'object' || typeof x.length !== 'number') return false;
+  if (typeof x.copy !== 'function' || typeof x.slice !== 'function') {
+    return false;
+  }
+  if (x.length > 0 && typeof x[0] !== 'number') return false;
+  return true;
+}
+
+function objEquiv(a, b, opts) {
+  var i, key;
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+    return false;
+  // an identical 'prototype' property.
+  if (a.prototype !== b.prototype) return false;
+  //~~~I've managed to break Object.keys through screwy arguments passing.
+  //   Converting to array solves the problem.
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = pSlice.call(a);
+    b = pSlice.call(b);
+    return deepEqual(a, b, opts);
+  }
+  if (isBuffer(a)) {
+    if (!isBuffer(b)) {
+      return false;
+    }
+    if (a.length !== b.length) return false;
+    for (i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  try {
+    var ka = objectKeys(a),
+        kb = objectKeys(b);
+  } catch (e) {//happens when one is a string literal and the other isn't
+    return false;
+  }
+  // having the same number of owned properties (keys incorporates
+  // hasOwnProperty)
+  if (ka.length != kb.length)
+    return false;
+  //the same set of keys (although not necessarily the same order),
+  ka.sort();
+  kb.sort();
+  //~~~cheap key test
+  for (i = ka.length - 1; i >= 0; i--) {
+    if (ka[i] != kb[i])
+      return false;
+  }
+  //equivalent values for every corresponding key, and
+  //~~~possibly expensive deep test
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!deepEqual(a[key], b[key], opts)) return false;
+  }
+  return typeof a === typeof b;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/deep-equal/lib/is_arguments.js":
+/*!*************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/deep-equal/lib/is_arguments.js ***!
+  \*************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+var supportsArgumentsClass = (function(){
+  return Object.prototype.toString.call(arguments)
+})() == '[object Arguments]';
+
+exports = module.exports = supportsArgumentsClass ? supported : unsupported;
+
+exports.supported = supported;
+function supported(object) {
+  return Object.prototype.toString.call(object) == '[object Arguments]';
+};
+
+exports.unsupported = unsupported;
+function unsupported(object){
+  return object &&
+    typeof object == 'object' &&
+    typeof object.length == 'number' &&
+    Object.prototype.hasOwnProperty.call(object, 'callee') &&
+    !Object.prototype.propertyIsEnumerable.call(object, 'callee') ||
+    false;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/deep-equal/lib/keys.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/deep-equal/lib/keys.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+exports = module.exports = typeof Object.keys === 'function'
+  ? Object.keys : shim;
+
+exports.shim = shim;
+function shim (obj) {
+  var keys = [];
+  for (var key in obj) keys.push(key);
+  return keys;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/expand-brackets/index.js":
+/*!*******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/expand-brackets/index.js ***!
+  \*******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * expand-brackets <https://github.com/jonschlinkert/expand-brackets>
+ *
+ * Copyright (c) 2015 Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+
+
+var isPosixBracket = __webpack_require__(/*! is-posix-bracket */ "../../api-javascript/node_modules/is-posix-bracket/index.js");
+
+/**
+ * POSIX character classes
+ */
+
+var POSIX = {
+  alnum: 'a-zA-Z0-9',
+  alpha: 'a-zA-Z',
+  blank: ' \\t',
+  cntrl: '\\x00-\\x1F\\x7F',
+  digit: '0-9',
+  graph: '\\x21-\\x7E',
+  lower: 'a-z',
+  print: '\\x20-\\x7E',
+  punct: '-!"#$%&\'()\\*+,./:;<=>?@[\\]^_`{|}~',
+  space: ' \\t\\r\\n\\v\\f',
+  upper: 'A-Z',
+  word:  'A-Za-z0-9_',
+  xdigit: 'A-Fa-f0-9',
+};
+
+/**
+ * Expose `brackets`
+ */
+
+module.exports = brackets;
+
+function brackets(str) {
+  if (!isPosixBracket(str)) {
+    return str;
+  }
+
+  var negated = false;
+  if (str.indexOf('[^') !== -1) {
+    negated = true;
+    str = str.split('[^').join('[');
+  }
+  if (str.indexOf('[!') !== -1) {
+    negated = true;
+    str = str.split('[!').join('[');
+  }
+
+  var a = str.split('[');
+  var b = str.split(']');
+  var imbalanced = a.length !== b.length;
+
+  var parts = str.split(/(?::\]\[:|\[?\[:|:\]\]?)/);
+  var len = parts.length, i = 0;
+  var end = '', beg = '';
+  var res = [];
+
+  // start at the end (innermost) first
+  while (len--) {
+    var inner = parts[i++];
+    if (inner === '^[!' || inner === '[!') {
+      inner = '';
+      negated = true;
+    }
+
+    var prefix = negated ? '^' : '';
+    var ch = POSIX[inner];
+
+    if (ch) {
+      res.push('[' + prefix + ch + ']');
+    } else if (inner) {
+      if (/^\[?\w-\w\]?$/.test(inner)) {
+        if (i === parts.length) {
+          res.push('[' + prefix + inner);
+        } else if (i === 1) {
+          res.push(prefix + inner + ']');
+        } else {
+          res.push(prefix + inner);
+        }
+      } else {
+        if (i === 1) {
+          beg += inner;
+        } else if (i === parts.length) {
+          end += inner;
+        } else {
+          res.push('[' + prefix + inner + ']');
+        }
+      }
+    }
+  }
+
+  var result = res.join('|');
+  var rlen = res.length || 1;
+  if (rlen > 1) {
+    result = '(?:' + result + ')';
+    rlen = 1;
+  }
+  if (beg) {
+    rlen++;
+    if (beg.charAt(0) === '[') {
+      if (imbalanced) {
+        beg = '\\[' + beg.slice(1);
+      } else {
+        beg += ']';
+      }
+    }
+    result = beg + result;
+  }
+  if (end) {
+    rlen++;
+    if (end.slice(-1) === ']') {
+      if (imbalanced) {
+        end = end.slice(0, end.length - 1) + '\\]';
+      } else {
+        end = '[' + end;
+      }
+    }
+    result += end;
+  }
+
+  if (rlen > 1) {
+    result = result.split('][').join(']|[');
+    if (result.indexOf('|') !== -1 && !/\(\?/.test(result)) {
+      result = '(?:' + result + ')';
+    }
+  }
+
+  result = result.replace(/\[+=|=\]+/g, '\\b');
+  return result;
+}
+
+brackets.makeRe = function(pattern) {
+  try {
+    return new RegExp(brackets(pattern));
+  } catch (err) {}
+};
+
+brackets.isMatch = function(str, pattern) {
+  try {
+    return brackets.makeRe(pattern).test(str);
+  } catch (err) {
+    return false;
+  }
+};
+
+brackets.match = function(arr, pattern) {
+  var len = arr.length, i = 0;
+  var res = arr.slice();
+
+  var re = brackets.makeRe(pattern);
+  while (i < len) {
+    var ele = arr[i++];
+    if (!re.test(ele)) {
+      continue;
+    }
+    res.splice(i, 1);
+  }
+  return res;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/expand-range/index.js":
+/*!****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/index.js ***!
+  \****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * expand-range <https://github.com/jonschlinkert/expand-range>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+
+
+var fill = __webpack_require__(/*! fill-range */ "../../api-javascript/node_modules/expand-range/node_modules/fill-range/index.js");
+
+module.exports = function expandRange(str, options, fn) {
+  if (typeof str !== 'string') {
+    throw new TypeError('expand-range expects a string.');
+  }
+
+  if (typeof options === 'function') {
+    fn = options;
+    options = {};
+  }
+
+  if (typeof options === 'boolean') {
+    options = {};
+    options.makeRe = true;
+  }
+
+  // create arguments to pass to fill-range
+  var opts = options || {};
+  var args = str.split('..');
+  var len = args.length;
+  if (len > 3) { return str; }
+
+  // if only one argument, it can't expand so return it
+  if (len === 1) { return args; }
+
+  // if `true`, tell fill-range to regexify the string
+  if (typeof fn === 'boolean' && fn === true) {
+    opts.makeRe = true;
+  }
+
+  args.push(opts);
+  return fill.apply(null, args.concat(fn));
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/expand-range/node_modules/fill-range/index.js":
+/*!****************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/fill-range/index.js ***!
+  \****************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * fill-range <https://github.com/jonschlinkert/fill-range>
+ *
+ * Copyright (c) 2014-2018, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+var isObject = __webpack_require__(/*! isobject */ "../../api-javascript/node_modules/expand-range/node_modules/isobject/index.js");
+var isNumber = __webpack_require__(/*! is-number */ "../../api-javascript/node_modules/expand-range/node_modules/is-number/index.js");
+var randomize = __webpack_require__(/*! randomatic */ "../../api-javascript/node_modules/randomatic/index.js");
+var repeatStr = __webpack_require__(/*! repeat-string */ "../../api-javascript/node_modules/repeat-string/index.js");
+var repeat = __webpack_require__(/*! repeat-element */ "../../api-javascript/node_modules/repeat-element/index.js");
+
+/**
+ * Expose `fillRange`
+ */
+
+module.exports = fillRange;
+
+/**
+ * Return a range of numbers or letters.
+ *
+ * @param  {String} `a` Start of the range
+ * @param  {String} `b` End of the range
+ * @param  {String} `step` Increment or decrement to use.
+ * @param  {Function} `fn` Custom function to modify each element in the range.
+ * @return {Array}
+ */
+
+function fillRange(a, b, step, options, fn) {
+  if (a == null || b == null) {
+    throw new Error('fill-range expects the first and second args to be strings.');
+  }
+
+  if (typeof step === 'function') {
+    fn = step; options = {}; step = null;
+  }
+
+  if (typeof options === 'function') {
+    fn = options; options = {};
+  }
+
+  if (isObject(step)) {
+    options = step; step = '';
+  }
+
+  var expand, regex = false, sep = '';
+  var opts = options || {};
+
+  if (typeof opts.silent === 'undefined') {
+    opts.silent = true;
+  }
+
+  step = step || opts.step;
+
+  // store a ref to unmodified arg
+  var origA = a, origB = b;
+
+  b = (b.toString() === '-0') ? 0 : b;
+
+  if (opts.optimize || opts.makeRe) {
+    step = step ? (step += '~') : step;
+    expand = true;
+    regex = true;
+    sep = '~';
+  }
+
+  // handle special step characters
+  if (typeof step === 'string') {
+    var match = stepRe().exec(step);
+
+    if (match) {
+      var i = match.index;
+      var m = match[0];
+
+      // repeat string
+      if (m === '+') {
+        return repeat(a, b);
+
+      // randomize a, `b` times
+      } else if (m === '?') {
+        return [randomize(a, b)];
+
+      // expand right, no regex reduction
+      } else if (m === '>') {
+        step = step.substr(0, i) + step.substr(i + 1);
+        expand = true;
+
+      // expand to an array, or if valid create a reduced
+      // string for a regex logic `or`
+      } else if (m === '|') {
+        step = step.substr(0, i) + step.substr(i + 1);
+        expand = true;
+        regex = true;
+        sep = m;
+
+      // expand to an array, or if valid create a reduced
+      // string for a regex range
+      } else if (m === '~') {
+        step = step.substr(0, i) + step.substr(i + 1);
+        expand = true;
+        regex = true;
+        sep = m;
+      }
+    } else if (!isNumber(step)) {
+      if (!opts.silent) {
+        throw new TypeError('fill-range: invalid step.');
+      }
+      return null;
+    }
+  }
+
+  if (/[.&*()[\]^%$#@!]/.test(a) || /[.&*()[\]^%$#@!]/.test(b)) {
+    if (!opts.silent) {
+      throw new RangeError('fill-range: invalid range arguments.');
+    }
+    return null;
+  }
+
+  // has neither a letter nor number, or has both letters and numbers
+  // this needs to be after the step logic
+  if (!noAlphaNum(a) || !noAlphaNum(b) || hasBoth(a) || hasBoth(b)) {
+    if (!opts.silent) {
+      throw new RangeError('fill-range: invalid range arguments.');
+    }
+    return null;
+  }
+
+  // validate arguments
+  var isNumA = isNumber(zeros(a));
+  var isNumB = isNumber(zeros(b));
+
+  if ((!isNumA && isNumB) || (isNumA && !isNumB)) {
+    if (!opts.silent) {
+      throw new TypeError('fill-range: first range argument is incompatible with second.');
+    }
+    return null;
+  }
+
+  // by this point both are the same, so we
+  // can use A to check going forward.
+  var isNum = isNumA;
+  var num = formatStep(step);
+
+  // is the range alphabetical? or numeric?
+  if (isNum) {
+    // if numeric, coerce to an integer
+    a = +a; b = +b;
+  } else {
+    // otherwise, get the charCode to expand alpha ranges
+    a = a.charCodeAt(0);
+    b = b.charCodeAt(0);
+  }
+
+  // is the pattern descending?
+  var isDescending = a > b;
+
+  // don't create a character class if the args are < 0
+  if (a < 0 || b < 0) {
+    expand = false;
+    regex = false;
+  }
+
+  // detect padding
+  var padding = isPadded(origA, origB);
+  var res, pad, arr = [];
+  var ii = 0;
+
+  // character classes, ranges and logical `or`
+  if (regex) {
+    if (shouldExpand(a, b, num, isNum, padding, opts)) {
+      // make sure the correct separator is used
+      if (sep === '|' || sep === '~') {
+        sep = detectSeparator(a, b, num, isNum, isDescending);
+      }
+      return wrap([origA, origB], sep, opts);
+    }
+  }
+
+  while (isDescending ? (a >= b) : (a <= b)) {
+    if (padding && isNum) {
+      pad = padding(a);
+    }
+
+    // custom function
+    if (typeof fn === 'function') {
+      res = fn(a, isNum, pad, ii++);
+
+    // letters
+    } else if (!isNum) {
+      if (regex && isInvalidChar(a)) {
+        res = null;
+      } else {
+        res = String.fromCharCode(a);
+      }
+
+    // numbers
+    } else {
+      res = formatPadding(a, pad);
+    }
+
+    // add result to the array, filtering any nulled values
+    if (res !== null) arr.push(res);
+
+    // increment or decrement
+    if (isDescending) {
+      a -= num;
+    } else {
+      a += num;
+    }
+  }
+
+  // now that the array is expanded, we need to handle regex
+  // character classes, ranges or logical `or` that wasn't
+  // already handled before the loop
+  if ((regex || expand) && !opts.noexpand) {
+    // make sure the correct separator is used
+    if (sep === '|' || sep === '~') {
+      sep = detectSeparator(a, b, num, isNum, isDescending);
+    }
+    if (arr.length === 1 || a < 0 || b < 0) { return arr; }
+    return wrap(arr, sep, opts);
+  }
+
+  return arr;
+}
+
+/**
+ * Wrap the string with the correct regex
+ * syntax.
+ */
+
+function wrap(arr, sep, opts) {
+  if (sep === '~') { sep = '-'; }
+  var str = arr.join(sep);
+  var pre = opts && opts.regexPrefix;
+
+  // regex logical `or`
+  if (sep === '|') {
+    str = pre ? pre + str : str;
+    str = '(' + str + ')';
+  }
+
+  // regex character class
+  if (sep === '-') {
+    str = (pre && pre === '^')
+      ? pre + str
+      : str;
+    str = '[' + str + ']';
+  }
+  return [str];
+}
+
+/**
+ * Check for invalid characters
+ */
+
+function isCharClass(a, b, step, isNum, isDescending) {
+  if (isDescending) { return false; }
+  if (isNum) { return a <= 9 && b <= 9; }
+  if (a < b) { return step === 1; }
+  return false;
+}
+
+/**
+ * Detect the correct separator to use
+ */
+
+function shouldExpand(a, b, num, isNum, padding, opts) {
+  if (isNum && (a > 9 || b > 9)) { return false; }
+  return !padding && num === 1 && a < b;
+}
+
+/**
+ * Detect the correct separator to use
+ */
+
+function detectSeparator(a, b, step, isNum, isDescending) {
+  var isChar = isCharClass(a, b, step, isNum, isDescending);
+  if (!isChar) {
+    return '|';
+  }
+  return '~';
+}
+
+/**
+ * Correctly format the step based on type
+ */
+
+function formatStep(step) {
+  return Math.abs(step >> 0) || 1;
+}
+
+/**
+ * Format padding, taking leading `-` into account
+ */
+
+function formatPadding(ch, pad) {
+  var res = pad ? pad + ch : ch;
+  if (pad && ch.toString().charAt(0) === '-') {
+    res = '-' + pad + ch.toString().substr(1);
+  }
+  return res.toString();
+}
+
+/**
+ * Check for invalid characters
+ */
+
+function isInvalidChar(str) {
+  var ch = toStr(str);
+  return ch === '\\'
+    || ch === '['
+    || ch === ']'
+    || ch === '^'
+    || ch === '('
+    || ch === ')'
+    || ch === '`';
+}
+
+/**
+ * Convert to a string from a charCode
+ */
+
+function toStr(ch) {
+  return String.fromCharCode(ch);
+}
+
+
+/**
+ * Step regex
+ */
+
+function stepRe() {
+  return /\?|>|\||\+|\~/g;
+}
+
+/**
+ * Return true if `val` has either a letter
+ * or a number
+ */
+
+function noAlphaNum(val) {
+  return /[a-z0-9]/i.test(val);
+}
+
+/**
+ * Return true if `val` has both a letter and
+ * a number (invalid)
+ */
+
+function hasBoth(val) {
+  return /[a-z][0-9]|[0-9][a-z]/i.test(val);
+}
+
+/**
+ * Normalize zeros for checks
+ */
+
+function zeros(val) {
+  if (/^-*0+$/.test(val.toString())) {
+    return '0';
+  }
+  return val;
+}
+
+/**
+ * Return true if `val` has leading zeros,
+ * or a similar valid pattern.
+ */
+
+function hasZeros(val) {
+  return /[^.]\.|^-*0+[0-9]/.test(val);
+}
+
+/**
+ * If the string is padded, returns a curried function with
+ * the a cached padding string, or `false` if no padding.
+ *
+ * @param  {*} `origA` String or number.
+ * @return {String|Boolean}
+ */
+
+function isPadded(origA, origB) {
+  if (hasZeros(origA) || hasZeros(origB)) {
+    var alen = length(origA);
+    var blen = length(origB);
+
+    var len = alen >= blen
+      ? alen
+      : blen;
+
+    return function (a) {
+      return repeatStr('0', len - length(a));
+    };
+  }
+  return false;
+}
+
+/**
+ * Get the string length of `val`
+ */
+
+function length(val) {
+  return val.toString().length;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/expand-range/node_modules/is-number/index.js":
+/*!***************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/is-number/index.js ***!
+  \***************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * is-number <https://github.com/jonschlinkert/is-number>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/kind-of/index.js");
+
+module.exports = function isNumber(num) {
+  var type = typeOf(num);
+  if (type !== 'number' && type !== 'string') {
+    return false;
+  }
+  var n = +num;
+  return (n - n + 1) >= 0 && num !== '';
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/expand-range/node_modules/isarray/index.js":
+/*!*************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/isarray/index.js ***!
+  \*************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+var toString = {}.toString;
+
+module.exports = Array.isArray || function (arr) {
+  return toString.call(arr) == '[object Array]';
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/expand-range/node_modules/isobject/index.js":
+/*!**************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/expand-range/node_modules/isobject/index.js ***!
+  \**************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * isobject <https://github.com/jonschlinkert/isobject>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var isArray = __webpack_require__(/*! isarray */ "../../api-javascript/node_modules/expand-range/node_modules/isarray/index.js");
+
+module.exports = function isObject(val) {
+  return val != null && typeof val === 'object' && isArray(val) === false;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/extend-shallow/index.js":
+/*!******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/extend-shallow/index.js ***!
+  \******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var isObject = __webpack_require__(/*! is-extendable */ "../../api-javascript/node_modules/is-extendable/index.js");
+
+module.exports = function extend(o/*, objects*/) {
+  if (!isObject(o)) { o = {}; }
+
+  var len = arguments.length;
+  for (var i = 1; i < len; i++) {
+    var obj = arguments[i];
+
+    if (isObject(obj)) {
+      assign(o, obj);
+    }
+  }
+  return o;
+};
+
+function assign(a, b) {
+  for (var key in b) {
+    if (hasOwn(b, key)) {
+      a[key] = b[key];
+    }
+  }
+}
+
+/**
+ * Returns true if the given `key` is an own property of `obj`.
+ */
+
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/extglob/index.js":
+/*!***********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/extglob/index.js ***!
+  \***********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * extglob <https://github.com/jonschlinkert/extglob>
+ *
+ * Copyright (c) 2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+/**
+ * Module dependencies
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
+var re, cache = {};
+
+/**
+ * Expose `extglob`
+ */
+
+module.exports = extglob;
+
+/**
+ * Convert the given extglob `string` to a regex-compatible
+ * string.
+ *
+ * ```js
+ * var extglob = require('extglob');
+ * extglob('!(a?(b))');
+ * //=> '(?!a(?:b)?)[^/]*?'
+ * ```
+ *
+ * @param {String} `str` The string to convert.
+ * @param {Object} `options`
+ *   @option {Boolean} [options] `esc` If `false` special characters will not be escaped. Defaults to `true`.
+ *   @option {Boolean} [options] `regex` If `true` a regular expression is returned instead of a string.
+ * @return {String}
+ * @api public
+ */
+
+
+function extglob(str, opts) {
+  opts = opts || {};
+  var o = {}, i = 0;
+
+  // fix common character reversals
+  // '*!(.js)' => '*.!(js)'
+  str = str.replace(/!\(([^\w*()])/g, '$1!(');
+
+  // support file extension negation
+  str = str.replace(/([*\/])\.!\([*]\)/g, function (m, ch) {
+    if (ch === '/') {
+      return escape('\\/[^.]+');
+    }
+    return escape('[^.]+');
+  });
+
+  // create a unique key for caching by
+  // combining the string and options
+  var key = str
+    + String(!!opts.regex)
+    + String(!!opts.contains)
+    + String(!!opts.escape);
+
+  if (cache.hasOwnProperty(key)) {
+    return cache[key];
+  }
+
+  if (!(re instanceof RegExp)) {
+    re = regex();
+  }
+
+  opts.negate = false;
+  var m;
+
+  while (m = re.exec(str)) {
+    var prefix = m[1];
+    var inner = m[3];
+    if (prefix === '!') {
+      opts.negate = true;
+    }
+
+    var id = '__EXTGLOB_' + (i++) + '__';
+    // use the prefix of the _last_ (outtermost) pattern
+    o[id] = wrap(inner, prefix, opts.escape);
+    str = str.split(m[0]).join(id);
+  }
+
+  var keys = Object.keys(o);
+  var len = keys.length;
+
+  // we have to loop again to allow us to convert
+  // patterns in reverse order (starting with the
+  // innermost/last pattern first)
+  while (len--) {
+    var prop = keys[len];
+    str = str.split(prop).join(o[prop]);
+  }
+
+  var result = opts.regex
+    ? toRegex(str, opts.contains, opts.negate)
+    : str;
+
+  result = result.split('.').join('\\.');
+
+  // cache the result and return it
+  return (cache[key] = result);
+}
+
+/**
+ * Convert `string` to a regex string.
+ *
+ * @param  {String} `str`
+ * @param  {String} `prefix` Character that determines how to wrap the string.
+ * @param  {Boolean} `esc` If `false` special characters will not be escaped. Defaults to `true`.
+ * @return {String}
+ */
+
+function wrap(inner, prefix, esc) {
+  if (esc) inner = escape(inner);
+
+  switch (prefix) {
+    case '!':
+      return '(?!' + inner + ')[^/]' + (esc ? '%%%~' : '*?');
+    case '@':
+      return '(?:' + inner + ')';
+    case '+':
+      return '(?:' + inner + ')+';
+    case '*':
+      return '(?:' + inner + ')' + (esc ? '%%' : '*')
+    case '?':
+      return '(?:' + inner + '|)';
+    default:
+      return inner;
+  }
+}
+
+function escape(str) {
+  str = str.split('*').join('[^/]%%%~');
+  str = str.split('.').join('\\.');
+  return str;
+}
+
+/**
+ * extglob regex.
+ */
+
+function regex() {
+  return /(\\?[@?!+*$]\\?)(\(([^()]*?)\))/;
+}
+
+/**
+ * Negation regex
+ */
+
+function negate(str) {
+  return '(?!^' + str + ').*$';
+}
+
+/**
+ * Create the regex to do the matching. If
+ * the leading character in the `pattern` is `!`
+ * a negation regex is returned.
+ *
+ * @param {String} `pattern`
+ * @param {Boolean} `contains` Allow loose matching.
+ * @param {Boolean} `isNegated` True if the pattern is a negation pattern.
+ */
+
+function toRegex(pattern, contains, isNegated) {
+  var prefix = contains ? '^' : '';
+  var after = contains ? '$' : '';
+  pattern = ('(?:' + pattern + ')' + after);
+  if (isNegated) {
+    pattern = prefix + negate(pattern);
+  }
+  return new RegExp(prefix + pattern);
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/fetch-ponyfill/build/fetch-browser.js":
+/*!********************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/fetch-ponyfill/build/fetch-browser.js ***!
+  \********************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/* WEBPACK VAR INJECTION */(function(global) {var __WEBPACK_AMD_DEFINE_RESULT__;(function (self) {
+  'use strict';
+
+  function fetchPonyfill(options) {
+    var Promise = options && options.Promise || self.Promise;
+    var XMLHttpRequest = options && options.XMLHttpRequest || self.XMLHttpRequest;
+    var global = self;
+
+    return (function () {
+      var self = Object.create(global, {
+        fetch: {
+          value: undefined,
+          writable: true
+        }
+      });
+
+      (function(self) {
+        'use strict';
+
+        if (self.fetch) {
+          return
+        }
+
+        var support = {
+          searchParams: 'URLSearchParams' in self,
+          iterable: 'Symbol' in self && 'iterator' in Symbol,
+          blob: 'FileReader' in self && 'Blob' in self && (function() {
+            try {
+              new Blob()
+              return true
+            } catch(e) {
+              return false
+            }
+          })(),
+          formData: 'FormData' in self,
+          arrayBuffer: 'ArrayBuffer' in self
+        }
+
+        if (support.arrayBuffer) {
+          var viewClasses = [
+            '[object Int8Array]',
+            '[object Uint8Array]',
+            '[object Uint8ClampedArray]',
+            '[object Int16Array]',
+            '[object Uint16Array]',
+            '[object Int32Array]',
+            '[object Uint32Array]',
+            '[object Float32Array]',
+            '[object Float64Array]'
+          ]
+
+          var isDataView = function(obj) {
+            return obj && DataView.prototype.isPrototypeOf(obj)
+          }
+
+          var isArrayBufferView = ArrayBuffer.isView || function(obj) {
+            return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
+          }
+        }
+
+        function normalizeName(name) {
+          if (typeof name !== 'string') {
+            name = String(name)
+          }
+          if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
+            throw new TypeError('Invalid character in header field name')
+          }
+          return name.toLowerCase()
+        }
+
+        function normalizeValue(value) {
+          if (typeof value !== 'string') {
+            value = String(value)
+          }
+          return value
+        }
+
+        // Build a destructive iterator for the value list
+        function iteratorFor(items) {
+          var iterator = {
+            next: function() {
+              var value = items.shift()
+              return {done: value === undefined, value: value}
+            }
+          }
+
+          if (support.iterable) {
+            iterator[Symbol.iterator] = function() {
+              return iterator
+            }
+          }
+
+          return iterator
+        }
+
+        function Headers(headers) {
+          this.map = {}
+
+          if (headers instanceof Headers) {
+            headers.forEach(function(value, name) {
+              this.append(name, value)
+            }, this)
+          } else if (Array.isArray(headers)) {
+            headers.forEach(function(header) {
+              this.append(header[0], header[1])
+            }, this)
+          } else if (headers) {
+            Object.getOwnPropertyNames(headers).forEach(function(name) {
+              this.append(name, headers[name])
+            }, this)
+          }
+        }
+
+        Headers.prototype.append = function(name, value) {
+          name = normalizeName(name)
+          value = normalizeValue(value)
+          var oldValue = this.map[name]
+          this.map[name] = oldValue ? oldValue+','+value : value
+        }
+
+        Headers.prototype['delete'] = function(name) {
+          delete this.map[normalizeName(name)]
+        }
+
+        Headers.prototype.get = function(name) {
+          name = normalizeName(name)
+          return this.has(name) ? this.map[name] : null
+        }
+
+        Headers.prototype.has = function(name) {
+          return this.map.hasOwnProperty(normalizeName(name))
+        }
+
+        Headers.prototype.set = function(name, value) {
+          this.map[normalizeName(name)] = normalizeValue(value)
+        }
+
+        Headers.prototype.forEach = function(callback, thisArg) {
+          for (var name in this.map) {
+            if (this.map.hasOwnProperty(name)) {
+              callback.call(thisArg, this.map[name], name, this)
+            }
+          }
+        }
+
+        Headers.prototype.keys = function() {
+          var items = []
+          this.forEach(function(value, name) { items.push(name) })
+          return iteratorFor(items)
+        }
+
+        Headers.prototype.values = function() {
+          var items = []
+          this.forEach(function(value) { items.push(value) })
+          return iteratorFor(items)
+        }
+
+        Headers.prototype.entries = function() {
+          var items = []
+          this.forEach(function(value, name) { items.push([name, value]) })
+          return iteratorFor(items)
+        }
+
+        if (support.iterable) {
+          Headers.prototype[Symbol.iterator] = Headers.prototype.entries
+        }
+
+        function consumed(body) {
+          if (body.bodyUsed) {
+            return Promise.reject(new TypeError('Already read'))
+          }
+          body.bodyUsed = true
+        }
+
+        function fileReaderReady(reader) {
+          return new Promise(function(resolve, reject) {
+            reader.onload = function() {
+              resolve(reader.result)
+            }
+            reader.onerror = function() {
+              reject(reader.error)
+            }
+          })
+        }
+
+        function readBlobAsArrayBuffer(blob) {
+          var reader = new FileReader()
+          var promise = fileReaderReady(reader)
+          reader.readAsArrayBuffer(blob)
+          return promise
+        }
+
+        function readBlobAsText(blob) {
+          var reader = new FileReader()
+          var promise = fileReaderReady(reader)
+          reader.readAsText(blob)
+          return promise
+        }
+
+        function readArrayBufferAsText(buf) {
+          var view = new Uint8Array(buf)
+          var chars = new Array(view.length)
+
+          for (var i = 0; i < view.length; i++) {
+            chars[i] = String.fromCharCode(view[i])
+          }
+          return chars.join('')
+        }
+
+        function bufferClone(buf) {
+          if (buf.slice) {
+            return buf.slice(0)
+          } else {
+            var view = new Uint8Array(buf.byteLength)
+            view.set(new Uint8Array(buf))
+            return view.buffer
+          }
+        }
+
+        function Body() {
+          this.bodyUsed = false
+
+          this._initBody = function(body) {
+            this._bodyInit = body
+            if (!body) {
+              this._bodyText = ''
+            } else if (typeof body === 'string') {
+              this._bodyText = body
+            } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
+              this._bodyBlob = body
+            } else if (support.formData && FormData.prototype.isPrototypeOf(body)) {
+              this._bodyFormData = body
+            } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
+              this._bodyText = body.toString()
+            } else if (support.arrayBuffer && support.blob && isDataView(body)) {
+              this._bodyArrayBuffer = bufferClone(body.buffer)
+              // IE 10-11 can't handle a DataView body.
+              this._bodyInit = new Blob([this._bodyArrayBuffer])
+            } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
+              this._bodyArrayBuffer = bufferClone(body)
+            } else {
+              throw new Error('unsupported BodyInit type')
+            }
+
+            if (!this.headers.get('content-type')) {
+              if (typeof body === 'string') {
+                this.headers.set('content-type', 'text/plain;charset=UTF-8')
+              } else if (this._bodyBlob && this._bodyBlob.type) {
+                this.headers.set('content-type', this._bodyBlob.type)
+              } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
+                this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
+              }
+            }
+          }
+
+          if (support.blob) {
+            this.blob = function() {
+              var rejected = consumed(this)
+              if (rejected) {
+                return rejected
+              }
+
+              if (this._bodyBlob) {
+                return Promise.resolve(this._bodyBlob)
+              } else if (this._bodyArrayBuffer) {
+                return Promise.resolve(new Blob([this._bodyArrayBuffer]))
+              } else if (this._bodyFormData) {
+                throw new Error('could not read FormData body as blob')
+              } else {
+                return Promise.resolve(new Blob([this._bodyText]))
+              }
+            }
+
+            this.arrayBuffer = function() {
+              if (this._bodyArrayBuffer) {
+                return consumed(this) || Promise.resolve(this._bodyArrayBuffer)
+              } else {
+                return this.blob().then(readBlobAsArrayBuffer)
+              }
+            }
+          }
+
+          this.text = function() {
+            var rejected = consumed(this)
+            if (rejected) {
+              return rejected
+            }
+
+            if (this._bodyBlob) {
+              return readBlobAsText(this._bodyBlob)
+            } else if (this._bodyArrayBuffer) {
+              return Promise.resolve(readArrayBufferAsText(this._bodyArrayBuffer))
+            } else if (this._bodyFormData) {
+              throw new Error('could not read FormData body as text')
+            } else {
+              return Promise.resolve(this._bodyText)
+            }
+          }
+
+          if (support.formData) {
+            this.formData = function() {
+              return this.text().then(decode)
+            }
+          }
+
+          this.json = function() {
+            return this.text().then(JSON.parse)
+          }
+
+          return this
+        }
+
+        // HTTP methods whose capitalization should be normalized
+        var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+
+        function normalizeMethod(method) {
+          var upcased = method.toUpperCase()
+          return (methods.indexOf(upcased) > -1) ? upcased : method
+        }
+
+        function Request(input, options) {
+          options = options || {}
+          var body = options.body
+
+          if (input instanceof Request) {
+            if (input.bodyUsed) {
+              throw new TypeError('Already read')
+            }
+            this.url = input.url
+            this.credentials = input.credentials
+            if (!options.headers) {
+              this.headers = new Headers(input.headers)
+            }
+            this.method = input.method
+            this.mode = input.mode
+            if (!body && input._bodyInit != null) {
+              body = input._bodyInit
+              input.bodyUsed = true
+            }
+          } else {
+            this.url = String(input)
+          }
+
+          this.credentials = options.credentials || this.credentials || 'omit'
+          if (options.headers || !this.headers) {
+            this.headers = new Headers(options.headers)
+          }
+          this.method = normalizeMethod(options.method || this.method || 'GET')
+          this.mode = options.mode || this.mode || null
+          this.referrer = null
+
+          if ((this.method === 'GET' || this.method === 'HEAD') && body) {
+            throw new TypeError('Body not allowed for GET or HEAD requests')
+          }
+          this._initBody(body)
+        }
+
+        Request.prototype.clone = function() {
+          return new Request(this, { body: this._bodyInit })
+        }
+
+        function decode(body) {
+          var form = new FormData()
+          body.trim().split('&').forEach(function(bytes) {
+            if (bytes) {
+              var split = bytes.split('=')
+              var name = split.shift().replace(/\+/g, ' ')
+              var value = split.join('=').replace(/\+/g, ' ')
+              form.append(decodeURIComponent(name), decodeURIComponent(value))
+            }
+          })
+          return form
+        }
+
+        function parseHeaders(rawHeaders) {
+          var headers = new Headers()
+          // Replace instances of \r\n and \n followed by at least one space or horizontal tab with a space
+          // https://tools.ietf.org/html/rfc7230#section-3.2
+          var preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/g, ' ')
+          preProcessedHeaders.split(/\r?\n/).forEach(function(line) {
+            var parts = line.split(':')
+            var key = parts.shift().trim()
+            if (key) {
+              var value = parts.join(':').trim()
+              headers.append(key, value)
+            }
+          })
+          return headers
+        }
+
+        Body.call(Request.prototype)
+
+        function Response(bodyInit, options) {
+          if (!options) {
+            options = {}
+          }
+
+          this.type = 'default'
+          this.status = options.status === undefined ? 200 : options.status
+          this.ok = this.status >= 200 && this.status < 300
+          this.statusText = 'statusText' in options ? options.statusText : 'OK'
+          this.headers = new Headers(options.headers)
+          this.url = options.url || ''
+          this._initBody(bodyInit)
+        }
+
+        Body.call(Response.prototype)
+
+        Response.prototype.clone = function() {
+          return new Response(this._bodyInit, {
+            status: this.status,
+            statusText: this.statusText,
+            headers: new Headers(this.headers),
+            url: this.url
+          })
+        }
+
+        Response.error = function() {
+          var response = new Response(null, {status: 0, statusText: ''})
+          response.type = 'error'
+          return response
+        }
+
+        var redirectStatuses = [301, 302, 303, 307, 308]
+
+        Response.redirect = function(url, status) {
+          if (redirectStatuses.indexOf(status) === -1) {
+            throw new RangeError('Invalid status code')
+          }
+
+          return new Response(null, {status: status, headers: {location: url}})
+        }
+
+        self.Headers = Headers
+        self.Request = Request
+        self.Response = Response
+
+        self.fetch = function(input, init) {
+          return new Promise(function(resolve, reject) {
+            var request = new Request(input, init)
+            var xhr = new XMLHttpRequest()
+
+            xhr.onload = function() {
+              var options = {
+                status: xhr.status,
+                statusText: xhr.statusText,
+                headers: parseHeaders(xhr.getAllResponseHeaders() || '')
+              }
+              options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
+              var body = 'response' in xhr ? xhr.response : xhr.responseText
+              resolve(new Response(body, options))
+            }
+
+            xhr.onerror = function() {
+              reject(new TypeError('Network request failed'))
+            }
+
+            xhr.ontimeout = function() {
+              reject(new TypeError('Network request failed'))
+            }
+
+            xhr.open(request.method, request.url, true)
+
+            if (request.credentials === 'include') {
+              xhr.withCredentials = true
+            } else if (request.credentials === 'omit') {
+              xhr.withCredentials = false
+            }
+
+            if ('responseType' in xhr && support.blob) {
+              xhr.responseType = 'blob'
+            }
+
+            request.headers.forEach(function(value, name) {
+              xhr.setRequestHeader(name, value)
+            })
+
+            xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)
+          })
+        }
+        self.fetch.polyfill = true
+      })(typeof self !== 'undefined' ? self : this);
+
+
+      return {
+        fetch: self.fetch,
+        Headers: self.Headers,
+        Request: self.Request,
+        Response: self.Response
+      };
+    }());
+  }
+
+  if (true) {
+    !(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {
+      return fetchPonyfill;
+    }).call(exports, __webpack_require__, exports, module),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  } else {}
+}(typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : this));
+
+
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../sfx/sfx-logic/node_modules/webpack/buildin/global.js */ "./node_modules/webpack/buildin/global.js")))
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/filename-regex/index.js":
+/*!******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/filename-regex/index.js ***!
+  \******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+/*!
+ * filename-regex <https://github.com/regexps/filename-regex>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert
+ * Licensed under the MIT license.
+ */
+
+module.exports = function filenameRegex() {
+  return /([^\\\/]+)$/;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/filter-keys/index.js":
+/*!***************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/filter-keys/index.js ***!
+  \***************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var mm = __webpack_require__(/*! micromatch */ "../../api-javascript/node_modules/micromatch/index.js");
+
+module.exports = function filterKeys(o, patterns, options) {
+  if (o == null) {
+    throw new Error('filter-keys expects an object');
+  }
+
+  var keys = Object.keys(o);
+  if (!patterns || arguments.length === 1) {
+    return keys;
+  }
+
+  return mm(keys, patterns, options);
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/filter-object/index.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/filter-object/index.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/filter-object/node_modules/kind-of/index.js");
+var filterKeys = __webpack_require__(/*! filter-keys */ "../../api-javascript/node_modules/filter-keys/index.js");
+var filterValues = __webpack_require__(/*! filter-values */ "../../api-javascript/node_modules/filter-values/index.js");
+var pick = __webpack_require__(/*! object.pick */ "../../api-javascript/node_modules/object.pick/index.js");
+var extend = __webpack_require__(/*! extend-shallow */ "../../api-javascript/node_modules/extend-shallow/index.js");
+
+module.exports = function filterObject(val, patterns, options) {
+  if (!val || typeof val !== 'object') {
+    throw new Error('filter-object expects an object');
+  }
+
+  if (patterns == null) return val;
+
+  if (typeOf(patterns) === 'function') {
+    return filterValues(val, patterns, options);
+  }
+
+  var keys = filterKeys(val, patterns, options);
+  return pick(val, keys);
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/filter-object/node_modules/kind-of/index.js":
+/*!**************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/filter-object/node_modules/kind-of/index.js ***!
+  \**************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/* WEBPACK VAR INJECTION */(function(Buffer) {var isBuffer = __webpack_require__(/*! is-buffer */ "../../api-javascript/node_modules/is-buffer/index.js");
+var toString = Object.prototype.toString;
+
+/**
+ * Get the native `typeof` a value.
+ *
+ * @param  {*} `val`
+ * @return {*} Native javascript type
+ */
+
+module.exports = function kindOf(val) {
+  // primitivies
+  if (typeof val === 'undefined') {
+    return 'undefined';
+  }
+  if (val === null) {
+    return 'null';
+  }
+  if (val === true || val === false || val instanceof Boolean) {
+    return 'boolean';
+  }
+  if (typeof val === 'string' || val instanceof String) {
+    return 'string';
+  }
+  if (typeof val === 'number' || val instanceof Number) {
+    return 'number';
+  }
+
+  // functions
+  if (typeof val === 'function' || val instanceof Function) {
+    return 'function';
+  }
+
+  // array
+  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
+    return 'array';
+  }
+
+  // check for instances of RegExp and Date before calling `toString`
+  if (val instanceof RegExp) {
+    return 'regexp';
+  }
+  if (val instanceof Date) {
+    return 'date';
+  }
+
+  // other objects
+  var type = toString.call(val);
+
+  if (type === '[object RegExp]') {
+    return 'regexp';
+  }
+  if (type === '[object Date]') {
+    return 'date';
+  }
+  if (type === '[object Arguments]') {
+    return 'arguments';
+  }
+
+  // buffer
+  if (typeof Buffer !== 'undefined' && isBuffer(val)) {
+    return 'buffer';
+  }
+
+  // es6: Map, WeakMap, Set, WeakSet
+  if (type === '[object Set]') {
+    return 'set';
+  }
+  if (type === '[object WeakSet]') {
+    return 'weakset';
+  }
+  if (type === '[object Map]') {
+    return 'map';
+  }
+  if (type === '[object WeakMap]') {
+    return 'weakmap';
+  }
+  if (type === '[object Symbol]') {
+    return 'symbol';
+  }
+
+  // must be a plain object
+  return 'object';
+};
+
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../../sfx/sfx-logic/node_modules/node-libs-browser/node_modules/buffer/index.js */ "./node_modules/node-libs-browser/node_modules/buffer/index.js").Buffer))
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/filter-values/index.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/filter-values/index.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * filter-values <https://github.com/jonschlinkert/filter-values>
+ *
+ * Copyright (c) 2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var forOwn = __webpack_require__(/*! for-own */ "../../api-javascript/node_modules/for-own/index.js");
+var matcher = __webpack_require__(/*! is-match */ "../../api-javascript/node_modules/is-match/index.js");
+
+/**
+ * Filter an object values using glob patterns
+ * or with a `callback` function returns true.
+ *
+ * @param  {Object} `obj`
+ * @param  {Function|Array|String|RegExp} `filter`
+ * @param  {Object} `options` pass options to `micromatch`
+ * @return {Object}
+ */
+
+module.exports = function filterValues(obj, filter, options) {
+  var isMatch = matcher(filter, options);
+  var res = {};
+
+  forOwn(obj, function (val, key) {
+    if (isMatch(val, key, obj)) {
+      res[key] = val;
+    }
+  });
+  return res;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/for-in/index.js":
+/*!**********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/for-in/index.js ***!
+  \**********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * for-in <https://github.com/jonschlinkert/for-in>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+module.exports = function forIn(obj, fn, thisArg) {
+  for (var key in obj) {
+    if (fn.call(thisArg, obj[key], key, obj) === false) {
+      break;
+    }
+  }
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/for-own/index.js":
+/*!***********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/for-own/index.js ***!
+  \***********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * for-own <https://github.com/jonschlinkert/for-own>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+var forIn = __webpack_require__(/*! for-in */ "../../api-javascript/node_modules/for-in/index.js");
+var hasOwn = Object.prototype.hasOwnProperty;
+
+module.exports = function forOwn(obj, fn, thisArg) {
+  forIn(obj, function(val, key) {
+    if (hasOwn.call(obj, key)) {
+      return fn.call(thisArg, obj[key], key, obj);
+    }
+  });
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/glob-base/index.js":
+/*!*************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/glob-base/index.js ***!
+  \*************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * glob-base <https://github.com/jonschlinkert/glob-base>
+ *
+ * Copyright (c) 2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
+var parent = __webpack_require__(/*! glob-parent */ "../../api-javascript/node_modules/glob-base/node_modules/glob-parent/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
+
+module.exports = function globBase(pattern) {
+  if (typeof pattern !== 'string') {
+    throw new TypeError('glob-base expects a string.');
+  }
+
+  var res = {};
+  res.base = parent(pattern);
+  res.isGlob = isGlob(pattern);
+
+  if (res.base !== '.') {
+    res.glob = pattern.substr(res.base.length);
+    if (res.glob.charAt(0) === '/') {
+      res.glob = res.glob.substr(1);
+    }
+  } else {
+    res.glob = pattern;
+  }
+
+  if (!res.isGlob) {
+    res.base = dirname(pattern);
+    res.glob = res.base !== '.'
+      ? pattern.substr(res.base.length)
+      : pattern;
+  }
+
+  if (res.glob.substr(0, 2) === './') {
+    res.glob = res.glob.substr(2);
+  }
+  if (res.glob.charAt(0) === '/') {
+    res.glob = res.glob.substr(1);
+  }
+  return res;
+};
+
+function dirname(glob) {
+  if (glob.slice(-1) === '/') return glob;
+  return path.dirname(glob);
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/glob-base/node_modules/glob-parent/index.js":
+/*!**************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/glob-base/node_modules/glob-parent/index.js ***!
+  \**************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
+var isglob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
+
+module.exports = function globParent(str) {
+	str += 'a'; // preserves full path in case of trailing path separator
+	do {str = path.dirname(str)} while (isglob(str));
+	return str;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-buffer/index.js":
+/*!*************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-buffer/index.js ***!
+  \*************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+/*!
+ * Determine if an object is a Buffer
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */
+
+// The _isBuffer check is for Safari 5-7 support, because it's missing
+// Object.prototype.constructor. Remove this eventually
+module.exports = function (obj) {
+  return obj != null && (isBuffer(obj) || isSlowBuffer(obj) || !!obj._isBuffer)
+}
+
+function isBuffer (obj) {
+  return !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
+}
+
+// For Node v0.10 support. Remove this eventually.
+function isSlowBuffer (obj) {
+  return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-dotfile/index.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-dotfile/index.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+/*!
+ * is-dotfile <https://github.com/jonschlinkert/is-dotfile>
+ *
+ * Copyright (c) 2015-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+module.exports = function(str) {
+  if (str.charCodeAt(0) === 46 /* . */ && str.indexOf('/', 1) === -1) {
+    return true;
+  }
+  var slash = str.lastIndexOf('/');
+  return slash !== -1 ? str.charCodeAt(slash + 1) === 46  /* . */ : false;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-equal-shallow/index.js":
+/*!********************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-equal-shallow/index.js ***!
+  \********************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * is-equal-shallow <https://github.com/jonschlinkert/is-equal-shallow>
+ *
+ * Copyright (c) 2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var isPrimitive = __webpack_require__(/*! is-primitive */ "../../api-javascript/node_modules/is-primitive/index.js");
+
+module.exports = function isEqual(a, b) {
+  if (!a && !b) { return true; }
+  if (!a && b || a && !b) { return false; }
+
+  var numKeysA = 0, numKeysB = 0, key;
+  for (key in b) {
+    numKeysB++;
+    if (!isPrimitive(b[key]) || !a.hasOwnProperty(key) || (a[key] !== b[key])) {
+      return false;
+    }
+  }
+  for (key in a) {
+    numKeysA++;
+  }
+  return numKeysA === numKeysB;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-extendable/index.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-extendable/index.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * is-extendable <https://github.com/jonschlinkert/is-extendable>
+ *
+ * Copyright (c) 2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+module.exports = function isExtendable(val) {
+  return typeof val !== 'undefined' && val !== null
+    && (typeof val === 'object' || typeof val === 'function');
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-extglob/index.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-extglob/index.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+/*!
+ * is-extglob <https://github.com/jonschlinkert/is-extglob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+module.exports = function isExtglob(str) {
+  return typeof str === 'string'
+    && /[@?!+*]\(/.test(str);
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-glob/index.js":
+/*!***********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-glob/index.js ***!
+  \***********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * is-glob <https://github.com/jonschlinkert/is-glob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
+
+module.exports = function isGlob(str) {
+  return typeof str === 'string'
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
+};
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-match/index.js":
+/*!************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-match/index.js ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * is-match <https://github.com/jonschlinkert/is-match>
+ *
+ * Copyright (c) 2015-2016 Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+
+
+var deepEqual = __webpack_require__(/*! deep-equal */ "../../api-javascript/node_modules/deep-equal/index.js");
+var isObject = __webpack_require__(/*! is-extendable */ "../../api-javascript/node_modules/is-extendable/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
+var mm = __webpack_require__(/*! micromatch */ "../../api-javascript/node_modules/micromatch/index.js");
+
+function isMatch(pattern, options) {
+  options = options || {};
+
+  if (typeof pattern === 'function') {
+    return pattern;
+  }
+
+  if (pattern instanceof RegExp) {
+    return function(val) {
+      return pattern.test(val);
+    };
+  }
+
+  if (typeof pattern === 'string') {
+    if (isGlob(pattern)) {
+      return function(val) {
+        return mm(val, pattern, options).length !== 0;
+      };
+    }
+    return function(val) {
+      if (options.strict === true) {
+        return pattern === val;
+      }
+      return val.indexOf(pattern) > -1;
+    };
+  }
+
+  if (Array.isArray(pattern)) {
+    return function(val) {
+      return mm(val, pattern, options).length !== 0;
+    };
+  }
+
+  if (isObject(pattern)) {
+    return function(val) {
+      return deepEqual(val, pattern);
+    };
+  }
+
+  throw new TypeError('isMatch expects a string, array, regex, plain object or function:', arguments);
+}
+
+/**
+ * Expose `isMatch`
+ */
+
+module.exports = isMatch;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-posix-bracket/index.js":
+/*!********************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-posix-bracket/index.js ***!
+  \********************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+/*!
+ * is-posix-bracket <https://github.com/jonschlinkert/is-posix-bracket>
+ *
+ * Copyright (c) 2015-2016, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+module.exports = function isPosixBracket(str) {
+  return typeof str === 'string' && /\[([:.=+])(?:[^\[\]]|)+\1\]/.test(str);
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/is-primitive/index.js":
+/*!****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/is-primitive/index.js ***!
+  \****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * is-primitive <https://github.com/jonschlinkert/is-primitive>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+// see http://jsperf.com/testing-value-is-primitive/7
+module.exports = function isPrimitive(value) {
+  return value == null || (typeof value !== 'function' && typeof value !== 'object');
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/isobject/index.js":
+/*!************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/isobject/index.js ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * isobject <https://github.com/jonschlinkert/isobject>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+module.exports = function isObject(val) {
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/kind-of/index.js":
+/*!***********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/kind-of/index.js ***!
+  \***********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isBuffer = __webpack_require__(/*! is-buffer */ "../../api-javascript/node_modules/is-buffer/index.js");
+var toString = Object.prototype.toString;
+
+/**
+ * Get the native `typeof` a value.
+ *
+ * @param  {*} `val`
+ * @return {*} Native javascript type
+ */
+
+module.exports = function kindOf(val) {
+  // primitivies
+  if (typeof val === 'undefined') {
+    return 'undefined';
+  }
+  if (val === null) {
+    return 'null';
+  }
+  if (val === true || val === false || val instanceof Boolean) {
+    return 'boolean';
+  }
+  if (typeof val === 'string' || val instanceof String) {
+    return 'string';
+  }
+  if (typeof val === 'number' || val instanceof Number) {
+    return 'number';
+  }
+
+  // functions
+  if (typeof val === 'function' || val instanceof Function) {
+    return 'function';
+  }
+
+  // array
+  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
+    return 'array';
+  }
+
+  // check for instances of RegExp and Date before calling `toString`
+  if (val instanceof RegExp) {
+    return 'regexp';
+  }
+  if (val instanceof Date) {
+    return 'date';
+  }
+
+  // other objects
+  var type = toString.call(val);
+
+  if (type === '[object RegExp]') {
+    return 'regexp';
+  }
+  if (type === '[object Date]') {
+    return 'date';
+  }
+  if (type === '[object Arguments]') {
+    return 'arguments';
+  }
+  if (type === '[object Error]') {
+    return 'error';
+  }
+
+  // buffer
+  if (isBuffer(val)) {
+    return 'buffer';
+  }
+
+  // es6: Map, WeakMap, Set, WeakSet
+  if (type === '[object Set]') {
+    return 'set';
+  }
+  if (type === '[object WeakSet]') {
+    return 'weakset';
+  }
+  if (type === '[object Map]') {
+    return 'map';
+  }
+  if (type === '[object WeakMap]') {
+    return 'weakmap';
+  }
+  if (type === '[object Symbol]') {
+    return 'symbol';
+  }
+
+  // typed arrays
+  if (type === '[object Int8Array]') {
+    return 'int8array';
+  }
+  if (type === '[object Uint8Array]') {
+    return 'uint8array';
+  }
+  if (type === '[object Uint8ClampedArray]') {
+    return 'uint8clampedarray';
+  }
+  if (type === '[object Int16Array]') {
+    return 'int16array';
+  }
+  if (type === '[object Uint16Array]') {
+    return 'uint16array';
+  }
+  if (type === '[object Int32Array]') {
+    return 'int32array';
+  }
+  if (type === '[object Uint32Array]') {
+    return 'uint32array';
+  }
+  if (type === '[object Float32Array]') {
+    return 'float32array';
+  }
+  if (type === '[object Float64Array]') {
+    return 'float64array';
+  }
+
+  // must be a plain object
+  return 'object';
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/math-random/browser.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/math-random/browser.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+module.exports = (function (global) {
+  var uint32 = 'Uint32Array' in global
+  var crypto = global.crypto || global.msCrypto
+  var rando = crypto && typeof crypto.getRandomValues === 'function'
+  var good = uint32 && rando
+  if (!good) return Math.random
+
+  var arr = new Uint32Array(1)
+  var max = Math.pow(2, 32)
+  function random () {
+    crypto.getRandomValues(arr)
+    return arr[0] / max
+  }
+
+  random.cryptographic = true
+  return random
+})(typeof self !== 'undefined' ? self : window)
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/index.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/index.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * micromatch <https://github.com/jonschlinkert/micromatch>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var expand = __webpack_require__(/*! ./lib/expand */ "../../api-javascript/node_modules/micromatch/lib/expand.js");
+var utils = __webpack_require__(/*! ./lib/utils */ "../../api-javascript/node_modules/micromatch/lib/utils.js");
+
+/**
+ * The main function. Pass an array of filepaths,
+ * and a string or array of glob patterns
+ *
+ * @param  {Array|String} `files`
+ * @param  {Array|String} `patterns`
+ * @param  {Object} `opts`
+ * @return {Array} Array of matches
+ */
+
+function micromatch(files, patterns, opts) {
+  if (!files || !patterns) return [];
+  opts = opts || {};
+
+  if (typeof opts.cache === 'undefined') {
+    opts.cache = true;
+  }
+
+  if (!Array.isArray(patterns)) {
+    return match(files, patterns, opts);
+  }
+
+  var len = patterns.length, i = 0;
+  var omit = [], keep = [];
+
+  while (len--) {
+    var glob = patterns[i++];
+    if (typeof glob === 'string' && glob.charCodeAt(0) === 33 /* ! */) {
+      omit.push.apply(omit, match(files, glob.slice(1), opts));
+    } else {
+      keep.push.apply(keep, match(files, glob, opts));
+    }
+  }
+  return utils.diff(keep, omit);
+}
+
+/**
+ * Return an array of files that match the given glob pattern.
+ *
+ * This function is called by the main `micromatch` function If you only
+ * need to pass a single pattern you might get very minor speed improvements
+ * using this function.
+ *
+ * @param  {Array} `files`
+ * @param  {String} `pattern`
+ * @param  {Object} `options`
+ * @return {Array}
+ */
+
+function match(files, pattern, opts) {
+  if (utils.typeOf(files) !== 'string' && !Array.isArray(files)) {
+    throw new Error(msg('match', 'files', 'a string or array'));
+  }
+
+  files = utils.arrayify(files);
+  opts = opts || {};
+
+  var negate = opts.negate || false;
+  var orig = pattern;
+
+  if (typeof pattern === 'string') {
+    negate = pattern.charAt(0) === '!';
+    if (negate) {
+      pattern = pattern.slice(1);
+    }
+
+    // we need to remove the character regardless,
+    // so the above logic is still needed
+    if (opts.nonegate === true) {
+      negate = false;
+    }
+  }
+
+  var _isMatch = matcher(pattern, opts);
+  var len = files.length, i = 0;
+  var res = [];
+
+  while (i < len) {
+    var file = files[i++];
+    var fp = utils.unixify(file, opts);
+
+    if (!_isMatch(fp)) { continue; }
+    res.push(fp);
+  }
+
+  if (res.length === 0) {
+    if (opts.failglob === true) {
+      throw new Error('micromatch.match() found no matches for: "' + orig + '".');
+    }
+
+    if (opts.nonull || opts.nullglob) {
+      res.push(utils.unescapeGlob(orig));
+    }
+  }
+
+  // if `negate` was defined, diff negated files
+  if (negate) { res = utils.diff(files, res); }
+
+  // if `ignore` was defined, diff ignored filed
+  if (opts.ignore && opts.ignore.length) {
+    pattern = opts.ignore;
+    opts = utils.omit(opts, ['ignore']);
+    res = utils.diff(res, micromatch(res, pattern, opts));
+  }
+
+  if (opts.nodupes) {
+    return utils.unique(res);
+  }
+  return res;
+}
+
+/**
+ * Returns a function that takes a glob pattern or array of glob patterns
+ * to be used with `Array#filter()`. (Internally this function generates
+ * the matching function using the [matcher] method).
+ *
+ * ```js
+ * var fn = mm.filter('[a-c]');
+ * ['a', 'b', 'c', 'd', 'e'].filter(fn);
+ * //=> ['a', 'b', 'c']
+ * ```
+ * @param  {String|Array} `patterns` Can be a glob or array of globs.
+ * @param  {Options} `opts` Options to pass to the [matcher] method.
+ * @return {Function} Filter function to be passed to `Array#filter()`.
+ */
+
+function filter(patterns, opts) {
+  if (!Array.isArray(patterns) && typeof patterns !== 'string') {
+    throw new TypeError(msg('filter', 'patterns', 'a string or array'));
+  }
+
+  patterns = utils.arrayify(patterns);
+  var len = patterns.length, i = 0;
+  var patternMatchers = Array(len);
+  while (i < len) {
+    patternMatchers[i] = matcher(patterns[i++], opts);
+  }
+
+  return function(fp) {
+    if (fp == null) return [];
+    var len = patternMatchers.length, i = 0;
+    var res = true;
+
+    fp = utils.unixify(fp, opts);
+    while (i < len) {
+      var fn = patternMatchers[i++];
+      if (!fn(fp)) {
+        res = false;
+        break;
+      }
+    }
+    return res;
+  };
+}
+
+/**
+ * Returns true if the filepath contains the given
+ * pattern. Can also return a function for matching.
+ *
+ * ```js
+ * isMatch('foo.md', '*.md', {});
+ * //=> true
+ *
+ * isMatch('*.md', {})('foo.md')
+ * //=> true
+ * ```
+ * @param  {String} `fp`
+ * @param  {String} `pattern`
+ * @param  {Object} `opts`
+ * @return {Boolean}
+ */
+
+function isMatch(fp, pattern, opts) {
+  if (typeof fp !== 'string') {
+    throw new TypeError(msg('isMatch', 'filepath', 'a string'));
+  }
+
+  fp = utils.unixify(fp, opts);
+  if (utils.typeOf(pattern) === 'object') {
+    return matcher(fp, pattern);
+  }
+  return matcher(pattern, opts)(fp);
+}
+
+/**
+ * Returns true if the filepath matches the
+ * given pattern.
+ */
+
+function contains(fp, pattern, opts) {
+  if (typeof fp !== 'string') {
+    throw new TypeError(msg('contains', 'pattern', 'a string'));
+  }
+
+  opts = opts || {};
+  opts.contains = (pattern !== '');
+  fp = utils.unixify(fp, opts);
+
+  if (opts.contains && !utils.isGlob(pattern)) {
+    return fp.indexOf(pattern) !== -1;
+  }
+  return matcher(pattern, opts)(fp);
+}
+
+/**
+ * Returns true if a file path matches any of the
+ * given patterns.
+ *
+ * @param  {String} `fp` The filepath to test.
+ * @param  {String|Array} `patterns` Glob patterns to use.
+ * @param  {Object} `opts` Options to pass to the `matcher()` function.
+ * @return {String}
+ */
+
+function any(fp, patterns, opts) {
+  if (!Array.isArray(patterns) && typeof patterns !== 'string') {
+    throw new TypeError(msg('any', 'patterns', 'a string or array'));
+  }
+
+  patterns = utils.arrayify(patterns);
+  var len = patterns.length;
+
+  fp = utils.unixify(fp, opts);
+  while (len--) {
+    var isMatch = matcher(patterns[len], opts);
+    if (isMatch(fp)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Filter the keys of an object with the given `glob` pattern
+ * and `options`
+ *
+ * @param  {Object} `object`
+ * @param  {Pattern} `object`
+ * @return {Array}
+ */
+
+function matchKeys(obj, glob, options) {
+  if (utils.typeOf(obj) !== 'object') {
+    throw new TypeError(msg('matchKeys', 'first argument', 'an object'));
+  }
+
+  var fn = matcher(glob, options);
+  var res = {};
+
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key) && fn(key)) {
+      res[key] = obj[key];
+    }
+  }
+  return res;
+}
+
+/**
+ * Return a function for matching based on the
+ * given `pattern` and `options`.
+ *
+ * @param  {String} `pattern`
+ * @param  {Object} `options`
+ * @return {Function}
+ */
+
+function matcher(pattern, opts) {
+  // pattern is a function
+  if (typeof pattern === 'function') {
+    return pattern;
+  }
+  // pattern is a regex
+  if (pattern instanceof RegExp) {
+    return function(fp) {
+      return pattern.test(fp);
+    };
+  }
+
+  if (typeof pattern !== 'string') {
+    throw new TypeError(msg('matcher', 'pattern', 'a string, regex, or function'));
+  }
+
+  // strings, all the way down...
+  pattern = utils.unixify(pattern, opts);
+
+  // pattern is a non-glob string
+  if (!utils.isGlob(pattern)) {
+    return utils.matchPath(pattern, opts);
+  }
+  // pattern is a glob string
+  var re = makeRe(pattern, opts);
+
+  // `matchBase` is defined
+  if (opts && opts.matchBase) {
+    return utils.hasFilename(re, opts);
+  }
+  // `matchBase` is not defined
+  return function(fp) {
+    fp = utils.unixify(fp, opts);
+    return re.test(fp);
+  };
+}
+
+/**
+ * Create and cache a regular expression for matching
+ * file paths.
+ *
+ * If the leading character in the `glob` is `!`, a negation
+ * regex is returned.
+ *
+ * @param  {String} `glob`
+ * @param  {Object} `options`
+ * @return {RegExp}
+ */
+
+function toRegex(glob, options) {
+  // clone options to prevent  mutating the original object
+  var opts = Object.create(options || {});
+  var flags = opts.flags || '';
+  if (opts.nocase && flags.indexOf('i') === -1) {
+    flags += 'i';
+  }
+
+  var parsed = expand(glob, opts);
+
+  // pass in tokens to avoid parsing more than once
+  opts.negated = opts.negated || parsed.negated;
+  opts.negate = opts.negated;
+  glob = wrapGlob(parsed.pattern, opts);
+  var re;
+
+  try {
+    re = new RegExp(glob, flags);
+    return re;
+  } catch (err) {
+    err.reason = 'micromatch invalid regex: (' + re + ')';
+    if (opts.strict) throw new SyntaxError(err);
+  }
+
+  // we're only here if a bad pattern was used and the user
+  // passed `options.silent`, so match nothing
+  return /$^/;
+}
+
+/**
+ * Create the regex to do the matching. If the leading
+ * character in the `glob` is `!` a negation regex is returned.
+ *
+ * @param {String} `glob`
+ * @param {Boolean} `negate`
+ */
+
+function wrapGlob(glob, opts) {
+  var prefix = (opts && !opts.contains) ? '^' : '';
+  var after = (opts && !opts.contains) ? '$' : '';
+  glob = ('(?:' + glob + ')' + after);
+  if (opts && opts.negate) {
+    return prefix + ('(?!^' + glob + ').*$');
+  }
+  return prefix + glob;
+}
+
+/**
+ * Create and cache a regular expression for matching file paths.
+ * If the leading character in the `glob` is `!`, a negation
+ * regex is returned.
+ *
+ * @param  {String} `glob`
+ * @param  {Object} `options`
+ * @return {RegExp}
+ */
+
+function makeRe(glob, opts) {
+  if (utils.typeOf(glob) !== 'string') {
+    throw new Error(msg('makeRe', 'glob', 'a string'));
+  }
+  return utils.cache(toRegex, glob, opts);
+}
+
+/**
+ * Make error messages consistent. Follows this format:
+ *
+ * ```js
+ * msg(methodName, argNumber, nativeType);
+ * // example:
+ * msg('matchKeys', 'first', 'an object');
+ * ```
+ *
+ * @param  {String} `method`
+ * @param  {String} `num`
+ * @param  {String} `type`
+ * @return {String}
+ */
+
+function msg(method, what, type) {
+  return 'micromatch.' + method + '(): ' + what + ' should be ' + type + '.';
+}
+
+/**
+ * Public methods
+ */
+
+/* eslint no-multi-spaces: 0 */
+micromatch.any       = any;
+micromatch.braces    = micromatch.braceExpand = utils.braces;
+micromatch.contains  = contains;
+micromatch.expand    = expand;
+micromatch.filter    = filter;
+micromatch.isMatch   = isMatch;
+micromatch.makeRe    = makeRe;
+micromatch.match     = match;
+micromatch.matcher   = matcher;
+micromatch.matchKeys = matchKeys;
+
+/**
+ * Expose `micromatch`
+ */
+
+module.exports = micromatch;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/lib/chars.js":
+/*!******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/chars.js ***!
+  \******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var chars = {}, unesc, temp;
+
+function reverse(object, prepender) {
+  return Object.keys(object).reduce(function(reversed, key) {
+    var newKey = prepender ? prepender + key : key; // Optionally prepend a string to key.
+    reversed[object[key]] = newKey; // Swap key and value.
+    return reversed; // Return the result.
+  }, {});
+}
+
+/**
+ * Regex for common characters
+ */
+
+chars.escapeRegex = {
+  '?': /\?/g,
+  '@': /\@/g,
+  '!': /\!/g,
+  '+': /\+/g,
+  '*': /\*/g,
+  '(': /\(/g,
+  ')': /\)/g,
+  '[': /\[/g,
+  ']': /\]/g
+};
+
+/**
+ * Escape characters
+ */
+
+chars.ESC = {
+  '?': '__UNESC_QMRK__',
+  '@': '__UNESC_AMPE__',
+  '!': '__UNESC_EXCL__',
+  '+': '__UNESC_PLUS__',
+  '*': '__UNESC_STAR__',
+  ',': '__UNESC_COMMA__',
+  '(': '__UNESC_LTPAREN__',
+  ')': '__UNESC_RTPAREN__',
+  '[': '__UNESC_LTBRACK__',
+  ']': '__UNESC_RTBRACK__'
+};
+
+/**
+ * Unescape characters
+ */
+
+chars.UNESC = unesc || (unesc = reverse(chars.ESC, '\\'));
+
+chars.ESC_TEMP = {
+  '?': '__TEMP_QMRK__',
+  '@': '__TEMP_AMPE__',
+  '!': '__TEMP_EXCL__',
+  '*': '__TEMP_STAR__',
+  '+': '__TEMP_PLUS__',
+  ',': '__TEMP_COMMA__',
+  '(': '__TEMP_LTPAREN__',
+  ')': '__TEMP_RTPAREN__',
+  '[': '__TEMP_LTBRACK__',
+  ']': '__TEMP_RTBRACK__'
+};
+
+chars.TEMP = temp || (temp = reverse(chars.ESC_TEMP));
+
+module.exports = chars;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/lib/expand.js":
+/*!*******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/expand.js ***!
+  \*******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * micromatch <https://github.com/jonschlinkert/micromatch>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/micromatch/lib/utils.js");
+var Glob = __webpack_require__(/*! ./glob */ "../../api-javascript/node_modules/micromatch/lib/glob.js");
+
+/**
+ * Expose `expand`
+ */
+
+module.exports = expand;
+
+/**
+ * Expand a glob pattern to resolve braces and
+ * similar patterns before converting to regex.
+ *
+ * @param  {String|Array} `pattern`
+ * @param  {Array} `files`
+ * @param  {Options} `opts`
+ * @return {Array}
+ */
+
+function expand(pattern, options) {
+  if (typeof pattern !== 'string') {
+    throw new TypeError('micromatch.expand(): argument should be a string.');
+  }
+
+  var glob = new Glob(pattern, options || {});
+  var opts = glob.options;
+
+  if (!utils.isGlob(pattern)) {
+    glob.pattern = glob.pattern.replace(/([\/.])/g, '\\$1');
+    return glob;
+  }
+
+  glob.pattern = glob.pattern.replace(/(\+)(?!\()/g, '\\$1');
+  glob.pattern = glob.pattern.split('$').join('\\$');
+
+  if (typeof opts.braces !== 'boolean' && typeof opts.nobraces !== 'boolean') {
+    opts.braces = true;
+  }
+
+  if (glob.pattern === '.*') {
+    return {
+      pattern: '\\.' + star,
+      tokens: tok,
+      options: opts
+    };
+  }
+
+  if (glob.pattern === '*') {
+    return {
+      pattern: oneStar(opts.dot),
+      tokens: tok,
+      options: opts
+    };
+  }
+
+  // parse the glob pattern into tokens
+  glob.parse();
+  var tok = glob.tokens;
+  tok.is.negated = opts.negated;
+
+  // dotfile handling
+  if ((opts.dotfiles === true || tok.is.dotfile) && opts.dot !== false) {
+    opts.dotfiles = true;
+    opts.dot = true;
+  }
+
+  if ((opts.dotdirs === true || tok.is.dotdir) && opts.dot !== false) {
+    opts.dotdirs = true;
+    opts.dot = true;
+  }
+
+  // check for braces with a dotfile pattern
+  if (/[{,]\./.test(glob.pattern)) {
+    opts.makeRe = false;
+    opts.dot = true;
+  }
+
+  if (opts.nonegate !== true) {
+    opts.negated = glob.negated;
+  }
+
+  // if the leading character is a dot or a slash, escape it
+  if (glob.pattern.charAt(0) === '.' && glob.pattern.charAt(1) !== '/') {
+    glob.pattern = '\\' + glob.pattern;
+  }
+
+  /**
+   * Extended globs
+   */
+
+  // expand braces, e.g `{1..5}`
+  glob.track('before braces');
+  if (tok.is.braces) {
+    glob.braces();
+  }
+  glob.track('after braces');
+
+  // expand extglobs, e.g `foo/!(a|b)`
+  glob.track('before extglob');
+  if (tok.is.extglob) {
+    glob.extglob();
+  }
+  glob.track('after extglob');
+
+  // expand brackets, e.g `[[:alpha:]]`
+  glob.track('before brackets');
+  if (tok.is.brackets) {
+    glob.brackets();
+  }
+  glob.track('after brackets');
+
+  // special patterns
+  glob._replace('[!', '[^');
+  glob._replace('(?', '(%~');
+  glob._replace(/\[\]/, '\\[\\]');
+  glob._replace('/[', '/' + (opts.dot ? dotfiles : nodot) + '[', true);
+  glob._replace('/?', '/' + (opts.dot ? dotfiles : nodot) + '[^/]', true);
+  glob._replace('/.', '/(?=.)\\.', true);
+
+  // windows drives
+  glob._replace(/^(\w):([\\\/]+?)/gi, '(?=.)$1:$2', true);
+
+  // negate slashes in exclusion ranges
+  if (glob.pattern.indexOf('[^') !== -1) {
+    glob.pattern = negateSlash(glob.pattern);
+  }
+
+  if (opts.globstar !== false && glob.pattern === '**') {
+    glob.pattern = globstar(opts.dot);
+
+  } else {
+    glob.pattern = balance(glob.pattern, '[', ']');
+    glob.escape(glob.pattern);
+
+    // if the pattern has `**`
+    if (tok.is.globstar) {
+      glob.pattern = collapse(glob.pattern, '/**');
+      glob.pattern = collapse(glob.pattern, '**/');
+      glob._replace('/**/', '(?:/' + globstar(opts.dot) + '/|/)', true);
+      glob._replace(/\*{2,}/g, '**');
+
+      // 'foo/*'
+      glob._replace(/(\w+)\*(?!\/)/g, '$1[^/]*?', true);
+      glob._replace(/\*\*\/\*(\w)/g, globstar(opts.dot) + '\\/' + (opts.dot ? dotfiles : nodot) + '[^/]*?$1', true);
+
+      if (opts.dot !== true) {
+        glob._replace(/\*\*\/(.)/g, '(?:**\\/|)$1');
+      }
+
+      // 'foo/**' or '{**,*}', but not 'foo**'
+      if (tok.path.dirname !== '' || /,\*\*|\*\*,/.test(glob.orig)) {
+        glob._replace('**', globstar(opts.dot), true);
+      }
+    }
+
+    // ends with /*
+    glob._replace(/\/\*$/, '\\/' + oneStar(opts.dot), true);
+    // ends with *, no slashes
+    glob._replace(/(?!\/)\*$/, star, true);
+    // has 'n*.' (partial wildcard w/ file extension)
+    glob._replace(/([^\/]+)\*/, '$1' + oneStar(true), true);
+    // has '*'
+    glob._replace('*', oneStar(opts.dot), true);
+    glob._replace('?.', '?\\.', true);
+    glob._replace('?:', '?:', true);
+
+    glob._replace(/\?+/g, function(match) {
+      var len = match.length;
+      if (len === 1) {
+        return qmark;
+      }
+      return qmark + '{' + len + '}';
+    });
+
+    // escape '.abc' => '\\.abc'
+    glob._replace(/\.([*\w]+)/g, '\\.$1');
+    // fix '[^\\\\/]'
+    glob._replace(/\[\^[\\\/]+\]/g, qmark);
+    // '///' => '\/'
+    glob._replace(/\/+/g, '\\/');
+    // '\\\\\\' => '\\'
+    glob._replace(/\\{2,}/g, '\\');
+  }
+
+  // unescape previously escaped patterns
+  glob.unescape(glob.pattern);
+  glob._replace('__UNESC_STAR__', '*');
+
+  // escape dots that follow qmarks
+  glob._replace('?.', '?\\.');
+
+  // remove unnecessary slashes in character classes
+  glob._replace('[^\\/]', qmark);
+
+  if (glob.pattern.length > 1) {
+    if (/^[\[?*]/.test(glob.pattern)) {
+      // only prepend the string if we don't want to match dotfiles
+      glob.pattern = (opts.dot ? dotfiles : nodot) + glob.pattern;
+    }
+  }
+
+  return glob;
+}
+
+/**
+ * Collapse repeated character sequences.
+ *
+ * ```js
+ * collapse('a/../../../b', '../');
+ * //=> 'a/../b'
+ * ```
+ *
+ * @param  {String} `str`
+ * @param  {String} `ch` Character sequence to collapse
+ * @return {String}
+ */
+
+function collapse(str, ch) {
+  var res = str.split(ch);
+  var isFirst = res[0] === '';
+  var isLast = res[res.length - 1] === '';
+  res = res.filter(Boolean);
+  if (isFirst) res.unshift('');
+  if (isLast) res.push('');
+  return res.join(ch);
+}
+
+/**
+ * Negate slashes in exclusion ranges, per glob spec:
+ *
+ * ```js
+ * negateSlash('[^foo]');
+ * //=> '[^\\/foo]'
+ * ```
+ *
+ * @param  {String} `str` glob pattern
+ * @return {String}
+ */
+
+function negateSlash(str) {
+  return str.replace(/\[\^([^\]]*?)\]/g, function(match, inner) {
+    if (inner.indexOf('/') === -1) {
+      inner = '\\/' + inner;
+    }
+    return '[^' + inner + ']';
+  });
+}
+
+/**
+ * Escape imbalanced braces/bracket. This is a very
+ * basic, naive implementation that only does enough
+ * to serve the purpose.
+ */
+
+function balance(str, a, b) {
+  var aarr = str.split(a);
+  var alen = aarr.join('').length;
+  var blen = str.split(b).join('').length;
+
+  if (alen !== blen) {
+    str = aarr.join('\\' + a);
+    return str.split(b).join('\\' + b);
+  }
+  return str;
+}
+
+/**
+ * Special patterns to be converted to regex.
+ * Heuristics are used to simplify patterns
+ * and speed up processing.
+ */
+
+/* eslint no-multi-spaces: 0 */
+var qmark       = '[^/]';
+var star        = qmark + '*?';
+var nodot       = '(?!\\.)(?=.)';
+var dotfileGlob = '(?:\\/|^)\\.{1,2}($|\\/)';
+var dotfiles    = '(?!' + dotfileGlob + ')(?=.)';
+var twoStarDot  = '(?:(?!' + dotfileGlob + ').)*?';
+
+/**
+ * Create a regex for `*`.
+ *
+ * If `dot` is true, or the pattern does not begin with
+ * a leading star, then return the simpler regex.
+ */
+
+function oneStar(dotfile) {
+  return dotfile ? '(?!' + dotfileGlob + ')(?=.)' + star : (nodot + star);
+}
+
+function globstar(dotfile) {
+  if (dotfile) { return twoStarDot; }
+  return '(?:(?!(?:\\/|^)\\.).)*?';
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/lib/glob.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/glob.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var chars = __webpack_require__(/*! ./chars */ "../../api-javascript/node_modules/micromatch/lib/chars.js");
+var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/micromatch/lib/utils.js");
+
+/**
+ * Expose `Glob`
+ */
+
+var Glob = module.exports = function Glob(pattern, options) {
+  if (!(this instanceof Glob)) {
+    return new Glob(pattern, options);
+  }
+  this.options = options || {};
+  this.pattern = pattern;
+  this.history = [];
+  this.tokens = {};
+  this.init(pattern);
+};
+
+/**
+ * Initialize defaults
+ */
+
+Glob.prototype.init = function(pattern) {
+  this.orig = pattern;
+  this.negated = this.isNegated();
+  this.options.track = this.options.track || false;
+  this.options.makeRe = true;
+};
+
+/**
+ * Push a change into `glob.history`. Useful
+ * for debugging.
+ */
+
+Glob.prototype.track = function(msg) {
+  if (this.options.track) {
+    this.history.push({msg: msg, pattern: this.pattern});
+  }
+};
+
+/**
+ * Return true if `glob.pattern` was negated
+ * with `!`, also remove the `!` from the pattern.
+ *
+ * @return {Boolean}
+ */
+
+Glob.prototype.isNegated = function() {
+  if (this.pattern.charCodeAt(0) === 33 /* '!' */) {
+    this.pattern = this.pattern.slice(1);
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Expand braces in the given glob pattern.
+ *
+ * We only need to use the [braces] lib when
+ * patterns are nested.
+ */
+
+Glob.prototype.braces = function() {
+  if (this.options.nobraces !== true && this.options.nobrace !== true) {
+    // naive/fast check for imbalanced characters
+    var a = this.pattern.match(/[\{\(\[]/g);
+    var b = this.pattern.match(/[\}\)\]]/g);
+
+    // if imbalanced, don't optimize the pattern
+    if (a && b && (a.length !== b.length)) {
+      this.options.makeRe = false;
+    }
+
+    // expand brace patterns and join the resulting array
+    var expanded = utils.braces(this.pattern, this.options);
+    this.pattern = expanded.join('|');
+  }
+};
+
+/**
+ * Expand bracket expressions in `glob.pattern`
+ */
+
+Glob.prototype.brackets = function() {
+  if (this.options.nobrackets !== true) {
+    this.pattern = utils.brackets(this.pattern);
+  }
+};
+
+/**
+ * Expand bracket expressions in `glob.pattern`
+ */
+
+Glob.prototype.extglob = function() {
+  if (this.options.noextglob === true) return;
+
+  if (utils.isExtglob(this.pattern)) {
+    this.pattern = utils.extglob(this.pattern, {escape: true});
+  }
+};
+
+/**
+ * Parse the given pattern
+ */
+
+Glob.prototype.parse = function(pattern) {
+  this.tokens = utils.parseGlob(pattern || this.pattern, true);
+  return this.tokens;
+};
+
+/**
+ * Replace `a` with `b`. Also tracks the change before and
+ * after each replacement. This is disabled by default, but
+ * can be enabled by setting `options.track` to true.
+ *
+ * Also, when the pattern is a string, `.split()` is used,
+ * because it's much faster than replace.
+ *
+ * @param  {RegExp|String} `a`
+ * @param  {String} `b`
+ * @param  {Boolean} `escape` When `true`, escapes `*` and `?` in the replacement.
+ * @return {String}
+ */
+
+Glob.prototype._replace = function(a, b, escape) {
+  this.track('before (find): "' + a + '" (replace with): "' + b + '"');
+  if (escape) b = esc(b);
+  if (a && b && typeof a === 'string') {
+    this.pattern = this.pattern.split(a).join(b);
+  } else {
+    this.pattern = this.pattern.replace(a, b);
+  }
+  this.track('after');
+};
+
+/**
+ * Escape special characters in the given string.
+ *
+ * @param  {String} `str` Glob pattern
+ * @return {String}
+ */
+
+Glob.prototype.escape = function(str) {
+  this.track('before escape: ');
+  var re = /["\\](['"]?[^"'\\]['"]?)/g;
+
+  this.pattern = str.replace(re, function($0, $1) {
+    var o = chars.ESC;
+    var ch = o && o[$1];
+    if (ch) {
+      return ch;
+    }
+    if (/[a-z]/i.test($0)) {
+      return $0.split('\\').join('');
+    }
+    return $0;
+  });
+
+  this.track('after escape: ');
+};
+
+/**
+ * Unescape special characters in the given string.
+ *
+ * @param  {String} `str`
+ * @return {String}
+ */
+
+Glob.prototype.unescape = function(str) {
+  var re = /__([A-Z]+)_([A-Z]+)__/g;
+  this.pattern = str.replace(re, function($0, $1) {
+    return chars[$1][$0];
+  });
+  this.pattern = unesc(this.pattern);
+};
+
+/**
+ * Escape/unescape utils
+ */
+
+function esc(str) {
+  str = str.split('?').join('%~');
+  str = str.split('*').join('%%');
+  return str;
+}
+
+function unesc(str) {
+  str = str.split('%~').join('?');
+  str = str.split('%%').join('*');
+  return str;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/lib/utils.js":
+/*!******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/lib/utils.js ***!
+  \******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/* WEBPACK VAR INJECTION */(function(process) {
+
+var win32 = process && process.platform === 'win32';
+var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
+var fileRe = __webpack_require__(/*! filename-regex */ "../../api-javascript/node_modules/filename-regex/index.js");
+var utils = module.exports;
+
+/**
+ * Module dependencies
+ */
+
+utils.diff = __webpack_require__(/*! arr-diff */ "../../api-javascript/node_modules/micromatch/node_modules/arr-diff/index.js");
+utils.unique = __webpack_require__(/*! array-unique */ "../../api-javascript/node_modules/micromatch/node_modules/array-unique/index.js");
+utils.braces = __webpack_require__(/*! braces */ "../../api-javascript/node_modules/micromatch/node_modules/braces/index.js");
+utils.brackets = __webpack_require__(/*! expand-brackets */ "../../api-javascript/node_modules/expand-brackets/index.js");
+utils.extglob = __webpack_require__(/*! extglob */ "../../api-javascript/node_modules/extglob/index.js");
+utils.isExtglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
+utils.isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
+utils.typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/kind-of/index.js");
+utils.normalize = __webpack_require__(/*! normalize-path */ "../../api-javascript/node_modules/normalize-path/index.js");
+utils.omit = __webpack_require__(/*! object.omit */ "../../api-javascript/node_modules/object.omit/index.js");
+utils.parseGlob = __webpack_require__(/*! parse-glob */ "../../api-javascript/node_modules/parse-glob/index.js");
+utils.cache = __webpack_require__(/*! regex-cache */ "../../api-javascript/node_modules/regex-cache/index.js");
+
+/**
+ * Get the filename of a filepath
+ *
+ * @param {String} `string`
+ * @return {String}
+ */
+
+utils.filename = function filename(fp) {
+  var seg = fp.match(fileRe());
+  return seg && seg[0];
+};
+
+/**
+ * Returns a function that returns true if the given
+ * pattern is the same as a given `filepath`
+ *
+ * @param {String} `pattern`
+ * @return {Function}
+ */
+
+utils.isPath = function isPath(pattern, opts) {
+  opts = opts || {};
+  return function(fp) {
+    var unixified = utils.unixify(fp, opts);
+    if(opts.nocase){
+      return pattern.toLowerCase() === unixified.toLowerCase();
+    }
+    return pattern === unixified;
+  };
+};
+
+/**
+ * Returns a function that returns true if the given
+ * pattern contains a `filepath`
+ *
+ * @param {String} `pattern`
+ * @return {Function}
+ */
+
+utils.hasPath = function hasPath(pattern, opts) {
+  return function(fp) {
+    return utils.unixify(pattern, opts).indexOf(fp) !== -1;
+  };
+};
+
+/**
+ * Returns a function that returns true if the given
+ * pattern matches or contains a `filepath`
+ *
+ * @param {String} `pattern`
+ * @return {Function}
+ */
+
+utils.matchPath = function matchPath(pattern, opts) {
+  var fn = (opts && opts.contains)
+    ? utils.hasPath(pattern, opts)
+    : utils.isPath(pattern, opts);
+  return fn;
+};
+
+/**
+ * Returns a function that returns true if the given
+ * regex matches the `filename` of a file path.
+ *
+ * @param {RegExp} `re`
+ * @return {Boolean}
+ */
+
+utils.hasFilename = function hasFilename(re) {
+  return function(fp) {
+    var name = utils.filename(fp);
+    return name && re.test(name);
+  };
+};
+
+/**
+ * Coerce `val` to an array
+ *
+ * @param  {*} val
+ * @return {Array}
+ */
+
+utils.arrayify = function arrayify(val) {
+  return !Array.isArray(val)
+    ? [val]
+    : val;
+};
+
+/**
+ * Normalize all slashes in a file path or glob pattern to
+ * forward slashes.
+ */
+
+utils.unixify = function unixify(fp, opts) {
+  if (opts && opts.unixify === false) return fp;
+  if (opts && opts.unixify === true || win32 || path.sep === '\\') {
+    return utils.normalize(fp, false);
+  }
+  if (opts && opts.unescape === true) {
+    return fp ? fp.toString().replace(/\\(\w)/g, '$1') : '';
+  }
+  return fp;
+};
+
+/**
+ * Escape/unescape utils
+ */
+
+utils.escapePath = function escapePath(fp) {
+  return fp.replace(/[\\.]/g, '\\$&');
+};
+
+utils.unescapeGlob = function unescapeGlob(fp) {
+  return fp.replace(/[\\"']/g, '');
+};
+
+utils.escapeRe = function escapeRe(str) {
+  return str.replace(/[-[\\$*+?.#^\s{}(|)\]]/g, '\\$&');
+};
+
+/**
+ * Expose `utils`
+ */
+
+module.exports = utils;
+
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../sfx/sfx-logic/node_modules/process/browser.js */ "./node_modules/process/browser.js")))
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/node_modules/arr-diff/index.js":
+/*!************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/node_modules/arr-diff/index.js ***!
+  \************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * arr-diff <https://github.com/jonschlinkert/arr-diff>
+ *
+ * Copyright (c) 2014 Jon Schlinkert, contributors.
+ * Licensed under the MIT License
+ */
+
+
+
+var flatten = __webpack_require__(/*! arr-flatten */ "../../api-javascript/node_modules/arr-flatten/index.js");
+var slice = [].slice;
+
+/**
+ * Return the difference between the first array and
+ * additional arrays.
+ *
+ * ```js
+ * var diff = require('{%= name %}');
+ *
+ * var a = ['a', 'b', 'c', 'd'];
+ * var b = ['b', 'c'];
+ *
+ * console.log(diff(a, b))
+ * //=> ['a', 'd']
+ * ```
+ *
+ * @param  {Array} `a`
+ * @param  {Array} `b`
+ * @return {Array}
+ * @api public
+ */
+
+function diff(arr, arrays) {
+  var argsLen = arguments.length;
+  var len = arr.length, i = -1;
+  var res = [], arrays;
+
+  if (argsLen === 1) {
+    return arr;
+  }
+
+  if (argsLen > 2) {
+    arrays = flatten(slice.call(arguments, 1));
+  }
+
+  while (++i < len) {
+    if (!~arrays.indexOf(arr[i])) {
+      res.push(arr[i]);
+    }
+  }
+  return res;
+}
+
+/**
+ * Expose `diff`
+ */
+
+module.exports = diff;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/node_modules/array-unique/index.js":
+/*!****************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/node_modules/array-unique/index.js ***!
+  \****************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * array-unique <https://github.com/jonschlinkert/array-unique>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+module.exports = function unique(arr) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('array-unique expects an array.');
+  }
+
+  var len = arr.length;
+  var i = -1;
+
+  while (i++ < len) {
+    var j = i + 1;
+
+    for (; j < arr.length; ++j) {
+      if (arr[i] === arr[j]) {
+        arr.splice(j--, 1);
+      }
+    }
+  }
+  return arr;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/micromatch/node_modules/braces/index.js":
+/*!**********************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/micromatch/node_modules/braces/index.js ***!
+  \**********************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * braces <https://github.com/jonschlinkert/braces>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+
+
+/**
+ * Module dependencies
+ */
+
+var expand = __webpack_require__(/*! expand-range */ "../../api-javascript/node_modules/expand-range/index.js");
+var repeat = __webpack_require__(/*! repeat-element */ "../../api-javascript/node_modules/repeat-element/index.js");
+var tokens = __webpack_require__(/*! preserve */ "../../api-javascript/node_modules/preserve/index.js");
+
+/**
+ * Expose `braces`
+ */
+
+module.exports = function(str, options) {
+  if (typeof str !== 'string') {
+    throw new Error('braces expects a string');
+  }
+  return braces(str, options);
+};
+
+/**
+ * Expand `{foo,bar}` or `{1..5}` braces in the
+ * given `string`.
+ *
+ * @param  {String} `str`
+ * @param  {Array} `arr`
+ * @param  {Object} `options`
+ * @return {Array}
+ */
+
+function braces(str, arr, options) {
+  if (str === '') {
+    return [];
+  }
+
+  if (!Array.isArray(arr)) {
+    options = arr;
+    arr = [];
+  }
+
+  var opts = options || {};
+  arr = arr || [];
+
+  if (typeof opts.nodupes === 'undefined') {
+    opts.nodupes = true;
+  }
+
+  var fn = opts.fn;
+  var es6;
+
+  if (typeof opts === 'function') {
+    fn = opts;
+    opts = {};
+  }
+
+  if (!(patternRe instanceof RegExp)) {
+    patternRe = patternRegex();
+  }
+
+  var matches = str.match(patternRe) || [];
+  var m = matches[0];
+
+  switch(m) {
+    case '\\,':
+      return escapeCommas(str, arr, opts);
+    case '\\.':
+      return escapeDots(str, arr, opts);
+    case '\/.':
+      return escapePaths(str, arr, opts);
+    case ' ':
+      return splitWhitespace(str);
+    case '{,}':
+      return exponential(str, opts, braces);
+    case '{}':
+      return emptyBraces(str, arr, opts);
+    case '\\{':
+    case '\\}':
+      return escapeBraces(str, arr, opts);
+    case '${':
+      if (!/\{[^{]+\{/.test(str)) {
+        return arr.concat(str);
+      } else {
+        es6 = true;
+        str = tokens.before(str, es6Regex());
+      }
+  }
+
+  if (!(braceRe instanceof RegExp)) {
+    braceRe = braceRegex();
+  }
+
+  var match = braceRe.exec(str);
+  if (match == null) {
+    return [str];
+  }
+
+  var outter = match[1];
+  var inner = match[2];
+  if (inner === '') { return [str]; }
+
+  var segs, segsLength;
+
+  if (inner.indexOf('..') !== -1) {
+    segs = expand(inner, opts, fn) || inner.split(',');
+    segsLength = segs.length;
+
+  } else if (inner[0] === '"' || inner[0] === '\'') {
+    return arr.concat(str.split(/['"]/).join(''));
+
+  } else {
+    segs = inner.split(',');
+    if (opts.makeRe) {
+      return braces(str.replace(outter, wrap(segs, '|')), opts);
+    }
+
+    segsLength = segs.length;
+    if (segsLength === 1 && opts.bash) {
+      segs[0] = wrap(segs[0], '\\');
+    }
+  }
+
+  var len = segs.length;
+  var i = 0, val;
+
+  while (len--) {
+    var path = segs[i++];
+
+    if (/(\.[^.\/])/.test(path)) {
+      if (segsLength > 1) {
+        return segs;
+      } else {
+        return [str];
+      }
+    }
+
+    val = splice(str, outter, path);
+
+    if (/\{[^{}]+?\}/.test(val)) {
+      arr = braces(val, arr, opts);
+    } else if (val !== '') {
+      if (opts.nodupes && arr.indexOf(val) !== -1) { continue; }
+      arr.push(es6 ? tokens.after(val) : val);
+    }
+  }
+
+  if (opts.strict) { return filter(arr, filterEmpty); }
+  return arr;
+}
+
+/**
+ * Expand exponential ranges
+ *
+ *   `a{,}{,}` => ['a', 'a', 'a', 'a']
+ */
+
+function exponential(str, options, fn) {
+  if (typeof options === 'function') {
+    fn = options;
+    options = null;
+  }
+
+  var opts = options || {};
+  var esc = '__ESC_EXP__';
+  var exp = 0;
+  var res;
+
+  var parts = str.split('{,}');
+  if (opts.nodupes) {
+    return fn(parts.join(''), opts);
+  }
+
+  exp = parts.length - 1;
+  res = fn(parts.join(esc), opts);
+  var len = res.length;
+  var arr = [];
+  var i = 0;
+
+  while (len--) {
+    var ele = res[i++];
+    var idx = ele.indexOf(esc);
+
+    if (idx === -1) {
+      arr.push(ele);
+
+    } else {
+      ele = ele.split('__ESC_EXP__').join('');
+      if (!!ele && opts.nodupes !== false) {
+        arr.push(ele);
+
+      } else {
+        var num = Math.pow(2, exp);
+        arr.push.apply(arr, repeat(ele, num));
+      }
+    }
+  }
+  return arr;
+}
+
+/**
+ * Wrap a value with parens, brackets or braces,
+ * based on the given character/separator.
+ *
+ * @param  {String|Array} `val`
+ * @param  {String} `ch`
+ * @return {String}
+ */
+
+function wrap(val, ch) {
+  if (ch === '|') {
+    return '(' + val.join(ch) + ')';
+  }
+  if (ch === ',') {
+    return '{' + val.join(ch) + '}';
+  }
+  if (ch === '-') {
+    return '[' + val.join(ch) + ']';
+  }
+  if (ch === '\\') {
+    return '\\{' + val + '\\}';
+  }
+}
+
+/**
+ * Handle empty braces: `{}`
+ */
+
+function emptyBraces(str, arr, opts) {
+  return braces(str.split('{}').join('\\{\\}'), arr, opts);
+}
+
+/**
+ * Filter out empty-ish values
+ */
+
+function filterEmpty(ele) {
+  return !!ele && ele !== '\\';
+}
+
+/**
+ * Handle patterns with whitespace
+ */
+
+function splitWhitespace(str) {
+  var segs = str.split(' ');
+  var len = segs.length;
+  var res = [];
+  var i = 0;
+
+  while (len--) {
+    res.push.apply(res, braces(segs[i++]));
+  }
+  return res;
+}
+
+/**
+ * Handle escaped braces: `\\{foo,bar}`
+ */
+
+function escapeBraces(str, arr, opts) {
+  if (!/\{[^{]+\{/.test(str)) {
+    return arr.concat(str.split('\\').join(''));
+  } else {
+    str = str.split('\\{').join('__LT_BRACE__');
+    str = str.split('\\}').join('__RT_BRACE__');
+    return map(braces(str, arr, opts), function(ele) {
+      ele = ele.split('__LT_BRACE__').join('{');
+      return ele.split('__RT_BRACE__').join('}');
+    });
+  }
+}
+
+/**
+ * Handle escaped dots: `{1\\.2}`
+ */
+
+function escapeDots(str, arr, opts) {
+  if (!/[^\\]\..+\\\./.test(str)) {
+    return arr.concat(str.split('\\').join(''));
+  } else {
+    str = str.split('\\.').join('__ESC_DOT__');
+    return map(braces(str, arr, opts), function(ele) {
+      return ele.split('__ESC_DOT__').join('.');
+    });
+  }
+}
+
+/**
+ * Handle escaped dots: `{1\\.2}`
+ */
+
+function escapePaths(str, arr, opts) {
+  str = str.split('\/.').join('__ESC_PATH__');
+  return map(braces(str, arr, opts), function(ele) {
+    return ele.split('__ESC_PATH__').join('\/.');
+  });
+}
+
+/**
+ * Handle escaped commas: `{a\\,b}`
+ */
+
+function escapeCommas(str, arr, opts) {
+  if (!/\w,/.test(str)) {
+    return arr.concat(str.split('\\').join(''));
+  } else {
+    str = str.split('\\,').join('__ESC_COMMA__');
+    return map(braces(str, arr, opts), function(ele) {
+      return ele.split('__ESC_COMMA__').join(',');
+    });
+  }
+}
+
+/**
+ * Regex for common patterns
+ */
+
+function patternRegex() {
+  return /\${|( (?=[{,}])|(?=[{,}]) )|{}|{,}|\\,(?=.*[{}])|\/\.(?=.*[{}])|\\\.(?={)|\\{|\\}/;
+}
+
+/**
+ * Braces regex.
+ */
+
+function braceRegex() {
+  return /.*(\\?\{([^}]+)\})/;
+}
+
+/**
+ * es6 delimiter regex.
+ */
+
+function es6Regex() {
+  return /\$\{([^}]+)\}/;
+}
+
+var braceRe;
+var patternRe;
+
+/**
+ * Faster alternative to `String.replace()` when the
+ * index of the token to be replaces can't be supplied
+ */
+
+function splice(str, token, replacement) {
+  var i = str.indexOf(token);
+  return str.substr(0, i) + replacement
+    + str.substr(i + token.length);
+}
+
+/**
+ * Fast array map
+ */
+
+function map(arr, fn) {
+  if (arr == null) {
+    return [];
+  }
+
+  var len = arr.length;
+  var res = new Array(len);
+  var i = -1;
+
+  while (++i < len) {
+    res[i] = fn(arr[i], i, arr);
+  }
+
+  return res;
+}
+
+/**
+ * Fast array filter
+ */
+
+function filter(arr, cb) {
+  if (arr == null) return [];
+  if (typeof cb !== 'function') {
+    throw new TypeError('braces: filter expects a callback function.');
+  }
+
+  var len = arr.length;
+  var res = arr.slice();
+  var i = 0;
+
+  while (len--) {
+    if (!cb(arr[len], i++)) {
+      res.splice(len, 1);
+    }
+  }
+  return res;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/normalize-path/index.js":
+/*!******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/normalize-path/index.js ***!
+  \******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * normalize-path <https://github.com/jonschlinkert/normalize-path>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "../../api-javascript/node_modules/remove-trailing-separator/index.js");
+
+module.exports = function normalizePath(str, stripTrailing) {
+  if (typeof str !== 'string') {
+    throw new TypeError('expected a string');
+  }
+  str = str.replace(/[\\\/]+/g, '/');
+  if (stripTrailing !== false) {
+    str = removeTrailingSeparator(str);
+  }
+  return str;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/object.omit/index.js":
+/*!***************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/object.omit/index.js ***!
+  \***************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * object.omit <https://github.com/jonschlinkert/object.omit>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var isObject = __webpack_require__(/*! is-extendable */ "../../api-javascript/node_modules/is-extendable/index.js");
+var forOwn = __webpack_require__(/*! for-own */ "../../api-javascript/node_modules/for-own/index.js");
+
+module.exports = function omit(obj, keys) {
+  if (!isObject(obj)) return {};
+
+  keys = [].concat.apply([], [].slice.call(arguments, 1));
+  var last = keys[keys.length - 1];
+  var res = {}, fn;
+
+  if (typeof last === 'function') {
+    fn = keys.pop();
+  }
+
+  var isFunction = typeof fn === 'function';
+  if (!keys.length && !isFunction) {
+    return obj;
+  }
+
+  forOwn(obj, function(value, key) {
+    if (keys.indexOf(key) === -1) {
+
+      if (!isFunction) {
+        res[key] = value;
+      } else if (fn(value, key, obj)) {
+        res[key] = value;
+      }
+    }
+  });
+  return res;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/object.pick/index.js":
+/*!***************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/object.pick/index.js ***!
+  \***************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * object.pick <https://github.com/jonschlinkert/object.pick>
+ *
+ * Copyright (c) 2014-2015 Jon Schlinkert, contributors.
+ * Licensed under the MIT License
+ */
+
+
+
+var isObject = __webpack_require__(/*! isobject */ "../../api-javascript/node_modules/isobject/index.js");
+
+module.exports = function pick(obj, keys) {
+  if (!isObject(obj) && typeof obj !== 'function') {
+    return {};
+  }
+
+  var res = {};
+  if (typeof keys === 'string') {
+    if (keys in obj) {
+      res[keys] = obj[keys];
+    }
+    return res;
+  }
+
+  var len = keys.length;
+  var idx = -1;
+
+  while (++idx < len) {
+    var key = keys[idx];
+    if (key in obj) {
+      res[key] = obj[key];
+    }
+  }
+  return res;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/parse-glob/index.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/parse-glob/index.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * parse-glob <https://github.com/jonschlinkert/parse-glob>
+ *
+ * Copyright (c) 2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+var isGlob = __webpack_require__(/*! is-glob */ "../../api-javascript/node_modules/is-glob/index.js");
+var findBase = __webpack_require__(/*! glob-base */ "../../api-javascript/node_modules/glob-base/index.js");
+var extglob = __webpack_require__(/*! is-extglob */ "../../api-javascript/node_modules/is-extglob/index.js");
+var dotfile = __webpack_require__(/*! is-dotfile */ "../../api-javascript/node_modules/is-dotfile/index.js");
+
+/**
+ * Expose `cache`
+ */
+
+var cache = module.exports.cache = {};
+
+/**
+ * Parse a glob pattern into tokens.
+ *
+ * When no paths or '**' are in the glob, we use a
+ * different strategy for parsing the filename, since
+ * file names can contain braces and other difficult
+ * patterns. such as:
+ *
+ *  - `*.{a,b}`
+ *  - `(**|*.js)`
+ */
+
+module.exports = function parseGlob(glob) {
+  if (cache.hasOwnProperty(glob)) {
+    return cache[glob];
+  }
+
+  var tok = {};
+  tok.orig = glob;
+  tok.is = {};
+
+  // unescape dots and slashes in braces/brackets
+  glob = escape(glob);
+
+  var parsed = findBase(glob);
+  tok.is.glob = parsed.isGlob;
+
+  tok.glob = parsed.glob;
+  tok.base = parsed.base;
+  var segs = /([^\/]*)$/.exec(glob);
+
+  tok.path = {};
+  tok.path.dirname = '';
+  tok.path.basename = segs[1] || '';
+  tok.path.dirname = glob.split(tok.path.basename).join('') || '';
+  var basename = (tok.path.basename || '').split('.') || '';
+  tok.path.filename = basename[0] || '';
+  tok.path.extname = basename.slice(1).join('.') || '';
+  tok.path.ext = '';
+
+  if (isGlob(tok.path.dirname) && !tok.path.basename) {
+    if (!/\/$/.test(tok.glob)) {
+      tok.path.basename = tok.glob;
+    }
+    tok.path.dirname = tok.base;
+  }
+
+  if (glob.indexOf('/') === -1 && !tok.is.globstar) {
+    tok.path.dirname = '';
+    tok.path.basename = tok.orig;
+  }
+
+  var dot = tok.path.basename.indexOf('.');
+  if (dot !== -1) {
+    tok.path.filename = tok.path.basename.slice(0, dot);
+    tok.path.extname = tok.path.basename.slice(dot);
+  }
+
+  if (tok.path.extname.charAt(0) === '.') {
+    var exts = tok.path.extname.split('.');
+    tok.path.ext = exts[exts.length - 1];
+  }
+
+  // unescape dots and slashes in braces/brackets
+  tok.glob = unescape(tok.glob);
+  tok.path.dirname = unescape(tok.path.dirname);
+  tok.path.basename = unescape(tok.path.basename);
+  tok.path.filename = unescape(tok.path.filename);
+  tok.path.extname = unescape(tok.path.extname);
+
+  // Booleans
+  var is = (glob && tok.is.glob);
+  tok.is.negated  = glob && glob.charAt(0) === '!';
+  tok.is.extglob  = glob && extglob(glob);
+  tok.is.braces   = has(is, glob, '{');
+  tok.is.brackets = has(is, glob, '[:');
+  tok.is.globstar = has(is, glob, '**');
+  tok.is.dotfile  = dotfile(tok.path.basename) || dotfile(tok.path.filename);
+  tok.is.dotdir   = dotdir(tok.path.dirname);
+  return (cache[glob] = tok);
+}
+
+/**
+ * Returns true if the glob matches dot-directories.
+ *
+ * @param  {Object} `tok` The tokens object
+ * @param  {Object} `path` The path object
+ * @return {Object}
+ */
+
+function dotdir(base) {
+  if (base.indexOf('/.') !== -1) {
+    return true;
+  }
+  if (base.charAt(0) === '.' && base.charAt(1) !== '/') {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true if the pattern has the given `ch`aracter(s)
+ *
+ * @param  {Object} `glob` The glob pattern.
+ * @param  {Object} `ch` The character to test for
+ * @return {Object}
+ */
+
+function has(is, glob, ch) {
+  return is && glob.indexOf(ch) !== -1;
+}
+
+/**
+ * Escape/unescape utils
+ */
+
+function escape(str) {
+  var re = /\{([^{}]*?)}|\(([^()]*?)\)|\[([^\[\]]*?)\]/g;
+  return str.replace(re, function (outter, braces, parens, brackets) {
+    var inner = braces || parens || brackets;
+    if (!inner) { return outter; }
+    return outter.split(inner).join(esc(inner));
+  });
+}
+
+function esc(str) {
+  str = str.split('/').join('__SLASH__');
+  str = str.split('.').join('__DOT__');
+  return str;
+}
+
+function unescape(str) {
+  str = str.split('__SLASH__').join('/');
+  str = str.split('__DOT__').join('.');
+  return str;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/preserve/index.js":
+/*!************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/preserve/index.js ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * preserve <https://github.com/jonschlinkert/preserve>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+
+
+/**
+ * Replace tokens in `str` with a temporary, heuristic placeholder.
+ *
+ * ```js
+ * tokens.before('{a\\,b}');
+ * //=> '{__ID1__}'
+ * ```
+ *
+ * @param  {String} `str`
+ * @return {String} String with placeholders.
+ * @api public
+ */
+
+exports.before = function before(str, re) {
+  return str.replace(re, function (match) {
+    var id = randomize();
+    cache[id] = match;
+    return '__ID' + id + '__';
+  });
+};
+
+/**
+ * Replace placeholders in `str` with original tokens.
+ *
+ * ```js
+ * tokens.after('{__ID1__}');
+ * //=> '{a\\,b}'
+ * ```
+ *
+ * @param  {String} `str` String with placeholders
+ * @return {String} `str` String with original tokens.
+ * @api public
+ */
+
+exports.after = function after(str) {
+  return str.replace(/__ID(.{5})__/g, function (_, id) {
+    return cache[id];
+  });
+};
+
+function randomize() {
+  return Math.random().toString().slice(2, 7);
+}
+
+var cache = {};
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/qs/lib/formats.js":
+/*!************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/formats.js ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var replace = String.prototype.replace;
+var percentTwenties = /%20/g;
+
+module.exports = {
+    'default': 'RFC3986',
+    formatters: {
+        RFC1738: function (value) {
+            return replace.call(value, percentTwenties, '+');
+        },
+        RFC3986: function (value) {
+            return value;
+        }
+    },
+    RFC1738: 'RFC1738',
+    RFC3986: 'RFC3986'
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/qs/lib/index.js":
+/*!**********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/index.js ***!
+  \**********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var stringify = __webpack_require__(/*! ./stringify */ "../../api-javascript/node_modules/qs/lib/stringify.js");
+var parse = __webpack_require__(/*! ./parse */ "../../api-javascript/node_modules/qs/lib/parse.js");
+var formats = __webpack_require__(/*! ./formats */ "../../api-javascript/node_modules/qs/lib/formats.js");
+
+module.exports = {
+    formats: formats,
+    parse: parse,
+    stringify: stringify
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/qs/lib/parse.js":
+/*!**********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/parse.js ***!
+  \**********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/qs/lib/utils.js");
+
+var has = Object.prototype.hasOwnProperty;
+
+var defaults = {
+    allowDots: false,
+    allowPrototypes: false,
+    arrayLimit: 20,
+    charset: 'utf-8',
+    charsetSentinel: false,
+    comma: false,
+    decoder: utils.decode,
+    delimiter: '&',
+    depth: 5,
+    ignoreQueryPrefix: false,
+    interpretNumericEntities: false,
+    parameterLimit: 1000,
+    parseArrays: true,
+    plainObjects: false,
+    strictNullHandling: false
+};
+
+var interpretNumericEntities = function (str) {
+    return str.replace(/&#(\d+);/g, function ($0, numberStr) {
+        return String.fromCharCode(parseInt(numberStr, 10));
+    });
+};
+
+// This is what browsers will submit when the ✓ character occurs in an
+// application/x-www-form-urlencoded body and the encoding of the page containing
+// the form is iso-8859-1, or when the submitted form has an accept-charset
+// attribute of iso-8859-1. Presumably also with other charsets that do not contain
+// the ✓ character, such as us-ascii.
+var isoSentinel = 'utf8=%26%2310003%3B'; // encodeURIComponent('&#10003;')
+
+// These are the percent-encoded utf-8 octets representing a checkmark, indicating that the request actually is utf-8 encoded.
+var charsetSentinel = 'utf8=%E2%9C%93'; // encodeURIComponent('✓')
+
+var parseValues = function parseQueryStringValues(str, options) {
+    var obj = {};
+    var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, '') : str;
+    var limit = options.parameterLimit === Infinity ? undefined : options.parameterLimit;
+    var parts = cleanStr.split(options.delimiter, limit);
+    var skipIndex = -1; // Keep track of where the utf8 sentinel was found
+    var i;
+
+    var charset = options.charset;
+    if (options.charsetSentinel) {
+        for (i = 0; i < parts.length; ++i) {
+            if (parts[i].indexOf('utf8=') === 0) {
+                if (parts[i] === charsetSentinel) {
+                    charset = 'utf-8';
+                } else if (parts[i] === isoSentinel) {
+                    charset = 'iso-8859-1';
+                }
+                skipIndex = i;
+                i = parts.length; // The eslint settings do not allow break;
+            }
+        }
+    }
+
+    for (i = 0; i < parts.length; ++i) {
+        if (i === skipIndex) {
+            continue;
+        }
+        var part = parts[i];
+
+        var bracketEqualsPos = part.indexOf(']=');
+        var pos = bracketEqualsPos === -1 ? part.indexOf('=') : bracketEqualsPos + 1;
+
+        var key, val;
+        if (pos === -1) {
+            key = options.decoder(part, defaults.decoder, charset);
+            val = options.strictNullHandling ? null : '';
+        } else {
+            key = options.decoder(part.slice(0, pos), defaults.decoder, charset);
+            val = options.decoder(part.slice(pos + 1), defaults.decoder, charset);
+        }
+
+        if (val && options.interpretNumericEntities && charset === 'iso-8859-1') {
+            val = interpretNumericEntities(val);
+        }
+
+        if (val && options.comma && val.indexOf(',') > -1) {
+            val = val.split(',');
+        }
+
+        if (has.call(obj, key)) {
+            obj[key] = utils.combine(obj[key], val);
+        } else {
+            obj[key] = val;
+        }
+    }
+
+    return obj;
+};
+
+var parseObject = function (chain, val, options) {
+    var leaf = val;
+
+    for (var i = chain.length - 1; i >= 0; --i) {
+        var obj;
+        var root = chain[i];
+
+        if (root === '[]' && options.parseArrays) {
+            obj = [].concat(leaf);
+        } else {
+            obj = options.plainObjects ? Object.create(null) : {};
+            var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+            var index = parseInt(cleanRoot, 10);
+            if (!options.parseArrays && cleanRoot === '') {
+                obj = { 0: leaf };
+            } else if (
+                !isNaN(index)
+                && root !== cleanRoot
+                && String(index) === cleanRoot
+                && index >= 0
+                && (options.parseArrays && index <= options.arrayLimit)
+            ) {
+                obj = [];
+                obj[index] = leaf;
+            } else {
+                obj[cleanRoot] = leaf;
+            }
+        }
+
+        leaf = obj;
+    }
+
+    return leaf;
+};
+
+var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
+    if (!givenKey) {
+        return;
+    }
+
+    // Transform dot notation to bracket notation
+    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+
+    // The regex chunks
+
+    var brackets = /(\[[^[\]]*])/;
+    var child = /(\[[^[\]]*])/g;
+
+    // Get the parent
+
+    var segment = brackets.exec(key);
+    var parent = segment ? key.slice(0, segment.index) : key;
+
+    // Stash the parent if it exists
+
+    var keys = [];
+    if (parent) {
+        // If we aren't using plain objects, optionally prefix keys that would overwrite object prototype properties
+        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+            if (!options.allowPrototypes) {
+                return;
+            }
+        }
+
+        keys.push(parent);
+    }
+
+    // Loop through children appending to the array until we hit depth
+
+    var i = 0;
+    while ((segment = child.exec(key)) !== null && i < options.depth) {
+        i += 1;
+        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+            if (!options.allowPrototypes) {
+                return;
+            }
+        }
+        keys.push(segment[1]);
+    }
+
+    // If there's a remainder, just add whatever is left
+
+    if (segment) {
+        keys.push('[' + key.slice(segment.index) + ']');
+    }
+
+    return parseObject(keys, val, options);
+};
+
+var normalizeParseOptions = function normalizeParseOptions(opts) {
+    if (!opts) {
+        return defaults;
+    }
+
+    if (opts.decoder !== null && opts.decoder !== undefined && typeof opts.decoder !== 'function') {
+        throw new TypeError('Decoder has to be a function.');
+    }
+
+    if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
+        throw new Error('The charset option must be either utf-8, iso-8859-1, or undefined');
+    }
+    var charset = typeof opts.charset === 'undefined' ? defaults.charset : opts.charset;
+
+    return {
+        allowDots: typeof opts.allowDots === 'undefined' ? defaults.allowDots : !!opts.allowDots,
+        allowPrototypes: typeof opts.allowPrototypes === 'boolean' ? opts.allowPrototypes : defaults.allowPrototypes,
+        arrayLimit: typeof opts.arrayLimit === 'number' ? opts.arrayLimit : defaults.arrayLimit,
+        charset: charset,
+        charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
+        comma: typeof opts.comma === 'boolean' ? opts.comma : defaults.comma,
+        decoder: typeof opts.decoder === 'function' ? opts.decoder : defaults.decoder,
+        delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
+        depth: typeof opts.depth === 'number' ? opts.depth : defaults.depth,
+        ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
+        interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
+        parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,
+        parseArrays: opts.parseArrays !== false,
+        plainObjects: typeof opts.plainObjects === 'boolean' ? opts.plainObjects : defaults.plainObjects,
+        strictNullHandling: typeof opts.strictNullHandling === 'boolean' ? opts.strictNullHandling : defaults.strictNullHandling
+    };
+};
+
+module.exports = function (str, opts) {
+    var options = normalizeParseOptions(opts);
+
+    if (str === '' || str === null || typeof str === 'undefined') {
+        return options.plainObjects ? Object.create(null) : {};
+    }
+
+    var tempObj = typeof str === 'string' ? parseValues(str, options) : str;
+    var obj = options.plainObjects ? Object.create(null) : {};
+
+    // Iterate over the keys and setup the new object
+
+    var keys = Object.keys(tempObj);
+    for (var i = 0; i < keys.length; ++i) {
+        var key = keys[i];
+        var newObj = parseKeys(key, tempObj[key], options);
+        obj = utils.merge(obj, newObj, options);
+    }
+
+    return utils.compact(obj);
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/qs/lib/stringify.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/stringify.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var utils = __webpack_require__(/*! ./utils */ "../../api-javascript/node_modules/qs/lib/utils.js");
+var formats = __webpack_require__(/*! ./formats */ "../../api-javascript/node_modules/qs/lib/formats.js");
+var has = Object.prototype.hasOwnProperty;
+
+var arrayPrefixGenerators = {
+    brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
+        return prefix + '[]';
+    },
+    comma: 'comma',
+    indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
+        return prefix + '[' + key + ']';
+    },
+    repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
+        return prefix;
+    }
+};
+
+var isArray = Array.isArray;
+var push = Array.prototype.push;
+var pushToArray = function (arr, valueOrArray) {
+    push.apply(arr, isArray(valueOrArray) ? valueOrArray : [valueOrArray]);
+};
+
+var toISO = Date.prototype.toISOString;
+
+var defaults = {
+    addQueryPrefix: false,
+    allowDots: false,
+    charset: 'utf-8',
+    charsetSentinel: false,
+    delimiter: '&',
+    encode: true,
+    encoder: utils.encode,
+    encodeValuesOnly: false,
+    formatter: formats.formatters[formats['default']],
+    // deprecated
+    indices: false,
+    serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
+        return toISO.call(date);
+    },
+    skipNulls: false,
+    strictNullHandling: false
+};
+
+var stringify = function stringify( // eslint-disable-line func-name-matching
+    object,
+    prefix,
+    generateArrayPrefix,
+    strictNullHandling,
+    skipNulls,
+    encoder,
+    filter,
+    sort,
+    allowDots,
+    serializeDate,
+    formatter,
+    encodeValuesOnly,
+    charset
+) {
+    var obj = object;
+    if (typeof filter === 'function') {
+        obj = filter(prefix, obj);
+    } else if (obj instanceof Date) {
+        obj = serializeDate(obj);
+    } else if (generateArrayPrefix === 'comma' && isArray(obj)) {
+        obj = obj.join(',');
+    }
+
+    if (obj === null) {
+        if (strictNullHandling) {
+            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset) : prefix;
+        }
+
+        obj = '';
+    }
+
+    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
+        if (encoder) {
+            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
+            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
+        }
+        return [formatter(prefix) + '=' + formatter(String(obj))];
+    }
+
+    var values = [];
+
+    if (typeof obj === 'undefined') {
+        return values;
+    }
+
+    var objKeys;
+    if (isArray(filter)) {
+        objKeys = filter;
+    } else {
+        var keys = Object.keys(obj);
+        objKeys = sort ? keys.sort(sort) : keys;
+    }
+
+    for (var i = 0; i < objKeys.length; ++i) {
+        var key = objKeys[i];
+
+        if (skipNulls && obj[key] === null) {
+            continue;
+        }
+
+        if (isArray(obj)) {
+            pushToArray(values, stringify(
+                obj[key],
+                typeof generateArrayPrefix === 'function' ? generateArrayPrefix(prefix, key) : prefix,
+                generateArrayPrefix,
+                strictNullHandling,
+                skipNulls,
+                encoder,
+                filter,
+                sort,
+                allowDots,
+                serializeDate,
+                formatter,
+                encodeValuesOnly,
+                charset
+            ));
+        } else {
+            pushToArray(values, stringify(
+                obj[key],
+                prefix + (allowDots ? '.' + key : '[' + key + ']'),
+                generateArrayPrefix,
+                strictNullHandling,
+                skipNulls,
+                encoder,
+                filter,
+                sort,
+                allowDots,
+                serializeDate,
+                formatter,
+                encodeValuesOnly,
+                charset
+            ));
+        }
+    }
+
+    return values;
+};
+
+var normalizeStringifyOptions = function normalizeStringifyOptions(opts) {
+    if (!opts) {
+        return defaults;
+    }
+
+    if (opts.encoder !== null && opts.encoder !== undefined && typeof opts.encoder !== 'function') {
+        throw new TypeError('Encoder has to be a function.');
+    }
+
+    var charset = opts.charset || defaults.charset;
+    if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
+        throw new TypeError('The charset option must be either utf-8, iso-8859-1, or undefined');
+    }
+
+    var format = formats['default'];
+    if (typeof opts.format !== 'undefined') {
+        if (!has.call(formats.formatters, opts.format)) {
+            throw new TypeError('Unknown format option provided.');
+        }
+        format = opts.format;
+    }
+    var formatter = formats.formatters[format];
+
+    var filter = defaults.filter;
+    if (typeof opts.filter === 'function' || isArray(opts.filter)) {
+        filter = opts.filter;
+    }
+
+    return {
+        addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,
+        allowDots: typeof opts.allowDots === 'undefined' ? defaults.allowDots : !!opts.allowDots,
+        charset: charset,
+        charsetSentinel: typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
+        delimiter: typeof opts.delimiter === 'undefined' ? defaults.delimiter : opts.delimiter,
+        encode: typeof opts.encode === 'boolean' ? opts.encode : defaults.encode,
+        encoder: typeof opts.encoder === 'function' ? opts.encoder : defaults.encoder,
+        encodeValuesOnly: typeof opts.encodeValuesOnly === 'boolean' ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
+        filter: filter,
+        formatter: formatter,
+        serializeDate: typeof opts.serializeDate === 'function' ? opts.serializeDate : defaults.serializeDate,
+        skipNulls: typeof opts.skipNulls === 'boolean' ? opts.skipNulls : defaults.skipNulls,
+        sort: typeof opts.sort === 'function' ? opts.sort : null,
+        strictNullHandling: typeof opts.strictNullHandling === 'boolean' ? opts.strictNullHandling : defaults.strictNullHandling
+    };
+};
+
+module.exports = function (object, opts) {
+    var obj = object;
+    var options = normalizeStringifyOptions(opts);
+
+    var objKeys;
+    var filter;
+
+    if (typeof options.filter === 'function') {
+        filter = options.filter;
+        obj = filter('', obj);
+    } else if (isArray(options.filter)) {
+        filter = options.filter;
+        objKeys = filter;
+    }
+
+    var keys = [];
+
+    if (typeof obj !== 'object' || obj === null) {
+        return '';
+    }
+
+    var arrayFormat;
+    if (opts && opts.arrayFormat in arrayPrefixGenerators) {
+        arrayFormat = opts.arrayFormat;
+    } else if (opts && 'indices' in opts) {
+        arrayFormat = opts.indices ? 'indices' : 'repeat';
+    } else {
+        arrayFormat = 'indices';
+    }
+
+    var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
+
+    if (!objKeys) {
+        objKeys = Object.keys(obj);
+    }
+
+    if (options.sort) {
+        objKeys.sort(options.sort);
+    }
+
+    for (var i = 0; i < objKeys.length; ++i) {
+        var key = objKeys[i];
+
+        if (options.skipNulls && obj[key] === null) {
+            continue;
+        }
+        pushToArray(keys, stringify(
+            obj[key],
+            key,
+            generateArrayPrefix,
+            options.strictNullHandling,
+            options.skipNulls,
+            options.encode ? options.encoder : null,
+            options.filter,
+            options.sort,
+            options.allowDots,
+            options.serializeDate,
+            options.formatter,
+            options.encodeValuesOnly,
+            options.charset
+        ));
+    }
+
+    var joined = keys.join(options.delimiter);
+    var prefix = options.addQueryPrefix === true ? '?' : '';
+
+    if (options.charsetSentinel) {
+        if (options.charset === 'iso-8859-1') {
+            // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
+            prefix += 'utf8=%26%2310003%3B&';
+        } else {
+            // encodeURIComponent('✓')
+            prefix += 'utf8=%E2%9C%93&';
+        }
+    }
+
+    return joined.length > 0 ? prefix + joined : '';
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/qs/lib/utils.js":
+/*!**********************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/qs/lib/utils.js ***!
+  \**********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var has = Object.prototype.hasOwnProperty;
+var isArray = Array.isArray;
+
+var hexTable = (function () {
+    var array = [];
+    for (var i = 0; i < 256; ++i) {
+        array.push('%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase());
+    }
+
+    return array;
+}());
+
+var compactQueue = function compactQueue(queue) {
+    while (queue.length > 1) {
+        var item = queue.pop();
+        var obj = item.obj[item.prop];
+
+        if (isArray(obj)) {
+            var compacted = [];
+
+            for (var j = 0; j < obj.length; ++j) {
+                if (typeof obj[j] !== 'undefined') {
+                    compacted.push(obj[j]);
+                }
+            }
+
+            item.obj[item.prop] = compacted;
+        }
+    }
+};
+
+var arrayToObject = function arrayToObject(source, options) {
+    var obj = options && options.plainObjects ? Object.create(null) : {};
+    for (var i = 0; i < source.length; ++i) {
+        if (typeof source[i] !== 'undefined') {
+            obj[i] = source[i];
+        }
+    }
+
+    return obj;
+};
+
+var merge = function merge(target, source, options) {
+    if (!source) {
+        return target;
+    }
+
+    if (typeof source !== 'object') {
+        if (isArray(target)) {
+            target.push(source);
+        } else if (target && typeof target === 'object') {
+            if ((options && (options.plainObjects || options.allowPrototypes)) || !has.call(Object.prototype, source)) {
+                target[source] = true;
+            }
+        } else {
+            return [target, source];
+        }
+
+        return target;
+    }
+
+    if (!target || typeof target !== 'object') {
+        return [target].concat(source);
+    }
+
+    var mergeTarget = target;
+    if (isArray(target) && !isArray(source)) {
+        mergeTarget = arrayToObject(target, options);
+    }
+
+    if (isArray(target) && isArray(source)) {
+        source.forEach(function (item, i) {
+            if (has.call(target, i)) {
+                var targetItem = target[i];
+                if (targetItem && typeof targetItem === 'object' && item && typeof item === 'object') {
+                    target[i] = merge(targetItem, item, options);
+                } else {
+                    target.push(item);
+                }
+            } else {
+                target[i] = item;
+            }
+        });
+        return target;
+    }
+
+    return Object.keys(source).reduce(function (acc, key) {
+        var value = source[key];
+
+        if (has.call(acc, key)) {
+            acc[key] = merge(acc[key], value, options);
+        } else {
+            acc[key] = value;
+        }
+        return acc;
+    }, mergeTarget);
+};
+
+var assign = function assignSingleSource(target, source) {
+    return Object.keys(source).reduce(function (acc, key) {
+        acc[key] = source[key];
+        return acc;
+    }, target);
+};
+
+var decode = function (str, decoder, charset) {
+    var strWithoutPlus = str.replace(/\+/g, ' ');
+    if (charset === 'iso-8859-1') {
+        // unescape never throws, no try...catch needed:
+        return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
+    }
+    // utf-8
+    try {
+        return decodeURIComponent(strWithoutPlus);
+    } catch (e) {
+        return strWithoutPlus;
+    }
+};
+
+var encode = function encode(str, defaultEncoder, charset) {
+    // This code was originally written by Brian White (mscdex) for the io.js core querystring library.
+    // It has been adapted here for stricter adherence to RFC 3986
+    if (str.length === 0) {
+        return str;
+    }
+
+    var string = typeof str === 'string' ? str : String(str);
+
+    if (charset === 'iso-8859-1') {
+        return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
+            return '%26%23' + parseInt($0.slice(2), 16) + '%3B';
+        });
+    }
+
+    var out = '';
+    for (var i = 0; i < string.length; ++i) {
+        var c = string.charCodeAt(i);
+
+        if (
+            c === 0x2D // -
+            || c === 0x2E // .
+            || c === 0x5F // _
+            || c === 0x7E // ~
+            || (c >= 0x30 && c <= 0x39) // 0-9
+            || (c >= 0x41 && c <= 0x5A) // a-z
+            || (c >= 0x61 && c <= 0x7A) // A-Z
+        ) {
+            out += string.charAt(i);
+            continue;
+        }
+
+        if (c < 0x80) {
+            out = out + hexTable[c];
+            continue;
+        }
+
+        if (c < 0x800) {
+            out = out + (hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)]);
+            continue;
+        }
+
+        if (c < 0xD800 || c >= 0xE000) {
+            out = out + (hexTable[0xE0 | (c >> 12)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)]);
+            continue;
+        }
+
+        i += 1;
+        c = 0x10000 + (((c & 0x3FF) << 10) | (string.charCodeAt(i) & 0x3FF));
+        out += hexTable[0xF0 | (c >> 18)]
+            + hexTable[0x80 | ((c >> 12) & 0x3F)]
+            + hexTable[0x80 | ((c >> 6) & 0x3F)]
+            + hexTable[0x80 | (c & 0x3F)];
+    }
+
+    return out;
+};
+
+var compact = function compact(value) {
+    var queue = [{ obj: { o: value }, prop: 'o' }];
+    var refs = [];
+
+    for (var i = 0; i < queue.length; ++i) {
+        var item = queue[i];
+        var obj = item.obj[item.prop];
+
+        var keys = Object.keys(obj);
+        for (var j = 0; j < keys.length; ++j) {
+            var key = keys[j];
+            var val = obj[key];
+            if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
+                queue.push({ obj: obj, prop: key });
+                refs.push(val);
+            }
+        }
+    }
+
+    compactQueue(queue);
+
+    return value;
+};
+
+var isRegExp = function isRegExp(obj) {
+    return Object.prototype.toString.call(obj) === '[object RegExp]';
+};
+
+var isBuffer = function isBuffer(obj) {
+    if (!obj || typeof obj !== 'object') {
+        return false;
+    }
+
+    return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
+};
+
+var combine = function combine(a, b) {
+    return [].concat(a, b);
+};
+
+module.exports = {
+    arrayToObject: arrayToObject,
+    assign: assign,
+    combine: combine,
+    compact: compact,
+    decode: decode,
+    encode: encode,
+    isBuffer: isBuffer,
+    isRegExp: isRegExp,
+    merge: merge
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/randomatic/index.js":
+/*!**************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/randomatic/index.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * randomatic <https://github.com/jonschlinkert/randomatic>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+var isNumber = __webpack_require__(/*! is-number */ "../../api-javascript/node_modules/randomatic/node_modules/is-number/index.js");
+var typeOf = __webpack_require__(/*! kind-of */ "../../api-javascript/node_modules/randomatic/node_modules/kind-of/index.js");
+var mathRandom = __webpack_require__(/*! math-random */ "../../api-javascript/node_modules/math-random/browser.js");
+
+/**
+ * Expose `randomatic`
+ */
+
+module.exports = randomatic;
+module.exports.isCrypto = !!mathRandom.cryptographic;
+
+/**
+ * Available mask characters
+ */
+
+var type = {
+  lower: 'abcdefghijklmnopqrstuvwxyz',
+  upper: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  number: '0123456789',
+  special: '~!@#$%^&()_+-={}[];\',.'
+};
+
+type.all = type.lower + type.upper + type.number + type.special;
+
+/**
+ * Generate random character sequences of a specified `length`,
+ * based on the given `pattern`.
+ *
+ * @param {String} `pattern` The pattern to use for generating the random string.
+ * @param {String} `length` The length of the string to generate.
+ * @param {String} `options`
+ * @return {String}
+ * @api public
+ */
+
+function randomatic(pattern, length, options) {
+  if (typeof pattern === 'undefined') {
+    throw new Error('randomatic expects a string or number.');
+  }
+
+  var custom = false;
+  if (arguments.length === 1) {
+    if (typeof pattern === 'string') {
+      length = pattern.length;
+
+    } else if (isNumber(pattern)) {
+      options = {};
+      length = pattern;
+      pattern = '*';
+    }
+  }
+
+  if (typeOf(length) === 'object' && length.hasOwnProperty('chars')) {
+    options = length;
+    pattern = options.chars;
+    length = pattern.length;
+    custom = true;
+  }
+
+  var opts = options || {};
+  var mask = '';
+  var res = '';
+
+  // Characters to be used
+  if (pattern.indexOf('?') !== -1) mask += opts.chars;
+  if (pattern.indexOf('a') !== -1) mask += type.lower;
+  if (pattern.indexOf('A') !== -1) mask += type.upper;
+  if (pattern.indexOf('0') !== -1) mask += type.number;
+  if (pattern.indexOf('!') !== -1) mask += type.special;
+  if (pattern.indexOf('*') !== -1) mask += type.all;
+  if (custom) mask += pattern;
+
+  // Characters to exclude
+  if (opts.exclude) {
+    var exclude = typeOf(opts.exclude) === 'string' ? opts.exclude : opts.exclude.join('');
+    exclude = exclude.replace(new RegExp('[\\]]+', 'g'), '');
+    mask = mask.replace(new RegExp('[' + exclude + ']+', 'g'), '');
+    
+    if(opts.exclude.indexOf(']') !== -1) mask = mask.replace(new RegExp('[\\]]+', 'g'), '');
+  }
+
+  while (length--) {
+    res += mask.charAt(parseInt(mathRandom() * mask.length, 10));
+  }
+  return res;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/randomatic/node_modules/is-number/index.js":
+/*!*************************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/randomatic/node_modules/is-number/index.js ***!
+  \*************************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * is-number <https://github.com/jonschlinkert/is-number>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+module.exports = function isNumber(num) {
+  var type = typeof num;
+
+  if (type === 'string' || num instanceof String) {
+    // an empty string would be coerced to true with the below logic
+    if (!num.trim()) return false;
+  } else if (type !== 'number' && !(num instanceof Number)) {
+    return false;
+  }
+
+  return (num - num + 1) >= 0;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/randomatic/node_modules/kind-of/index.js":
+/*!***********************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/randomatic/node_modules/kind-of/index.js ***!
+  \***********************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+var toString = Object.prototype.toString;
+
+module.exports = function kindOf(val) {
+  if (val === void 0) return 'undefined';
+  if (val === null) return 'null';
+
+  var type = typeof val;
+  if (type === 'boolean') return 'boolean';
+  if (type === 'string') return 'string';
+  if (type === 'number') return 'number';
+  if (type === 'symbol') return 'symbol';
+  if (type === 'function') {
+    return isGeneratorFn(val) ? 'generatorfunction' : 'function';
+  }
+
+  if (isArray(val)) return 'array';
+  if (isBuffer(val)) return 'buffer';
+  if (isArguments(val)) return 'arguments';
+  if (isDate(val)) return 'date';
+  if (isError(val)) return 'error';
+  if (isRegexp(val)) return 'regexp';
+
+  switch (ctorName(val)) {
+    case 'Symbol': return 'symbol';
+    case 'Promise': return 'promise';
+
+    // Set, Map, WeakSet, WeakMap
+    case 'WeakMap': return 'weakmap';
+    case 'WeakSet': return 'weakset';
+    case 'Map': return 'map';
+    case 'Set': return 'set';
+
+    // 8-bit typed arrays
+    case 'Int8Array': return 'int8array';
+    case 'Uint8Array': return 'uint8array';
+    case 'Uint8ClampedArray': return 'uint8clampedarray';
+
+    // 16-bit typed arrays
+    case 'Int16Array': return 'int16array';
+    case 'Uint16Array': return 'uint16array';
+
+    // 32-bit typed arrays
+    case 'Int32Array': return 'int32array';
+    case 'Uint32Array': return 'uint32array';
+    case 'Float32Array': return 'float32array';
+    case 'Float64Array': return 'float64array';
+  }
+
+  if (isGeneratorObj(val)) {
+    return 'generator';
+  }
+
+  // Non-plain objects
+  type = toString.call(val);
+  switch (type) {
+    case '[object Object]': return 'object';
+    // iterators
+    case '[object Map Iterator]': return 'mapiterator';
+    case '[object Set Iterator]': return 'setiterator';
+    case '[object String Iterator]': return 'stringiterator';
+    case '[object Array Iterator]': return 'arrayiterator';
+  }
+
+  // other
+  return type.slice(8, -1).toLowerCase().replace(/\s/g, '');
+};
+
+function ctorName(val) {
+  return val.constructor ? val.constructor.name : null;
+}
+
+function isArray(val) {
+  if (Array.isArray) return Array.isArray(val);
+  return val instanceof Array;
+}
+
+function isError(val) {
+  return val instanceof Error || (typeof val.message === 'string' && val.constructor && typeof val.constructor.stackTraceLimit === 'number');
+}
+
+function isDate(val) {
+  if (val instanceof Date) return true;
+  return typeof val.toDateString === 'function'
+    && typeof val.getDate === 'function'
+    && typeof val.setDate === 'function';
+}
+
+function isRegexp(val) {
+  if (val instanceof RegExp) return true;
+  return typeof val.flags === 'string'
+    && typeof val.ignoreCase === 'boolean'
+    && typeof val.multiline === 'boolean'
+    && typeof val.global === 'boolean';
+}
+
+function isGeneratorFn(name, val) {
+  return ctorName(name) === 'GeneratorFunction';
+}
+
+function isGeneratorObj(val) {
+  return typeof val.throw === 'function'
+    && typeof val.return === 'function'
+    && typeof val.next === 'function';
+}
+
+function isArguments(val) {
+  try {
+    if (typeof val.length === 'number' && typeof val.callee === 'function') {
+      return true;
+    }
+  } catch (err) {
+    if (err.message.indexOf('callee') !== -1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * If you need to support Safari 5-7 (8-10 yr-old browser),
+ * take a look at https://github.com/feross/is-buffer
+ */
+
+function isBuffer(val) {
+  if (val.constructor && typeof val.constructor.isBuffer === 'function') {
+    return val.constructor.isBuffer(val);
+  }
+  return false;
+}
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/regex-cache/index.js":
+/*!***************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/regex-cache/index.js ***!
+  \***************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * regex-cache <https://github.com/jonschlinkert/regex-cache>
+ *
+ * Copyright (c) 2015-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+var equal = __webpack_require__(/*! is-equal-shallow */ "../../api-javascript/node_modules/is-equal-shallow/index.js");
+var basic = {};
+var cache = {};
+
+/**
+ * Expose `regexCache`
+ */
+
+module.exports = regexCache;
+
+/**
+ * Memoize the results of a call to the new RegExp constructor.
+ *
+ * @param  {Function} fn [description]
+ * @param  {String} str [description]
+ * @param  {Options} options [description]
+ * @param  {Boolean} nocompare [description]
+ * @return {RegExp}
+ */
+
+function regexCache(fn, str, opts) {
+  var key = '_default_', regex, cached;
+
+  if (!str && !opts) {
+    if (typeof fn !== 'function') {
+      return fn;
+    }
+    return basic[key] || (basic[key] = fn(str));
+  }
+
+  var isString = typeof str === 'string';
+  if (isString) {
+    if (!opts) {
+      return basic[str] || (basic[str] = fn(str));
+    }
+    key = str;
+  } else {
+    opts = str;
+  }
+
+  cached = cache[key];
+  if (cached && equal(cached.opts, opts)) {
+    return cached.regex;
+  }
+
+  memo(key, opts, (regex = fn(str, opts)));
+  return regex;
+}
+
+function memo(key, opts, regex) {
+  cache[key] = {regex: regex, opts: opts};
+}
+
+/**
+ * Expose `cache`
+ */
+
+module.exports.cache = cache;
+module.exports.basic = basic;
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/remove-trailing-separator/index.js":
+/*!*****************************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/remove-trailing-separator/index.js ***!
+  \*****************************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/* WEBPACK VAR INJECTION */(function(process) {var isWin = process.platform === 'win32';
+
+module.exports = function (str) {
+	var i = str.length - 1;
+	if (i < 2) {
+		return str;
+	}
+	while (isSeparator(str, i)) {
+		i--;
+	}
+	return str.substr(0, i + 1);
+};
+
+function isSeparator(str, i) {
+	var char = str[i];
+	return i > 0 && (char === '/' || (isWin && char === '\\'));
+}
+
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../sfx/sfx-logic/node_modules/process/browser.js */ "./node_modules/process/browser.js")))
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/repeat-element/index.js":
+/*!******************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/repeat-element/index.js ***!
+  \******************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * repeat-element <https://github.com/jonschlinkert/repeat-element>
+ *
+ * Copyright (c) 2015-present, Jon Schlinkert.
+ * Licensed under the MIT license.
+ */
+
+
+
+module.exports = function repeat(ele, num) {
+  var arr = new Array(num);
+
+  for (var i = 0; i < num; i++) {
+    arr[i] = ele;
+  }
+
+  return arr;
+};
+
+
+/***/ }),
+
+/***/ "../../api-javascript/node_modules/repeat-string/index.js":
+/*!*****************************************************************************!*\
+  !*** /Users/shawna/Work/api-javascript/node_modules/repeat-string/index.js ***!
+  \*****************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * repeat-string <https://github.com/jonschlinkert/repeat-string>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+
+
+/**
+ * Results cache
+ */
+
+var res = '';
+var cache;
+
+/**
+ * Expose `repeat`
+ */
+
+module.exports = repeat;
+
+/**
+ * Repeat the given `string` the specified `number`
+ * of times.
+ *
+ * **Example:**
+ *
+ * ```js
+ * var repeat = require('repeat-string');
+ * repeat('A', 5);
+ * //=> AAAAA
+ * ```
+ *
+ * @param {String} `string` The string to repeat
+ * @param {Number} `number` The number of times to repeat the string
+ * @return {String} Repeated string
+ * @api public
+ */
+
+function repeat(str, num) {
+  if (typeof str !== 'string') {
+    throw new TypeError('expected a string');
+  }
+
+  // cover common, quick use cases
+  if (num === 1) return str;
+  if (num === 2) return str + str;
+
+  var max = str.length * num;
+  if (cache !== str || typeof cache === 'undefined') {
+    cache = str;
+    res = '';
+  } else if (res.length >= max) {
+    return res.substr(0, max);
+  }
+
+  while (max > res.length && num > 1) {
+    if (num & 1) {
+      res += str;
+    }
+
+    num >>= 1;
+    str += str;
+  }
+
+  res += str;
+  res = res.substr(0, max);
+  return res;
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/arr-flatten/index.js":
+/*!*******************************************!*\
+  !*** ./node_modules/arr-flatten/index.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/*!
+ * arr-flatten <https://github.com/jonschlinkert/arr-flatten>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+
+
+module.exports = function (arr) {
+  return flat(arr, []);
+};
+
+function flat(arr, res) {
+  var i = 0, cur;
+  var len = arr.length;
+  for (; i < len; i++) {
+    cur = arr[i];
+    Array.isArray(cur) ? flat(cur, res) : res.push(cur);
+  }
+  return res;
+}
+
+
+/***/ }),
+
+/***/ "./node_modules/base64-js/index.js":
+/*!*****************************************!*\
+  !*** ./node_modules/base64-js/index.js ***!
+  \*****************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+exports.byteLength = byteLength
+exports.toByteArray = toByteArray
+exports.fromByteArray = fromByteArray
+
+var lookup = []
+var revLookup = []
+var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
+
+var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+for (var i = 0, len = code.length; i < len; ++i) {
+  lookup[i] = code[i]
+  revLookup[code.charCodeAt(i)] = i
+}
+
+// Support decoding URL-safe base64 strings, as Node.js does.
+// See: https://en.wikipedia.org/wiki/Base64#URL_applications
+revLookup['-'.charCodeAt(0)] = 62
+revLookup['_'.charCodeAt(0)] = 63
+
+function getLens (b64) {
+  var len = b64.length
+
+  if (len % 4 > 0) {
+    throw new Error('Invalid string. Length must be a multiple of 4')
+  }
+
+  // Trim off extra bytes after placeholder bytes are found
+  // See: https://github.com/beatgammit/base64-js/issues/42
+  var validLen = b64.indexOf('=')
+  if (validLen === -1) validLen = len
+
+  var placeHoldersLen = validLen === len
+    ? 0
+    : 4 - (validLen % 4)
+
+  return [validLen, placeHoldersLen]
+}
+
+// base64 is 4/3 + up to two characters of the original data
+function byteLength (b64) {
+  var lens = getLens(b64)
+  var validLen = lens[0]
+  var placeHoldersLen = lens[1]
+  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+}
+
+function _byteLength (b64, validLen, placeHoldersLen) {
+  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+}
+
+function toByteArray (b64) {
+  var tmp
+  var lens = getLens(b64)
+  var validLen = lens[0]
+  var placeHoldersLen = lens[1]
+
+  var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen))
+
+  var curByte = 0
+
+  // if there are placeholders, only get up to the last complete 4 chars
+  var len = placeHoldersLen > 0
+    ? validLen - 4
+    : validLen
+
+  for (var i = 0; i < len; i += 4) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 18) |
+      (revLookup[b64.charCodeAt(i + 1)] << 12) |
+      (revLookup[b64.charCodeAt(i + 2)] << 6) |
+      revLookup[b64.charCodeAt(i + 3)]
+    arr[curByte++] = (tmp >> 16) & 0xFF
+    arr[curByte++] = (tmp >> 8) & 0xFF
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  if (placeHoldersLen === 2) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 2) |
+      (revLookup[b64.charCodeAt(i + 1)] >> 4)
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  if (placeHoldersLen === 1) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 10) |
+      (revLookup[b64.charCodeAt(i + 1)] << 4) |
+      (revLookup[b64.charCodeAt(i + 2)] >> 2)
+    arr[curByte++] = (tmp >> 8) & 0xFF
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  return arr
+}
+
+function tripletToBase64 (num) {
+  return lookup[num >> 18 & 0x3F] +
+    lookup[num >> 12 & 0x3F] +
+    lookup[num >> 6 & 0x3F] +
+    lookup[num & 0x3F]
+}
+
+function encodeChunk (uint8, start, end) {
+  var tmp
+  var output = []
+  for (var i = start; i < end; i += 3) {
+    tmp =
+      ((uint8[i] << 16) & 0xFF0000) +
+      ((uint8[i + 1] << 8) & 0xFF00) +
+      (uint8[i + 2] & 0xFF)
+    output.push(tripletToBase64(tmp))
+  }
+  return output.join('')
+}
+
+function fromByteArray (uint8) {
+  var tmp
+  var len = uint8.length
+  var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
+  var parts = []
+  var maxChunkLength = 16383 // must be multiple of 3
+
+  // go through the array every three bytes, we'll deal with trailing stuff later
+  for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+    parts.push(encodeChunk(
+      uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
+    ))
+  }
+
+  // pad the end with zeros, but make sure to not forget the extra bytes
+  if (extraBytes === 1) {
+    tmp = uint8[len - 1]
+    parts.push(
+      lookup[tmp >> 2] +
+      lookup[(tmp << 4) & 0x3F] +
+      '=='
+    )
+  } else if (extraBytes === 2) {
+    tmp = (uint8[len - 2] << 8) + uint8[len - 1]
+    parts.push(
+      lookup[tmp >> 10] +
+      lookup[(tmp >> 4) & 0x3F] +
+      lookup[(tmp << 2) & 0x3F] +
+      '='
+    )
+  }
+
+  return parts.join('')
+}
+
 
 /***/ }),
 
@@ -1145,188 +7469,151 @@ function coerce(val) {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-var objectKeys = __webpack_require__(/*! object-keys */ "./node_modules/object-keys/index.js");
-var isArguments = __webpack_require__(/*! is-arguments */ "./node_modules/is-arguments/index.js");
-var is = __webpack_require__(/*! object-is */ "./node_modules/object-is/index.js");
-var isRegex = __webpack_require__(/*! is-regex */ "./node_modules/is-regex/index.js");
-var flags = __webpack_require__(/*! regexp.prototype.flags */ "./node_modules/regexp.prototype.flags/index.js");
-var isDate = __webpack_require__(/*! is-date-object */ "./node_modules/is-date-object/index.js");
+var pSlice = Array.prototype.slice;
+var objectKeys = __webpack_require__(/*! ./lib/keys.js */ "./node_modules/deep-equal/lib/keys.js");
+var isArguments = __webpack_require__(/*! ./lib/is_arguments.js */ "./node_modules/deep-equal/lib/is_arguments.js");
 
-var getTime = Date.prototype.getTime;
-
-function deepEqual(actual, expected, options) {
-  var opts = options || {};
-
+var deepEqual = module.exports = function (actual, expected, opts) {
+  if (!opts) opts = {};
   // 7.1. All identical values are equivalent, as determined by ===.
-  if (opts.strict ? is(actual, expected) : actual === expected) {
+  if (actual === expected) {
     return true;
-  }
 
-  // 7.3. Other pairs that do not both pass typeof value == 'object', equivalence is determined by ==.
-  if (!actual || !expected || (typeof actual !== 'object' && typeof expected !== 'object')) {
-    return opts.strict ? is(actual, expected) : actual == expected;
-  }
+  } else if (actual instanceof Date && expected instanceof Date) {
+    return actual.getTime() === expected.getTime();
 
-  /*
-   * 7.4. For all other Object pairs, including Array objects, equivalence is
-   * determined by having the same number of owned properties (as verified
-   * with Object.prototype.hasOwnProperty.call), the same set of keys
-   * (although not necessarily the same order), equivalent values for every
-   * corresponding key, and an identical 'prototype' property. Note: this
-   * accounts for both named and indexed properties on Arrays.
-   */
-  // eslint-disable-next-line no-use-before-define
-  return objEquiv(actual, expected, opts);
+  // 7.3. Other pairs that do not both pass typeof value == 'object',
+  // equivalence is determined by ==.
+  } else if (!actual || !expected || typeof actual != 'object' && typeof expected != 'object') {
+    return opts.strict ? actual === expected : actual == expected;
+
+  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // determined by having the same number of owned properties (as verified
+  // with Object.prototype.hasOwnProperty.call), the same set of keys
+  // (although not necessarily the same order), equivalent values for every
+  // corresponding key, and an identical 'prototype' property. Note: this
+  // accounts for both named and indexed properties on Arrays.
+  } else {
+    return objEquiv(actual, expected, opts);
+  }
 }
 
 function isUndefinedOrNull(value) {
   return value === null || value === undefined;
 }
 
-function isBuffer(x) {
-  if (!x || typeof x !== 'object' || typeof x.length !== 'number') {
-    return false;
-  }
+function isBuffer (x) {
+  if (!x || typeof x !== 'object' || typeof x.length !== 'number') return false;
   if (typeof x.copy !== 'function' || typeof x.slice !== 'function') {
     return false;
   }
-  if (x.length > 0 && typeof x[0] !== 'number') {
-    return false;
-  }
+  if (x.length > 0 && typeof x[0] !== 'number') return false;
   return true;
 }
 
 function objEquiv(a, b, opts) {
-  /* eslint max-statements: [2, 50] */
   var i, key;
-  if (typeof a !== typeof b) { return false; }
-  if (isUndefinedOrNull(a) || isUndefinedOrNull(b)) { return false; }
-
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+    return false;
   // an identical 'prototype' property.
-  if (a.prototype !== b.prototype) { return false; }
-
-  if (isArguments(a) !== isArguments(b)) { return false; }
-
-  var aIsRegex = isRegex(a);
-  var bIsRegex = isRegex(b);
-  if (aIsRegex !== bIsRegex) { return false; }
-  if (aIsRegex || bIsRegex) {
-    return a.source === b.source && flags(a) === flags(b);
+  if (a.prototype !== b.prototype) return false;
+  //~~~I've managed to break Object.keys through screwy arguments passing.
+  //   Converting to array solves the problem.
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = pSlice.call(a);
+    b = pSlice.call(b);
+    return deepEqual(a, b, opts);
   }
-
-  if (isDate(a) && isDate(b)) {
-    return getTime.call(a) === getTime.call(b);
-  }
-
-  var aIsBuffer = isBuffer(a);
-  var bIsBuffer = isBuffer(b);
-  if (aIsBuffer !== bIsBuffer) { return false; }
-  if (aIsBuffer || bIsBuffer) { // && would work too, because both are true or both false here
-    if (a.length !== b.length) { return false; }
+  if (isBuffer(a)) {
+    if (!isBuffer(b)) {
+      return false;
+    }
+    if (a.length !== b.length) return false;
     for (i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) { return false; }
+      if (a[i] !== b[i]) return false;
     }
     return true;
   }
-
-  if (typeof a !== typeof b) { return false; }
-
   try {
-    var ka = objectKeys(a);
-    var kb = objectKeys(b);
-  } catch (e) { // happens when one is a string literal and the other isn't
+    var ka = objectKeys(a),
+        kb = objectKeys(b);
+  } catch (e) {//happens when one is a string literal and the other isn't
     return false;
   }
-  // having the same number of owned properties (keys incorporates hasOwnProperty)
-  if (ka.length !== kb.length) { return false; }
-
-  // the same set of keys (although not necessarily the same order),
+  // having the same number of owned properties (keys incorporates
+  // hasOwnProperty)
+  if (ka.length != kb.length)
+    return false;
+  //the same set of keys (although not necessarily the same order),
   ka.sort();
   kb.sort();
-  // ~~~cheap key test
+  //~~~cheap key test
   for (i = ka.length - 1; i >= 0; i--) {
-    if (ka[i] != kb[i]) { return false; }
+    if (ka[i] != kb[i])
+      return false;
   }
-  // equivalent values for every corresponding key, and ~~~possibly expensive deep test
+  //equivalent values for every corresponding key, and
+  //~~~possibly expensive deep test
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
-    if (!deepEqual(a[key], b[key], opts)) { return false; }
+    if (!deepEqual(a[key], b[key], opts)) return false;
   }
-
-  return true;
+  return typeof a === typeof b;
 }
-
-module.exports = deepEqual;
 
 
 /***/ }),
 
-/***/ "./node_modules/define-properties/index.js":
-/*!*************************************************!*\
-  !*** ./node_modules/define-properties/index.js ***!
-  \*************************************************/
+/***/ "./node_modules/deep-equal/lib/is_arguments.js":
+/*!*****************************************************!*\
+  !*** ./node_modules/deep-equal/lib/is_arguments.js ***!
+  \*****************************************************/
 /*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-"use strict";
+var supportsArgumentsClass = (function(){
+  return Object.prototype.toString.call(arguments)
+})() == '[object Arguments]';
 
+exports = module.exports = supportsArgumentsClass ? supported : unsupported;
 
-var keys = __webpack_require__(/*! object-keys */ "./node_modules/object-keys/index.js");
-var hasSymbols = typeof Symbol === 'function' && typeof Symbol('foo') === 'symbol';
-
-var toStr = Object.prototype.toString;
-var concat = Array.prototype.concat;
-var origDefineProperty = Object.defineProperty;
-
-var isFunction = function (fn) {
-	return typeof fn === 'function' && toStr.call(fn) === '[object Function]';
+exports.supported = supported;
+function supported(object) {
+  return Object.prototype.toString.call(object) == '[object Arguments]';
 };
 
-var arePropertyDescriptorsSupported = function () {
-	var obj = {};
-	try {
-		origDefineProperty(obj, 'x', { enumerable: false, value: obj });
-		// eslint-disable-next-line no-unused-vars, no-restricted-syntax
-		for (var _ in obj) { // jscs:ignore disallowUnusedVariables
-			return false;
-		}
-		return obj.x === obj;
-	} catch (e) { /* this is IE 8. */
-		return false;
-	}
-};
-var supportsDescriptors = origDefineProperty && arePropertyDescriptorsSupported();
-
-var defineProperty = function (object, name, value, predicate) {
-	if (name in object && (!isFunction(predicate) || !predicate())) {
-		return;
-	}
-	if (supportsDescriptors) {
-		origDefineProperty(object, name, {
-			configurable: true,
-			enumerable: false,
-			value: value,
-			writable: true
-		});
-	} else {
-		object[name] = value;
-	}
+exports.unsupported = unsupported;
+function unsupported(object){
+  return object &&
+    typeof object == 'object' &&
+    typeof object.length == 'number' &&
+    Object.prototype.hasOwnProperty.call(object, 'callee') &&
+    !Object.prototype.propertyIsEnumerable.call(object, 'callee') ||
+    false;
 };
 
-var defineProperties = function (object, map) {
-	var predicates = arguments.length > 2 ? arguments[2] : {};
-	var props = keys(map);
-	if (hasSymbols) {
-		props = concat.call(props, Object.getOwnPropertySymbols(map));
-	}
-	for (var i = 0; i < props.length; i += 1) {
-		defineProperty(object, props[i], map[props[i]], predicates[props[i]]);
-	}
-};
 
-defineProperties.supportsDescriptors = !!supportsDescriptors;
+/***/ }),
 
-module.exports = defineProperties;
+/***/ "./node_modules/deep-equal/lib/keys.js":
+/*!*********************************************!*\
+  !*** ./node_modules/deep-equal/lib/keys.js ***!
+  \*********************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+exports = module.exports = typeof Object.keys === 'function'
+  ? Object.keys : shim;
+
+exports.shim = shim;
+function shim (obj) {
+  var keys = [];
+  for (var key in obj) keys.push(key);
+  return keys;
+}
 
 
 /***/ }),
@@ -3066,7 +9353,7 @@ function length(val) {
 
 
 
-var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/expand-range/node_modules/kind-of/index.js");
+var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
 
 module.exports = function isNumber(num) {
   var type = typeOf(num);
@@ -3101,133 +9388,6 @@ var isArray = __webpack_require__(/*! isarray */ "./node_modules/isarray/index.j
 
 module.exports = function isObject(val) {
   return val != null && typeof val === 'object' && isArray(val) === false;
-};
-
-
-/***/ }),
-
-/***/ "./node_modules/expand-range/node_modules/kind-of/index.js":
-/*!*****************************************************************!*\
-  !*** ./node_modules/expand-range/node_modules/kind-of/index.js ***!
-  \*****************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
-var toString = Object.prototype.toString;
-
-/**
- * Get the native `typeof` a value.
- *
- * @param  {*} `val`
- * @return {*} Native javascript type
- */
-
-module.exports = function kindOf(val) {
-  // primitivies
-  if (typeof val === 'undefined') {
-    return 'undefined';
-  }
-  if (val === null) {
-    return 'null';
-  }
-  if (val === true || val === false || val instanceof Boolean) {
-    return 'boolean';
-  }
-  if (typeof val === 'string' || val instanceof String) {
-    return 'string';
-  }
-  if (typeof val === 'number' || val instanceof Number) {
-    return 'number';
-  }
-
-  // functions
-  if (typeof val === 'function' || val instanceof Function) {
-    return 'function';
-  }
-
-  // array
-  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
-    return 'array';
-  }
-
-  // check for instances of RegExp and Date before calling `toString`
-  if (val instanceof RegExp) {
-    return 'regexp';
-  }
-  if (val instanceof Date) {
-    return 'date';
-  }
-
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-  if (type === '[object Error]') {
-    return 'error';
-  }
-
-  // buffer
-  if (isBuffer(val)) {
-    return 'buffer';
-  }
-
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
-
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
-  }
-
-  // must be a plain object
-  return 'object';
 };
 
 
@@ -3275,519 +9435,6 @@ function hasOwn(obj, key) {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-
-/***/ }),
-
-/***/ "./node_modules/fetch-ponyfill/build/fetch-browser.js":
-/*!************************************************************!*\
-  !*** ./node_modules/fetch-ponyfill/build/fetch-browser.js ***!
-  \************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/* WEBPACK VAR INJECTION */(function(global) {var __WEBPACK_AMD_DEFINE_RESULT__;(function (self) {
-  'use strict';
-
-  function fetchPonyfill(options) {
-    var Promise = options && options.Promise || self.Promise;
-    var XMLHttpRequest = options && options.XMLHttpRequest || self.XMLHttpRequest;
-    var global = self;
-
-    return (function () {
-      var self = Object.create(global, {
-        fetch: {
-          value: undefined,
-          writable: true
-        }
-      });
-
-      (function(self) {
-        'use strict';
-
-        if (self.fetch) {
-          return
-        }
-
-        var support = {
-          searchParams: 'URLSearchParams' in self,
-          iterable: 'Symbol' in self && 'iterator' in Symbol,
-          blob: 'FileReader' in self && 'Blob' in self && (function() {
-            try {
-              new Blob()
-              return true
-            } catch(e) {
-              return false
-            }
-          })(),
-          formData: 'FormData' in self,
-          arrayBuffer: 'ArrayBuffer' in self
-        }
-
-        if (support.arrayBuffer) {
-          var viewClasses = [
-            '[object Int8Array]',
-            '[object Uint8Array]',
-            '[object Uint8ClampedArray]',
-            '[object Int16Array]',
-            '[object Uint16Array]',
-            '[object Int32Array]',
-            '[object Uint32Array]',
-            '[object Float32Array]',
-            '[object Float64Array]'
-          ]
-
-          var isDataView = function(obj) {
-            return obj && DataView.prototype.isPrototypeOf(obj)
-          }
-
-          var isArrayBufferView = ArrayBuffer.isView || function(obj) {
-            return obj && viewClasses.indexOf(Object.prototype.toString.call(obj)) > -1
-          }
-        }
-
-        function normalizeName(name) {
-          if (typeof name !== 'string') {
-            name = String(name)
-          }
-          if (/[^a-z0-9\-#$%&'*+.\^_`|~]/i.test(name)) {
-            throw new TypeError('Invalid character in header field name')
-          }
-          return name.toLowerCase()
-        }
-
-        function normalizeValue(value) {
-          if (typeof value !== 'string') {
-            value = String(value)
-          }
-          return value
-        }
-
-        // Build a destructive iterator for the value list
-        function iteratorFor(items) {
-          var iterator = {
-            next: function() {
-              var value = items.shift()
-              return {done: value === undefined, value: value}
-            }
-          }
-
-          if (support.iterable) {
-            iterator[Symbol.iterator] = function() {
-              return iterator
-            }
-          }
-
-          return iterator
-        }
-
-        function Headers(headers) {
-          this.map = {}
-
-          if (headers instanceof Headers) {
-            headers.forEach(function(value, name) {
-              this.append(name, value)
-            }, this)
-          } else if (Array.isArray(headers)) {
-            headers.forEach(function(header) {
-              this.append(header[0], header[1])
-            }, this)
-          } else if (headers) {
-            Object.getOwnPropertyNames(headers).forEach(function(name) {
-              this.append(name, headers[name])
-            }, this)
-          }
-        }
-
-        Headers.prototype.append = function(name, value) {
-          name = normalizeName(name)
-          value = normalizeValue(value)
-          var oldValue = this.map[name]
-          this.map[name] = oldValue ? oldValue+','+value : value
-        }
-
-        Headers.prototype['delete'] = function(name) {
-          delete this.map[normalizeName(name)]
-        }
-
-        Headers.prototype.get = function(name) {
-          name = normalizeName(name)
-          return this.has(name) ? this.map[name] : null
-        }
-
-        Headers.prototype.has = function(name) {
-          return this.map.hasOwnProperty(normalizeName(name))
-        }
-
-        Headers.prototype.set = function(name, value) {
-          this.map[normalizeName(name)] = normalizeValue(value)
-        }
-
-        Headers.prototype.forEach = function(callback, thisArg) {
-          for (var name in this.map) {
-            if (this.map.hasOwnProperty(name)) {
-              callback.call(thisArg, this.map[name], name, this)
-            }
-          }
-        }
-
-        Headers.prototype.keys = function() {
-          var items = []
-          this.forEach(function(value, name) { items.push(name) })
-          return iteratorFor(items)
-        }
-
-        Headers.prototype.values = function() {
-          var items = []
-          this.forEach(function(value) { items.push(value) })
-          return iteratorFor(items)
-        }
-
-        Headers.prototype.entries = function() {
-          var items = []
-          this.forEach(function(value, name) { items.push([name, value]) })
-          return iteratorFor(items)
-        }
-
-        if (support.iterable) {
-          Headers.prototype[Symbol.iterator] = Headers.prototype.entries
-        }
-
-        function consumed(body) {
-          if (body.bodyUsed) {
-            return Promise.reject(new TypeError('Already read'))
-          }
-          body.bodyUsed = true
-        }
-
-        function fileReaderReady(reader) {
-          return new Promise(function(resolve, reject) {
-            reader.onload = function() {
-              resolve(reader.result)
-            }
-            reader.onerror = function() {
-              reject(reader.error)
-            }
-          })
-        }
-
-        function readBlobAsArrayBuffer(blob) {
-          var reader = new FileReader()
-          var promise = fileReaderReady(reader)
-          reader.readAsArrayBuffer(blob)
-          return promise
-        }
-
-        function readBlobAsText(blob) {
-          var reader = new FileReader()
-          var promise = fileReaderReady(reader)
-          reader.readAsText(blob)
-          return promise
-        }
-
-        function readArrayBufferAsText(buf) {
-          var view = new Uint8Array(buf)
-          var chars = new Array(view.length)
-
-          for (var i = 0; i < view.length; i++) {
-            chars[i] = String.fromCharCode(view[i])
-          }
-          return chars.join('')
-        }
-
-        function bufferClone(buf) {
-          if (buf.slice) {
-            return buf.slice(0)
-          } else {
-            var view = new Uint8Array(buf.byteLength)
-            view.set(new Uint8Array(buf))
-            return view.buffer
-          }
-        }
-
-        function Body() {
-          this.bodyUsed = false
-
-          this._initBody = function(body) {
-            this._bodyInit = body
-            if (!body) {
-              this._bodyText = ''
-            } else if (typeof body === 'string') {
-              this._bodyText = body
-            } else if (support.blob && Blob.prototype.isPrototypeOf(body)) {
-              this._bodyBlob = body
-            } else if (support.formData && FormData.prototype.isPrototypeOf(body)) {
-              this._bodyFormData = body
-            } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
-              this._bodyText = body.toString()
-            } else if (support.arrayBuffer && support.blob && isDataView(body)) {
-              this._bodyArrayBuffer = bufferClone(body.buffer)
-              // IE 10-11 can't handle a DataView body.
-              this._bodyInit = new Blob([this._bodyArrayBuffer])
-            } else if (support.arrayBuffer && (ArrayBuffer.prototype.isPrototypeOf(body) || isArrayBufferView(body))) {
-              this._bodyArrayBuffer = bufferClone(body)
-            } else {
-              throw new Error('unsupported BodyInit type')
-            }
-
-            if (!this.headers.get('content-type')) {
-              if (typeof body === 'string') {
-                this.headers.set('content-type', 'text/plain;charset=UTF-8')
-              } else if (this._bodyBlob && this._bodyBlob.type) {
-                this.headers.set('content-type', this._bodyBlob.type)
-              } else if (support.searchParams && URLSearchParams.prototype.isPrototypeOf(body)) {
-                this.headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
-              }
-            }
-          }
-
-          if (support.blob) {
-            this.blob = function() {
-              var rejected = consumed(this)
-              if (rejected) {
-                return rejected
-              }
-
-              if (this._bodyBlob) {
-                return Promise.resolve(this._bodyBlob)
-              } else if (this._bodyArrayBuffer) {
-                return Promise.resolve(new Blob([this._bodyArrayBuffer]))
-              } else if (this._bodyFormData) {
-                throw new Error('could not read FormData body as blob')
-              } else {
-                return Promise.resolve(new Blob([this._bodyText]))
-              }
-            }
-
-            this.arrayBuffer = function() {
-              if (this._bodyArrayBuffer) {
-                return consumed(this) || Promise.resolve(this._bodyArrayBuffer)
-              } else {
-                return this.blob().then(readBlobAsArrayBuffer)
-              }
-            }
-          }
-
-          this.text = function() {
-            var rejected = consumed(this)
-            if (rejected) {
-              return rejected
-            }
-
-            if (this._bodyBlob) {
-              return readBlobAsText(this._bodyBlob)
-            } else if (this._bodyArrayBuffer) {
-              return Promise.resolve(readArrayBufferAsText(this._bodyArrayBuffer))
-            } else if (this._bodyFormData) {
-              throw new Error('could not read FormData body as text')
-            } else {
-              return Promise.resolve(this._bodyText)
-            }
-          }
-
-          if (support.formData) {
-            this.formData = function() {
-              return this.text().then(decode)
-            }
-          }
-
-          this.json = function() {
-            return this.text().then(JSON.parse)
-          }
-
-          return this
-        }
-
-        // HTTP methods whose capitalization should be normalized
-        var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
-
-        function normalizeMethod(method) {
-          var upcased = method.toUpperCase()
-          return (methods.indexOf(upcased) > -1) ? upcased : method
-        }
-
-        function Request(input, options) {
-          options = options || {}
-          var body = options.body
-
-          if (input instanceof Request) {
-            if (input.bodyUsed) {
-              throw new TypeError('Already read')
-            }
-            this.url = input.url
-            this.credentials = input.credentials
-            if (!options.headers) {
-              this.headers = new Headers(input.headers)
-            }
-            this.method = input.method
-            this.mode = input.mode
-            if (!body && input._bodyInit != null) {
-              body = input._bodyInit
-              input.bodyUsed = true
-            }
-          } else {
-            this.url = String(input)
-          }
-
-          this.credentials = options.credentials || this.credentials || 'omit'
-          if (options.headers || !this.headers) {
-            this.headers = new Headers(options.headers)
-          }
-          this.method = normalizeMethod(options.method || this.method || 'GET')
-          this.mode = options.mode || this.mode || null
-          this.referrer = null
-
-          if ((this.method === 'GET' || this.method === 'HEAD') && body) {
-            throw new TypeError('Body not allowed for GET or HEAD requests')
-          }
-          this._initBody(body)
-        }
-
-        Request.prototype.clone = function() {
-          return new Request(this, { body: this._bodyInit })
-        }
-
-        function decode(body) {
-          var form = new FormData()
-          body.trim().split('&').forEach(function(bytes) {
-            if (bytes) {
-              var split = bytes.split('=')
-              var name = split.shift().replace(/\+/g, ' ')
-              var value = split.join('=').replace(/\+/g, ' ')
-              form.append(decodeURIComponent(name), decodeURIComponent(value))
-            }
-          })
-          return form
-        }
-
-        function parseHeaders(rawHeaders) {
-          var headers = new Headers()
-          // Replace instances of \r\n and \n followed by at least one space or horizontal tab with a space
-          // https://tools.ietf.org/html/rfc7230#section-3.2
-          var preProcessedHeaders = rawHeaders.replace(/\r?\n[\t ]+/g, ' ')
-          preProcessedHeaders.split(/\r?\n/).forEach(function(line) {
-            var parts = line.split(':')
-            var key = parts.shift().trim()
-            if (key) {
-              var value = parts.join(':').trim()
-              headers.append(key, value)
-            }
-          })
-          return headers
-        }
-
-        Body.call(Request.prototype)
-
-        function Response(bodyInit, options) {
-          if (!options) {
-            options = {}
-          }
-
-          this.type = 'default'
-          this.status = options.status === undefined ? 200 : options.status
-          this.ok = this.status >= 200 && this.status < 300
-          this.statusText = 'statusText' in options ? options.statusText : 'OK'
-          this.headers = new Headers(options.headers)
-          this.url = options.url || ''
-          this._initBody(bodyInit)
-        }
-
-        Body.call(Response.prototype)
-
-        Response.prototype.clone = function() {
-          return new Response(this._bodyInit, {
-            status: this.status,
-            statusText: this.statusText,
-            headers: new Headers(this.headers),
-            url: this.url
-          })
-        }
-
-        Response.error = function() {
-          var response = new Response(null, {status: 0, statusText: ''})
-          response.type = 'error'
-          return response
-        }
-
-        var redirectStatuses = [301, 302, 303, 307, 308]
-
-        Response.redirect = function(url, status) {
-          if (redirectStatuses.indexOf(status) === -1) {
-            throw new RangeError('Invalid status code')
-          }
-
-          return new Response(null, {status: status, headers: {location: url}})
-        }
-
-        self.Headers = Headers
-        self.Request = Request
-        self.Response = Response
-
-        self.fetch = function(input, init) {
-          return new Promise(function(resolve, reject) {
-            var request = new Request(input, init)
-            var xhr = new XMLHttpRequest()
-
-            xhr.onload = function() {
-              var options = {
-                status: xhr.status,
-                statusText: xhr.statusText,
-                headers: parseHeaders(xhr.getAllResponseHeaders() || '')
-              }
-              options.url = 'responseURL' in xhr ? xhr.responseURL : options.headers.get('X-Request-URL')
-              var body = 'response' in xhr ? xhr.response : xhr.responseText
-              resolve(new Response(body, options))
-            }
-
-            xhr.onerror = function() {
-              reject(new TypeError('Network request failed'))
-            }
-
-            xhr.ontimeout = function() {
-              reject(new TypeError('Network request failed'))
-            }
-
-            xhr.open(request.method, request.url, true)
-
-            if (request.credentials === 'include') {
-              xhr.withCredentials = true
-            } else if (request.credentials === 'omit') {
-              xhr.withCredentials = false
-            }
-
-            if ('responseType' in xhr && support.blob) {
-              xhr.responseType = 'blob'
-            }
-
-            request.headers.forEach(function(value, name) {
-              xhr.setRequestHeader(name, value)
-            })
-
-            xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)
-          })
-        }
-        self.fetch.polyfill = true
-      })(typeof self !== 'undefined' ? self : this);
-
-
-      return {
-        fetch: self.fetch,
-        Headers: self.Headers,
-        Request: self.Request,
-        Response: self.Response
-      };
-    }());
-  }
-
-  if (true) {
-    !(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {
-      return fetchPonyfill;
-    }).call(exports, __webpack_require__, exports, module),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-  } else {}
-}(typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : this));
-
-
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../webpack/buildin/global.js */ "./node_modules/webpack/buildin/global.js")))
 
 /***/ }),
 
@@ -4722,157 +10369,6 @@ function toRegex(pattern, contains, isNegated) {
   }
   return new RegExp(prefix + pattern);
 }
-
-
-/***/ }),
-
-/***/ "./node_modules/filter-keys/node_modules/is-glob/index.js":
-/*!****************************************************************!*\
-  !*** ./node_modules/filter-keys/node_modules/is-glob/index.js ***!
-  \****************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * is-glob <https://github.com/jonschlinkert/is-glob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-
-module.exports = function isGlob(str) {
-  return typeof str === 'string'
-    && (/[*!?{}(|)[\]]/.test(str)
-     || isExtglob(str));
-};
-
-/***/ }),
-
-/***/ "./node_modules/filter-keys/node_modules/kind-of/index.js":
-/*!****************************************************************!*\
-  !*** ./node_modules/filter-keys/node_modules/kind-of/index.js ***!
-  \****************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
-var toString = Object.prototype.toString;
-
-/**
- * Get the native `typeof` a value.
- *
- * @param  {*} `val`
- * @return {*} Native javascript type
- */
-
-module.exports = function kindOf(val) {
-  // primitivies
-  if (typeof val === 'undefined') {
-    return 'undefined';
-  }
-  if (val === null) {
-    return 'null';
-  }
-  if (val === true || val === false || val instanceof Boolean) {
-    return 'boolean';
-  }
-  if (typeof val === 'string' || val instanceof String) {
-    return 'string';
-  }
-  if (typeof val === 'number' || val instanceof Number) {
-    return 'number';
-  }
-
-  // functions
-  if (typeof val === 'function' || val instanceof Function) {
-    return 'function';
-  }
-
-  // array
-  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
-    return 'array';
-  }
-
-  // check for instances of RegExp and Date before calling `toString`
-  if (val instanceof RegExp) {
-    return 'regexp';
-  }
-  if (val instanceof Date) {
-    return 'date';
-  }
-
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-  if (type === '[object Error]') {
-    return 'error';
-  }
-
-  // buffer
-  if (isBuffer(val)) {
-    return 'buffer';
-  }
-
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
-
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
-  }
-
-  // must be a plain object
-  return 'object';
-};
 
 
 /***/ }),
@@ -5945,9 +11441,9 @@ utils.braces = __webpack_require__(/*! braces */ "./node_modules/filter-keys/nod
 utils.brackets = __webpack_require__(/*! expand-brackets */ "./node_modules/filter-keys/node_modules/expand-brackets/index.js");
 utils.extglob = __webpack_require__(/*! extglob */ "./node_modules/filter-keys/node_modules/extglob/index.js");
 utils.isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/filter-keys/node_modules/is-glob/index.js");
-utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/filter-keys/node_modules/kind-of/index.js");
-utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/filter-keys/node_modules/normalize-path/index.js");
+utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
+utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
+utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/normalize-path/index.js");
 utils.omit = __webpack_require__(/*! object.omit */ "./node_modules/object.omit/index.js");
 utils.parseGlob = __webpack_require__(/*! parse-glob */ "./node_modules/parse-glob/index.js");
 utils.cache = __webpack_require__(/*! regex-cache */ "./node_modules/regex-cache/index.js");
@@ -6079,36 +11575,6 @@ utils.escapeRe = function escapeRe(str) {
 module.exports = utils;
 
 /* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(/*! ./../../../../process/browser.js */ "./node_modules/process/browser.js")))
-
-/***/ }),
-
-/***/ "./node_modules/filter-keys/node_modules/normalize-path/index.js":
-/*!***********************************************************************!*\
-  !*** ./node_modules/filter-keys/node_modules/normalize-path/index.js ***!
-  \***********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * normalize-path <https://github.com/jonschlinkert/normalize-path>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "./node_modules/remove-trailing-separator/index.js");
-
-module.exports = function normalizePath(str, stripTrailing) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expected a string');
-  }
-  str = str.replace(/[\\\/]+/g, '/');
-  if (stripTrailing !== false) {
-    str = removeTrailingSeparator(str);
-  }
-  return str;
-};
-
 
 /***/ }),
 
@@ -6343,87 +11809,6 @@ module.exports = function forOwn(obj, fn, thisArg) {
 
 /***/ }),
 
-/***/ "./node_modules/function-bind/implementation.js":
-/*!******************************************************!*\
-  !*** ./node_modules/function-bind/implementation.js ***!
-  \******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-/* eslint no-invalid-this: 1 */
-
-var ERROR_MESSAGE = 'Function.prototype.bind called on incompatible ';
-var slice = Array.prototype.slice;
-var toStr = Object.prototype.toString;
-var funcType = '[object Function]';
-
-module.exports = function bind(that) {
-    var target = this;
-    if (typeof target !== 'function' || toStr.call(target) !== funcType) {
-        throw new TypeError(ERROR_MESSAGE + target);
-    }
-    var args = slice.call(arguments, 1);
-
-    var bound;
-    var binder = function () {
-        if (this instanceof bound) {
-            var result = target.apply(
-                this,
-                args.concat(slice.call(arguments))
-            );
-            if (Object(result) === result) {
-                return result;
-            }
-            return this;
-        } else {
-            return target.apply(
-                that,
-                args.concat(slice.call(arguments))
-            );
-        }
-    };
-
-    var boundLength = Math.max(0, target.length - args.length);
-    var boundArgs = [];
-    for (var i = 0; i < boundLength; i++) {
-        boundArgs.push('$' + i);
-    }
-
-    bound = Function('binder', 'return function (' + boundArgs.join(',') + '){ return binder.apply(this,arguments); }')(binder);
-
-    if (target.prototype) {
-        var Empty = function Empty() {};
-        Empty.prototype = target.prototype;
-        bound.prototype = new Empty();
-        Empty.prototype = null;
-    }
-
-    return bound;
-};
-
-
-/***/ }),
-
-/***/ "./node_modules/function-bind/index.js":
-/*!*********************************************!*\
-  !*** ./node_modules/function-bind/index.js ***!
-  \*********************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var implementation = __webpack_require__(/*! ./implementation */ "./node_modules/function-bind/implementation.js");
-
-module.exports = Function.prototype.bind || implementation;
-
-
-/***/ }),
-
 /***/ "./node_modules/glob-base/index.js":
 /*!*****************************************!*\
   !*** ./node_modules/glob-base/index.js ***!
@@ -6443,7 +11828,7 @@ module.exports = Function.prototype.bind || implementation;
 
 var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
 var parent = __webpack_require__(/*! glob-parent */ "./node_modules/glob-base/node_modules/glob-parent/index.js");
-var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/glob-base/node_modules/is-glob/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
 
 module.exports = function globBase(pattern) {
   if (typeof pattern !== 'string') {
@@ -6498,621 +11883,13 @@ function dirname(glob) {
 
 
 var path = __webpack_require__(/*! path */ "./node_modules/node-libs-browser/node_modules/path-browserify/index.js");
-var isglob = __webpack_require__(/*! is-glob */ "./node_modules/glob-base/node_modules/is-glob/index.js");
+var isglob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
 
 module.exports = function globParent(str) {
 	str += 'a'; // preserves full path in case of trailing path separator
 	do {str = path.dirname(str)} while (isglob(str));
 	return str;
 };
-
-
-/***/ }),
-
-/***/ "./node_modules/glob-base/node_modules/is-glob/index.js":
-/*!**************************************************************!*\
-  !*** ./node_modules/glob-base/node_modules/is-glob/index.js ***!
-  \**************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * is-glob <https://github.com/jonschlinkert/is-glob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-
-module.exports = function isGlob(str) {
-  return typeof str === 'string'
-    && (/[*!?{}(|)[\]]/.test(str)
-     || isExtglob(str));
-};
-
-/***/ }),
-
-/***/ "./node_modules/groupby-api/dist/core/bridge.js":
-/*!******************************************************!*\
-  !*** ./node_modules/groupby-api/dist/core/bridge.js ***!
-  \******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    };
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-var clone = __webpack_require__(/*! clone */ "./node_modules/clone/clone.js");
-var fetchPonyfill = __webpack_require__(/*! fetch-ponyfill */ "./node_modules/fetch-ponyfill/build/fetch-browser.js");
-var qs = __webpack_require__(/*! qs */ "./node_modules/qs/lib/index.js");
-var utils_1 = __webpack_require__(/*! ../utils */ "./node_modules/groupby-api/dist/utils/index.js");
-var query_1 = __webpack_require__(/*! ./query */ "./node_modules/groupby-api/dist/core/query.js");
-var SEARCH = '/search';
-var REFINEMENTS = '/refinements';
-var INVALID_QUERY_ERROR = 'query was not of a recognised type';
-var createTimeoutPromise = function (timeout) {
-    return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-            reject(new BridgeTimeout("Timed out in " + timeout + " ms"));
-        }, timeout);
-    });
-};
-var BridgeTimeout = /** @class */ (function (_super) {
-    __extends(BridgeTimeout, _super);
-    /* istanbul ignore next */
-    function BridgeTimeout(err) {
-        return _super.call(this, err) || this;
-    }
-    return BridgeTimeout;
-}(Error));
-exports.BridgeTimeout = BridgeTimeout;
-var BridgeError = /** @class */ (function (_super) {
-    __extends(BridgeError, _super);
-    /* istanbul ignore next */
-    function BridgeError(statusText, status, data) {
-        var _this = _super.call(this, statusText) || this;
-        _this.status = status;
-        _this.data = data;
-        Object.setPrototypeOf(_this, BridgeError.prototype);
-        return _this;
-    }
-    Object.defineProperty(BridgeError.prototype, "statusText", {
-        get: function () {
-            return this.message;
-        },
-        enumerable: true,
-        configurable: true
-    });
-    return BridgeError;
-}(Error));
-exports.BridgeError = BridgeError;
-exports.DEFAULT_CONFIG = {
-    timeout: 1500
-};
-var AbstractBridge = /** @class */ (function () {
-    function AbstractBridge(config) {
-        this.fetch = fetchPonyfill().fetch;
-        this.headers = {};
-        this.config = Object.assign({}, exports.DEFAULT_CONFIG, config);
-    }
-    AbstractBridge.prototype.search = function (query, callback) {
-        var _a = this.extractRequest(query), request = _a.request, queryParams = _a.queryParams;
-        if (request === null)
-            return this.generateError(INVALID_QUERY_ERROR, callback);
-        var response = this.fireRequest(this.bridgeUrl, request, queryParams)
-            .then(AbstractBridge.transformRecords)
-            .then(AbstractBridge.transformRefinements);
-        return this.handleResponse(response, callback);
-    };
-    AbstractBridge.prototype.refinements = function (query, navigationName, callback) {
-        var request = this.extractRequest(query).request;
-        if (request === null)
-            return this.generateError(INVALID_QUERY_ERROR, callback);
-        var refinementsRequest = { originalQuery: request, navigationName: navigationName };
-        var response = this.fireRequest(this.refinementsUrl, refinementsRequest);
-        return this.handleResponse(response, callback);
-    };
-    AbstractBridge.prototype.handleResponse = function (response, callback) {
-        if (callback) {
-            response.then(function (res) { return callback(undefined, res); }, function (err) { return callback(err); });
-        }
-        else {
-            return response;
-        }
-    };
-    AbstractBridge.prototype.extractRequest = function (query) {
-        switch (typeof query) {
-            case 'string': return { request: new query_1.Query(query).build(), queryParams: {} };
-            case 'object': return query instanceof query_1.Query
-                ? { request: query.build(), queryParams: query.queryParams }
-                : { request: clone(query), queryParams: {} };
-            default: return { request: null, queryParams: null };
-        }
-    };
-    AbstractBridge.prototype.generateError = function (error, callback) {
-        var err = new Error(error);
-        if (callback) {
-            callback(err);
-        }
-        else {
-            return Promise.reject(err);
-        }
-    };
-    // tslint:disable-next-line max-line-length
-    AbstractBridge.prototype.fireRequest = function (url, body, queryParams) {
-        var _this = this;
-        if (queryParams === void 0) { queryParams = {}; }
-        var options = {
-            method: 'POST',
-            headers: __assign({ 'Content-Type': 'application/json' }, this.headers),
-            body: JSON.stringify(AbstractBridge.normalizeRequest(this.augmentRequest(body))),
-        };
-        var params = qs.stringify(queryParams);
-        url = params ? url + "?" + params : url;
-        return Promise.race([this.fetch(url, options), createTimeoutPromise(this.config.timeout)])
-            .then(function (res) {
-            if (res.ok) {
-                return res.json();
-            }
-            else {
-                return res.json().then(function (err) {
-                    throw new BridgeError(res.statusText, res.status, err);
-                });
-            }
-        })
-            .catch(function (err) {
-            if (_this.errorHandler) {
-                _this.errorHandler(err);
-            }
-            throw err;
-        });
-    };
-    AbstractBridge.normalizeRequest = function (request) {
-        Object.keys(utils_1.Normalizers).forEach(function (normalize) { return utils_1.Normalizers[normalize](request); });
-        return request;
-    };
-    AbstractBridge.transform = function (response, key, callback) {
-        var _a;
-        if (response[key]) {
-            return Object.assign(response, (_a = {}, _a[key] = response[key].map(callback), _a));
-        }
-        else {
-            return response;
-        }
-    };
-    AbstractBridge.transformRecords = function (response) {
-        return AbstractBridge.transform(response, 'records', AbstractBridge.convertRecordFields);
-    };
-    AbstractBridge.transformRefinements = function (response) {
-        var transformed = AbstractBridge.transform(response, 'availableNavigation', AbstractBridge.convertRefinement);
-        return AbstractBridge.transform(transformed, 'selectedNavigation', AbstractBridge.convertRefinement);
-    };
-    AbstractBridge.convertRecordFields = function (record) {
-        var converted = Object.assign(record, { id: record._id, url: record._u, title: record._t });
-        delete converted._id;
-        delete converted._u;
-        delete converted._t;
-        if (record._snippet) {
-            converted.snippet = record._snippet;
-            delete converted._snippet;
-        }
-        return converted;
-    };
-    AbstractBridge.convertRefinement = function (navigation) {
-        if (navigation.range) {
-            navigation.min = Number.MAX_SAFE_INTEGER;
-            navigation.max = Number.MIN_SAFE_INTEGER;
-            navigation.refinements = navigation.refinements
-                .map(function (ref) {
-                navigation.min = Math.min(navigation.min, ref.low);
-                navigation.max = Math.max(navigation.max, ref.high);
-                return (__assign({}, ref, { high: parseFloat(ref.high), low: parseFloat(ref.low) }));
-            });
-        }
-        return navigation;
-    };
-    return AbstractBridge;
-}());
-exports.AbstractBridge = AbstractBridge;
-var CloudBridge = /** @class */ (function (_super) {
-    __extends(CloudBridge, _super);
-    function CloudBridge(clientKey, customerId, config) {
-        if (config === void 0) { config = {}; }
-        var _this = _super.call(this, config) || this;
-        _this.clientKey = clientKey;
-        _this.baseUrl = "https://" + customerId + ".groupbycloud.com:443/api/v1";
-        _this.bridgeUrl = _this.baseUrl + SEARCH;
-        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
-        return _this;
-    }
-    CloudBridge.prototype.augmentRequest = function (request) {
-        return Object.assign(request, { clientKey: this.clientKey });
-    };
-    return CloudBridge;
-}(AbstractBridge));
-exports.CloudBridge = CloudBridge;
-var BrowserBridge = /** @class */ (function (_super) {
-    __extends(BrowserBridge, _super);
-    function BrowserBridge(customerId, https, config) {
-        if (https === void 0) { https = false; }
-        if (config === void 0) { config = {}; }
-        var _this = _super.call(this, config) || this;
-        var scheme = https ? 'https' : 'http';
-        var port = https ? ':443' : '';
-        _this.baseUrl = config.proxyUrl || scheme + "://" + customerId + "-cors.groupbycloud.com" + port + "/api/v1";
-        _this.bridgeUrl = _this.baseUrl + SEARCH;
-        _this.refinementsUrl = _this.bridgeUrl + REFINEMENTS;
-        return _this;
-    }
-    BrowserBridge.prototype.augmentRequest = function (request) {
-        return request;
-    };
-    return BrowserBridge;
-}(AbstractBridge));
-exports.BrowserBridge = BrowserBridge;
-//# sourceMappingURL=bridge.js.map
-
-/***/ }),
-
-/***/ "./node_modules/groupby-api/dist/core/query.js":
-/*!*****************************************************!*\
-  !*** ./node_modules/groupby-api/dist/core/query.js ***!
-  \*****************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-var clone = __webpack_require__(/*! clone */ "./node_modules/clone/clone.js");
-var deepEqual = __webpack_require__(/*! deep-equal */ "./node_modules/deep-equal/index.js");
-var filterObject = __webpack_require__(/*! filter-object */ "./node_modules/filter-object/index.js");
-var qs = __webpack_require__(/*! qs */ "./node_modules/qs/lib/index.js");
-var utils_1 = __webpack_require__(/*! ../utils */ "./node_modules/groupby-api/dist/utils/index.js");
-var REFINEMENT_MASK = '{navigationName,value,low,high}';
-var Query = /** @class */ (function () {
-    function Query(query) {
-        if (query === void 0) { query = ''; }
-        this.request = {};
-        this.unprocessedNavigations = [];
-        this.queryParams = {};
-        this.request.query = query;
-        this.request.sort = [];
-        this.request.fields = [];
-        this.request.orFields = [];
-        this.request.refinements = [];
-        this.request.customUrlParams = [];
-        this.request.includedNavigations = [];
-        this.request.excludedNavigations = [];
-        this.request.wildcardSearchEnabled = false;
-        this.request.pruneRefinements = true;
-    }
-    Query.prototype.withQuery = function (query) {
-        this.request.query = query;
-        return this;
-    };
-    Query.prototype.withConfiguration = function (configuration, mask) {
-        if (mask === void 0) { mask = '*'; }
-        Object.assign(this.request, filterObject(configuration, mask));
-        return this;
-    };
-    Query.prototype.withSelectedRefinements = function () {
-        var _this = this;
-        var refinements = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            refinements[_i] = arguments[_i];
-        }
-        refinements.forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
-        return this;
-    };
-    Query.prototype.withoutSelectedRefinements = function () {
-        var _this = this;
-        var refinements = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            refinements[_i] = arguments[_i];
-        }
-        refinements.forEach(function (refinement) {
-            var index = _this.request.refinements.findIndex(function (ref) { return deepEqual(ref, refinement); });
-            if (index > -1)
-                _this.request.refinements.splice(index, 1);
-        });
-        return this;
-    };
-    Query.prototype.withRefinements = function (navigationName) {
-        var _this = this;
-        var refinements = [];
-        for (var _i = 1; _i < arguments.length; _i++) {
-            refinements[_i - 1] = arguments[_i];
-        }
-        var convert = function (refinement) { return Object.assign(refinement, { navigationName: navigationName }); };
-        refinements.map(convert).forEach(function (ref) { return _this.addRefinement(ref, _this.request.refinements); });
-        return this;
-    };
-    Query.prototype.withNavigations = function () {
-        var _a;
-        var navigations = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            navigations[_i] = arguments[_i];
-        }
-        (_a = this.unprocessedNavigations).push.apply(_a, navigations);
-        return this;
-    };
-    Query.prototype.withCustomUrlParams = function (customUrlParams) {
-        var _a, _b;
-        if (typeof customUrlParams === 'string') {
-            (_a = this.request.customUrlParams).push.apply(_a, this.convertParamString(customUrlParams));
-        }
-        else if (Array.isArray(customUrlParams)) {
-            (_b = this.request.customUrlParams).push.apply(_b, customUrlParams);
-        }
-        return this;
-    };
-    Query.prototype.withFields = function () {
-        var _a;
-        var fields = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            fields[_i] = arguments[_i];
-        }
-        (_a = this.request.fields).push.apply(_a, fields);
-        return this;
-    };
-    Query.prototype.withOrFields = function () {
-        var _a;
-        var orFields = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            orFields[_i] = arguments[_i];
-        }
-        (_a = this.request.orFields).push.apply(_a, orFields);
-        return this;
-    };
-    Query.prototype.withSorts = function () {
-        var _a;
-        var sorts = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            sorts[_i] = arguments[_i];
-        }
-        (_a = this.request.sort).push.apply(_a, sorts);
-        return this;
-    };
-    Query.prototype.withoutSorts = function () {
-        var sorts = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            sorts[_i] = arguments[_i];
-        }
-        this.request.sort = this.request.sort.filter(function (oldSort) { return !sorts.find(function (sort) {
-            return sort.type === 'ByIds'
-                ? oldSort.type === 'ByIds' && sort.ids.toString() === oldSort.ids.toString()
-                : sort.field === oldSort.field;
-        }); });
-        return this;
-    };
-    Query.prototype.withIncludedNavigations = function () {
-        var _a;
-        var navigationNames = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            navigationNames[_i] = arguments[_i];
-        }
-        (_a = this.request.includedNavigations).push.apply(_a, navigationNames);
-        return this;
-    };
-    Query.prototype.withExcludedNavigations = function () {
-        var _a;
-        var navigationNames = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            navigationNames[_i] = arguments[_i];
-        }
-        (_a = this.request.excludedNavigations).push.apply(_a, navigationNames);
-        return this;
-    };
-    Query.prototype.withQueryParams = function (queryParams) {
-        switch (typeof queryParams) {
-            case 'string':
-                return Object.assign(this, { queryParams: this.convertQueryString(queryParams) });
-            case 'object':
-                return Object.assign(this, { queryParams: queryParams });
-        }
-    };
-    Query.prototype.refineByValue = function (navigationName, value, exclude) {
-        if (exclude === void 0) { exclude = false; }
-        return this.withSelectedRefinements({
-            navigationName: navigationName,
-            value: value,
-            exclude: exclude,
-            type: 'Value'
-        });
-    };
-    Query.prototype.refineByRange = function (navigationName, low, high, exclude) {
-        if (exclude === void 0) { exclude = false; }
-        return this.withSelectedRefinements({
-            navigationName: navigationName,
-            low: low,
-            high: high,
-            exclude: exclude,
-            type: 'Range'
-        });
-    };
-    Query.prototype.restrictNavigation = function (restrictNavigation) {
-        this.request.restrictNavigation = restrictNavigation;
-        return this;
-    };
-    Query.prototype.skip = function (skip) {
-        this.request.skip = skip;
-        return this;
-    };
-    Query.prototype.withPageSize = function (pageSize) {
-        this.request.pageSize = pageSize;
-        return this;
-    };
-    Query.prototype.withMatchStrategy = function (matchStrategy) {
-        this.request.matchStrategy = matchStrategy;
-        return this;
-    };
-    Query.prototype.withBiasing = function (biasing) {
-        this.request.biasing = biasing;
-        return this;
-    };
-    Query.prototype.enableWildcardSearch = function () {
-        this.request.wildcardSearchEnabled = true;
-        return this;
-    };
-    Query.prototype.disableAutocorrection = function () {
-        this.request.disableAutocorrection = true;
-        return this;
-    };
-    Query.prototype.disableBinaryPayload = function () {
-        this.request.returnBinary = false;
-        return this;
-    };
-    Query.prototype.allowPrunedRefinements = function () {
-        this.request.pruneRefinements = false;
-        return this;
-    };
-    Query.prototype.build = function () {
-        var _this = this;
-        var builtRequest = this.raw;
-        utils_1.NavigationConverter.convert(this.unprocessedNavigations)
-            .forEach(function (ref) { return _this.addRefinement(ref, builtRequest.refinements); });
-        return this.clearEmptyArrays(builtRequest);
-    };
-    Object.defineProperty(Query.prototype, "raw", {
-        get: function () {
-            return clone(this.request, false);
-        },
-        enumerable: true,
-        configurable: true
-    });
-    Object.defineProperty(Query.prototype, "rawNavigations", {
-        get: function () {
-            return Object.create(this.unprocessedNavigations);
-        },
-        enumerable: true,
-        configurable: true
-    });
-    Query.prototype.addRefinement = function (refinement, refinements) {
-        var _this = this;
-        if (!refinements.find(function (ref) { return _this.refinementMatches(ref, refinement); })) {
-            refinements.push(refinement);
-        }
-    };
-    Query.prototype.refinementMatches = function (target, original) {
-        return deepEqual(filterObject(target, REFINEMENT_MASK), filterObject(original, REFINEMENT_MASK));
-    };
-    Query.prototype.convertParamString = function (customUrlParams) {
-        var parsed = qs.parse(customUrlParams);
-        return Object.keys(parsed).reduce(function (converted, key) { return converted.concat({ key: key, value: parsed[key] }); }, []);
-    };
-    Query.prototype.convertQueryString = function (queryParams) {
-        return qs.parse(queryParams);
-    };
-    Query.prototype.clearEmptyArrays = function (request) {
-        for (var key in request) {
-            if (Array.isArray(request[key]) && request[key].length === 0) {
-                delete request[key];
-            }
-        }
-        return request;
-    };
-    return Query;
-}());
-exports.Query = Query;
-//# sourceMappingURL=query.js.map
-
-/***/ }),
-
-/***/ "./node_modules/groupby-api/dist/index.js":
-/*!************************************************!*\
-  !*** ./node_modules/groupby-api/dist/index.js ***!
-  \************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
-Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! ./core/query */ "./node_modules/groupby-api/dist/core/query.js"));
-__export(__webpack_require__(/*! ./core/bridge */ "./node_modules/groupby-api/dist/core/bridge.js"));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ "./node_modules/groupby-api/dist/utils/index.js":
-/*!******************************************************!*\
-  !*** ./node_modules/groupby-api/dist/utils/index.js ***!
-  \******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-var NavigationConverter = /** @class */ (function () {
-    function NavigationConverter() {
-    }
-    NavigationConverter.convert = function (navigations) {
-        return navigations.reduce(function (refinements, navigation) {
-            navigation.refinements
-                // tslint:disable-next-line max-line-length
-                .forEach(function (refinement) { return refinements.push(Object.assign(refinement, { navigationName: navigation.name })); });
-            return refinements;
-        }, []);
-    };
-    return NavigationConverter;
-}());
-exports.NavigationConverter = NavigationConverter;
-var Normalizers;
-(function (Normalizers) {
-    function normalizeSort(request) {
-        if (request.sort && !Array.isArray(request.sort) && request.sort.field === '_relevance') {
-            delete request.sort;
-        }
-    }
-    Normalizers.normalizeSort = normalizeSort;
-})(Normalizers = exports.Normalizers || (exports.Normalizers = {}));
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ "./node_modules/has/src/index.js":
-/*!***************************************!*\
-  !*** ./node_modules/has/src/index.js ***!
-  \***************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var bind = __webpack_require__(/*! function-bind */ "./node_modules/function-bind/index.js");
-
-module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
 
 
 /***/ }),
@@ -7212,49 +11989,6 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 
 /***/ }),
 
-/***/ "./node_modules/is-arguments/index.js":
-/*!********************************************!*\
-  !*** ./node_modules/is-arguments/index.js ***!
-  \********************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
-var toStr = Object.prototype.toString;
-
-var isStandardArguments = function isArguments(value) {
-	if (hasToStringTag && value && typeof value === 'object' && Symbol.toStringTag in value) {
-		return false;
-	}
-	return toStr.call(value) === '[object Arguments]';
-};
-
-var isLegacyArguments = function isArguments(value) {
-	if (isStandardArguments(value)) {
-		return true;
-	}
-	return value !== null &&
-		typeof value === 'object' &&
-		typeof value.length === 'number' &&
-		value.length >= 0 &&
-		toStr.call(value) !== '[object Array]' &&
-		toStr.call(value.callee) === '[object Function]';
-};
-
-var supportsStandardArguments = (function () {
-	return isStandardArguments(arguments);
-}());
-
-isStandardArguments.isLegacyArguments = isLegacyArguments; // for tests
-
-module.exports = supportsStandardArguments ? isStandardArguments : isLegacyArguments;
-
-
-/***/ }),
-
 /***/ "./node_modules/is-buffer/index.js":
 /*!*****************************************!*\
   !*** ./node_modules/is-buffer/index.js ***!
@@ -7283,38 +12017,6 @@ function isBuffer (obj) {
 function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
-
-
-/***/ }),
-
-/***/ "./node_modules/is-date-object/index.js":
-/*!**********************************************!*\
-  !*** ./node_modules/is-date-object/index.js ***!
-  \**********************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var getDay = Date.prototype.getDay;
-var tryDateObject = function tryDateObject(value) {
-	try {
-		getDay.call(value);
-		return true;
-	} catch (e) {
-		return false;
-	}
-};
-
-var toStr = Object.prototype.toString;
-var dateClass = '[object Date]';
-var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
-
-module.exports = function isDateObject(value) {
-	if (typeof value !== 'object' || value === null) { return false; }
-	return hasToStringTag ? tryDateObject(value) : toStr.call(value) === dateClass;
-};
 
 
 /***/ }),
@@ -7430,6 +12132,30 @@ module.exports = function isExtglob(str) {
 
 /***/ }),
 
+/***/ "./node_modules/is-glob/index.js":
+/*!***************************************!*\
+  !*** ./node_modules/is-glob/index.js ***!
+  \***************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+/*!
+ * is-glob <https://github.com/jonschlinkert/is-glob>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
+
+module.exports = function isGlob(str) {
+  return typeof str === 'string'
+    && (/[*!?{}(|)[\]]/.test(str)
+     || isExtglob(str));
+};
+
+/***/ }),
+
 /***/ "./node_modules/is-match/index.js":
 /*!****************************************!*\
   !*** ./node_modules/is-match/index.js ***!
@@ -7449,7 +12175,7 @@ module.exports = function isExtglob(str) {
 
 var deepEqual = __webpack_require__(/*! deep-equal */ "./node_modules/deep-equal/index.js");
 var isObject = __webpack_require__(/*! is-extendable */ "./node_modules/is-extendable/index.js");
-var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-match/node_modules/is-glob/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
 var mm = __webpack_require__(/*! micromatch */ "./node_modules/is-match/node_modules/micromatch/index.js");
 
 function isMatch(pattern, options) {
@@ -8385,157 +13111,6 @@ function toRegex(pattern, contains, isNegated) {
   }
   return new RegExp(prefix + pattern);
 }
-
-
-/***/ }),
-
-/***/ "./node_modules/is-match/node_modules/is-glob/index.js":
-/*!*************************************************************!*\
-  !*** ./node_modules/is-match/node_modules/is-glob/index.js ***!
-  \*************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * is-glob <https://github.com/jonschlinkert/is-glob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-
-module.exports = function isGlob(str) {
-  return typeof str === 'string'
-    && (/[*!?{}(|)[\]]/.test(str)
-     || isExtglob(str));
-};
-
-/***/ }),
-
-/***/ "./node_modules/is-match/node_modules/kind-of/index.js":
-/*!*************************************************************!*\
-  !*** ./node_modules/is-match/node_modules/kind-of/index.js ***!
-  \*************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
-var toString = Object.prototype.toString;
-
-/**
- * Get the native `typeof` a value.
- *
- * @param  {*} `val`
- * @return {*} Native javascript type
- */
-
-module.exports = function kindOf(val) {
-  // primitivies
-  if (typeof val === 'undefined') {
-    return 'undefined';
-  }
-  if (val === null) {
-    return 'null';
-  }
-  if (val === true || val === false || val instanceof Boolean) {
-    return 'boolean';
-  }
-  if (typeof val === 'string' || val instanceof String) {
-    return 'string';
-  }
-  if (typeof val === 'number' || val instanceof Number) {
-    return 'number';
-  }
-
-  // functions
-  if (typeof val === 'function' || val instanceof Function) {
-    return 'function';
-  }
-
-  // array
-  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
-    return 'array';
-  }
-
-  // check for instances of RegExp and Date before calling `toString`
-  if (val instanceof RegExp) {
-    return 'regexp';
-  }
-  if (val instanceof Date) {
-    return 'date';
-  }
-
-  // other objects
-  var type = toString.call(val);
-
-  if (type === '[object RegExp]') {
-    return 'regexp';
-  }
-  if (type === '[object Date]') {
-    return 'date';
-  }
-  if (type === '[object Arguments]') {
-    return 'arguments';
-  }
-  if (type === '[object Error]') {
-    return 'error';
-  }
-
-  // buffer
-  if (isBuffer(val)) {
-    return 'buffer';
-  }
-
-  // es6: Map, WeakMap, Set, WeakSet
-  if (type === '[object Set]') {
-    return 'set';
-  }
-  if (type === '[object WeakSet]') {
-    return 'weakset';
-  }
-  if (type === '[object Map]') {
-    return 'map';
-  }
-  if (type === '[object WeakMap]') {
-    return 'weakmap';
-  }
-  if (type === '[object Symbol]') {
-    return 'symbol';
-  }
-
-  // typed arrays
-  if (type === '[object Int8Array]') {
-    return 'int8array';
-  }
-  if (type === '[object Uint8Array]') {
-    return 'uint8array';
-  }
-  if (type === '[object Uint8ClampedArray]') {
-    return 'uint8clampedarray';
-  }
-  if (type === '[object Int16Array]') {
-    return 'int16array';
-  }
-  if (type === '[object Uint16Array]') {
-    return 'uint16array';
-  }
-  if (type === '[object Int32Array]') {
-    return 'int32array';
-  }
-  if (type === '[object Uint32Array]') {
-    return 'uint32array';
-  }
-  if (type === '[object Float32Array]') {
-    return 'float32array';
-  }
-  if (type === '[object Float64Array]') {
-    return 'float64array';
-  }
-
-  // must be a plain object
-  return 'object';
-};
 
 
 /***/ }),
@@ -9608,9 +14183,9 @@ utils.braces = __webpack_require__(/*! braces */ "./node_modules/is-match/node_m
 utils.brackets = __webpack_require__(/*! expand-brackets */ "./node_modules/is-match/node_modules/expand-brackets/index.js");
 utils.extglob = __webpack_require__(/*! extglob */ "./node_modules/is-match/node_modules/extglob/index.js");
 utils.isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-match/node_modules/is-glob/index.js");
-utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/is-match/node_modules/kind-of/index.js");
-utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/is-match/node_modules/normalize-path/index.js");
+utils.isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
+utils.typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
+utils.normalize = __webpack_require__(/*! normalize-path */ "./node_modules/normalize-path/index.js");
 utils.omit = __webpack_require__(/*! object.omit */ "./node_modules/object.omit/index.js");
 utils.parseGlob = __webpack_require__(/*! parse-glob */ "./node_modules/parse-glob/index.js");
 utils.cache = __webpack_require__(/*! regex-cache */ "./node_modules/regex-cache/index.js");
@@ -9745,36 +14320,6 @@ module.exports = utils;
 
 /***/ }),
 
-/***/ "./node_modules/is-match/node_modules/normalize-path/index.js":
-/*!********************************************************************!*\
-  !*** ./node_modules/is-match/node_modules/normalize-path/index.js ***!
-  \********************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * normalize-path <https://github.com/jonschlinkert/normalize-path>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "./node_modules/remove-trailing-separator/index.js");
-
-module.exports = function normalizePath(str, stripTrailing) {
-  if (typeof str !== 'string') {
-    throw new TypeError('expected a string');
-  }
-  str = str.replace(/[\\\/]+/g, '/');
-  if (stripTrailing !== false) {
-    str = removeTrailingSeparator(str);
-  }
-  return str;
-};
-
-
-/***/ }),
-
 /***/ "./node_modules/is-posix-bracket/index.js":
 /*!************************************************!*\
   !*** ./node_modules/is-posix-bracket/index.js ***!
@@ -9816,57 +14361,6 @@ module.exports = function isPosixBracket(str) {
 // see http://jsperf.com/testing-value-is-primitive/7
 module.exports = function isPrimitive(value) {
   return value == null || (typeof value !== 'function' && typeof value !== 'object');
-};
-
-
-/***/ }),
-
-/***/ "./node_modules/is-regex/index.js":
-/*!****************************************!*\
-  !*** ./node_modules/is-regex/index.js ***!
-  \****************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var has = __webpack_require__(/*! has */ "./node_modules/has/src/index.js");
-var regexExec = RegExp.prototype.exec;
-var gOPD = Object.getOwnPropertyDescriptor;
-
-var tryRegexExecCall = function tryRegexExec(value) {
-	try {
-		var lastIndex = value.lastIndex;
-		value.lastIndex = 0;
-
-		regexExec.call(value);
-		return true;
-	} catch (e) {
-		return false;
-	} finally {
-		value.lastIndex = lastIndex;
-	}
-};
-var toStr = Object.prototype.toString;
-var regexClass = '[object RegExp]';
-var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
-
-module.exports = function isRegex(value) {
-	if (!value || typeof value !== 'object') {
-		return false;
-	}
-	if (!hasToStringTag) {
-		return toStr.call(value) === regexClass;
-	}
-
-	var descriptor = gOPD(value, 'lastIndex');
-	var hasLastIndexDataProperty = descriptor && has(descriptor, 'value');
-	if (!hasLastIndexDataProperty) {
-		return false;
-	}
-
-	return tryRegexExecCall(value);
 };
 
 
@@ -10025,137 +14519,124 @@ function jsonp(url, opts, fn){
   !*** ./node_modules/kind-of/index.js ***!
   \***************************************/
 /*! no static exports found */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
+var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
 var toString = Object.prototype.toString;
 
-module.exports = function kindOf(val) {
-  if (val === void 0) return 'undefined';
-  if (val === null) return 'null';
-
-  var type = typeof val;
-  if (type === 'boolean') return 'boolean';
-  if (type === 'string') return 'string';
-  if (type === 'number') return 'number';
-  if (type === 'symbol') return 'symbol';
-  if (type === 'function') {
-    return isGeneratorFn(val) ? 'generatorfunction' : 'function';
-  }
-
-  if (isArray(val)) return 'array';
-  if (isBuffer(val)) return 'buffer';
-  if (isArguments(val)) return 'arguments';
-  if (isDate(val)) return 'date';
-  if (isError(val)) return 'error';
-  if (isRegexp(val)) return 'regexp';
-
-  switch (ctorName(val)) {
-    case 'Symbol': return 'symbol';
-    case 'Promise': return 'promise';
-
-    // Set, Map, WeakSet, WeakMap
-    case 'WeakMap': return 'weakmap';
-    case 'WeakSet': return 'weakset';
-    case 'Map': return 'map';
-    case 'Set': return 'set';
-
-    // 8-bit typed arrays
-    case 'Int8Array': return 'int8array';
-    case 'Uint8Array': return 'uint8array';
-    case 'Uint8ClampedArray': return 'uint8clampedarray';
-
-    // 16-bit typed arrays
-    case 'Int16Array': return 'int16array';
-    case 'Uint16Array': return 'uint16array';
-
-    // 32-bit typed arrays
-    case 'Int32Array': return 'int32array';
-    case 'Uint32Array': return 'uint32array';
-    case 'Float32Array': return 'float32array';
-    case 'Float64Array': return 'float64array';
-  }
-
-  if (isGeneratorObj(val)) {
-    return 'generator';
-  }
-
-  // Non-plain objects
-  type = toString.call(val);
-  switch (type) {
-    case '[object Object]': return 'object';
-    // iterators
-    case '[object Map Iterator]': return 'mapiterator';
-    case '[object Set Iterator]': return 'setiterator';
-    case '[object String Iterator]': return 'stringiterator';
-    case '[object Array Iterator]': return 'arrayiterator';
-  }
-
-  // other
-  return type.slice(8, -1).toLowerCase().replace(/\s/g, '');
-};
-
-function ctorName(val) {
-  return val.constructor ? val.constructor.name : null;
-}
-
-function isArray(val) {
-  if (Array.isArray) return Array.isArray(val);
-  return val instanceof Array;
-}
-
-function isError(val) {
-  return val instanceof Error || (typeof val.message === 'string' && val.constructor && typeof val.constructor.stackTraceLimit === 'number');
-}
-
-function isDate(val) {
-  if (val instanceof Date) return true;
-  return typeof val.toDateString === 'function'
-    && typeof val.getDate === 'function'
-    && typeof val.setDate === 'function';
-}
-
-function isRegexp(val) {
-  if (val instanceof RegExp) return true;
-  return typeof val.flags === 'string'
-    && typeof val.ignoreCase === 'boolean'
-    && typeof val.multiline === 'boolean'
-    && typeof val.global === 'boolean';
-}
-
-function isGeneratorFn(name, val) {
-  return ctorName(name) === 'GeneratorFunction';
-}
-
-function isGeneratorObj(val) {
-  return typeof val.throw === 'function'
-    && typeof val.return === 'function'
-    && typeof val.next === 'function';
-}
-
-function isArguments(val) {
-  try {
-    if (typeof val.length === 'number' && typeof val.callee === 'function') {
-      return true;
-    }
-  } catch (err) {
-    if (err.message.indexOf('callee') !== -1) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /**
- * If you need to support Safari 5-7 (8-10 yr-old browser),
- * take a look at https://github.com/feross/is-buffer
+ * Get the native `typeof` a value.
+ *
+ * @param  {*} `val`
+ * @return {*} Native javascript type
  */
 
-function isBuffer(val) {
-  if (val.constructor && typeof val.constructor.isBuffer === 'function') {
-    return val.constructor.isBuffer(val);
+module.exports = function kindOf(val) {
+  // primitivies
+  if (typeof val === 'undefined') {
+    return 'undefined';
   }
-  return false;
-}
+  if (val === null) {
+    return 'null';
+  }
+  if (val === true || val === false || val instanceof Boolean) {
+    return 'boolean';
+  }
+  if (typeof val === 'string' || val instanceof String) {
+    return 'string';
+  }
+  if (typeof val === 'number' || val instanceof Number) {
+    return 'number';
+  }
+
+  // functions
+  if (typeof val === 'function' || val instanceof Function) {
+    return 'function';
+  }
+
+  // array
+  if (typeof Array.isArray !== 'undefined' && Array.isArray(val)) {
+    return 'array';
+  }
+
+  // check for instances of RegExp and Date before calling `toString`
+  if (val instanceof RegExp) {
+    return 'regexp';
+  }
+  if (val instanceof Date) {
+    return 'date';
+  }
+
+  // other objects
+  var type = toString.call(val);
+
+  if (type === '[object RegExp]') {
+    return 'regexp';
+  }
+  if (type === '[object Date]') {
+    return 'date';
+  }
+  if (type === '[object Arguments]') {
+    return 'arguments';
+  }
+  if (type === '[object Error]') {
+    return 'error';
+  }
+
+  // buffer
+  if (isBuffer(val)) {
+    return 'buffer';
+  }
+
+  // es6: Map, WeakMap, Set, WeakSet
+  if (type === '[object Set]') {
+    return 'set';
+  }
+  if (type === '[object WeakSet]') {
+    return 'weakset';
+  }
+  if (type === '[object Map]') {
+    return 'map';
+  }
+  if (type === '[object WeakMap]') {
+    return 'weakmap';
+  }
+  if (type === '[object Symbol]') {
+    return 'symbol';
+  }
+
+  // typed arrays
+  if (type === '[object Int8Array]') {
+    return 'int8array';
+  }
+  if (type === '[object Uint8Array]') {
+    return 'uint8array';
+  }
+  if (type === '[object Uint8ClampedArray]') {
+    return 'uint8clampedarray';
+  }
+  if (type === '[object Int16Array]') {
+    return 'int16array';
+  }
+  if (type === '[object Uint16Array]') {
+    return 'uint16array';
+  }
+  if (type === '[object Int32Array]') {
+    return 'int32array';
+  }
+  if (type === '[object Uint32Array]') {
+    return 'uint32array';
+  }
+  if (type === '[object Float32Array]') {
+    return 'float32array';
+  }
+  if (type === '[object Float64Array]') {
+    return 'float64array';
+  }
+
+  // must be a plain object
+  return 'object';
+};
 
 
 /***/ }),
@@ -12467,239 +16948,31 @@ var substr = 'ab'.substr(-1) === 'b'
 
 /***/ }),
 
-/***/ "./node_modules/object-is/index.js":
-/*!*****************************************!*\
-  !*** ./node_modules/object-is/index.js ***!
-  \*****************************************/
+/***/ "./node_modules/normalize-path/index.js":
+/*!**********************************************!*\
+  !*** ./node_modules/normalize-path/index.js ***!
+  \**********************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
+/*!
+ * normalize-path <https://github.com/jonschlinkert/normalize-path>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
 
+var removeTrailingSeparator = __webpack_require__(/*! remove-trailing-separator */ "./node_modules/remove-trailing-separator/index.js");
 
-/* https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.is */
-
-var NumberIsNaN = function (value) {
-	return value !== value;
-};
-
-module.exports = function is(a, b) {
-	if (a === 0 && b === 0) {
-		return 1 / a === 1 / b;
-	} else if (a === b) {
-		return true;
-	} else if (NumberIsNaN(a) && NumberIsNaN(b)) {
-		return true;
-	}
-	return false;
-};
-
-
-
-/***/ }),
-
-/***/ "./node_modules/object-keys/implementation.js":
-/*!****************************************************!*\
-  !*** ./node_modules/object-keys/implementation.js ***!
-  \****************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var keysShim;
-if (!Object.keys) {
-	// modified from https://github.com/es-shims/es5-shim
-	var has = Object.prototype.hasOwnProperty;
-	var toStr = Object.prototype.toString;
-	var isArgs = __webpack_require__(/*! ./isArguments */ "./node_modules/object-keys/isArguments.js"); // eslint-disable-line global-require
-	var isEnumerable = Object.prototype.propertyIsEnumerable;
-	var hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
-	var hasProtoEnumBug = isEnumerable.call(function () {}, 'prototype');
-	var dontEnums = [
-		'toString',
-		'toLocaleString',
-		'valueOf',
-		'hasOwnProperty',
-		'isPrototypeOf',
-		'propertyIsEnumerable',
-		'constructor'
-	];
-	var equalsConstructorPrototype = function (o) {
-		var ctor = o.constructor;
-		return ctor && ctor.prototype === o;
-	};
-	var excludedKeys = {
-		$applicationCache: true,
-		$console: true,
-		$external: true,
-		$frame: true,
-		$frameElement: true,
-		$frames: true,
-		$innerHeight: true,
-		$innerWidth: true,
-		$onmozfullscreenchange: true,
-		$onmozfullscreenerror: true,
-		$outerHeight: true,
-		$outerWidth: true,
-		$pageXOffset: true,
-		$pageYOffset: true,
-		$parent: true,
-		$scrollLeft: true,
-		$scrollTop: true,
-		$scrollX: true,
-		$scrollY: true,
-		$self: true,
-		$webkitIndexedDB: true,
-		$webkitStorageInfo: true,
-		$window: true
-	};
-	var hasAutomationEqualityBug = (function () {
-		/* global window */
-		if (typeof window === 'undefined') { return false; }
-		for (var k in window) {
-			try {
-				if (!excludedKeys['$' + k] && has.call(window, k) && window[k] !== null && typeof window[k] === 'object') {
-					try {
-						equalsConstructorPrototype(window[k]);
-					} catch (e) {
-						return true;
-					}
-				}
-			} catch (e) {
-				return true;
-			}
-		}
-		return false;
-	}());
-	var equalsConstructorPrototypeIfNotBuggy = function (o) {
-		/* global window */
-		if (typeof window === 'undefined' || !hasAutomationEqualityBug) {
-			return equalsConstructorPrototype(o);
-		}
-		try {
-			return equalsConstructorPrototype(o);
-		} catch (e) {
-			return false;
-		}
-	};
-
-	keysShim = function keys(object) {
-		var isObject = object !== null && typeof object === 'object';
-		var isFunction = toStr.call(object) === '[object Function]';
-		var isArguments = isArgs(object);
-		var isString = isObject && toStr.call(object) === '[object String]';
-		var theKeys = [];
-
-		if (!isObject && !isFunction && !isArguments) {
-			throw new TypeError('Object.keys called on a non-object');
-		}
-
-		var skipProto = hasProtoEnumBug && isFunction;
-		if (isString && object.length > 0 && !has.call(object, 0)) {
-			for (var i = 0; i < object.length; ++i) {
-				theKeys.push(String(i));
-			}
-		}
-
-		if (isArguments && object.length > 0) {
-			for (var j = 0; j < object.length; ++j) {
-				theKeys.push(String(j));
-			}
-		} else {
-			for (var name in object) {
-				if (!(skipProto && name === 'prototype') && has.call(object, name)) {
-					theKeys.push(String(name));
-				}
-			}
-		}
-
-		if (hasDontEnumBug) {
-			var skipConstructor = equalsConstructorPrototypeIfNotBuggy(object);
-
-			for (var k = 0; k < dontEnums.length; ++k) {
-				if (!(skipConstructor && dontEnums[k] === 'constructor') && has.call(object, dontEnums[k])) {
-					theKeys.push(dontEnums[k]);
-				}
-			}
-		}
-		return theKeys;
-	};
-}
-module.exports = keysShim;
-
-
-/***/ }),
-
-/***/ "./node_modules/object-keys/index.js":
-/*!*******************************************!*\
-  !*** ./node_modules/object-keys/index.js ***!
-  \*******************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var slice = Array.prototype.slice;
-var isArgs = __webpack_require__(/*! ./isArguments */ "./node_modules/object-keys/isArguments.js");
-
-var origKeys = Object.keys;
-var keysShim = origKeys ? function keys(o) { return origKeys(o); } : __webpack_require__(/*! ./implementation */ "./node_modules/object-keys/implementation.js");
-
-var originalKeys = Object.keys;
-
-keysShim.shim = function shimObjectKeys() {
-	if (Object.keys) {
-		var keysWorksWithArguments = (function () {
-			// Safari 5.0 bug
-			var args = Object.keys(arguments);
-			return args && args.length === arguments.length;
-		}(1, 2));
-		if (!keysWorksWithArguments) {
-			Object.keys = function keys(object) { // eslint-disable-line func-name-matching
-				if (isArgs(object)) {
-					return originalKeys(slice.call(object));
-				}
-				return originalKeys(object);
-			};
-		}
-	} else {
-		Object.keys = keysShim;
-	}
-	return Object.keys || keysShim;
-};
-
-module.exports = keysShim;
-
-
-/***/ }),
-
-/***/ "./node_modules/object-keys/isArguments.js":
-/*!*************************************************!*\
-  !*** ./node_modules/object-keys/isArguments.js ***!
-  \*************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var toStr = Object.prototype.toString;
-
-module.exports = function isArguments(value) {
-	var str = toStr.call(value);
-	var isArgs = str === '[object Arguments]';
-	if (!isArgs) {
-		isArgs = str !== '[object Array]' &&
-			value !== null &&
-			typeof value === 'object' &&
-			typeof value.length === 'number' &&
-			value.length >= 0 &&
-			toStr.call(value.callee) === '[object Function]';
-	}
-	return isArgs;
+module.exports = function normalizePath(str, stripTrailing) {
+  if (typeof str !== 'string') {
+    throw new TypeError('expected a string');
+  }
+  str = str.replace(/[\\\/]+/g, '/');
+  if (stripTrailing !== false) {
+    str = removeTrailingSeparator(str);
+  }
+  return str;
 };
 
 
@@ -12821,7 +17094,7 @@ module.exports = function pick(obj, keys) {
 
 
 
-var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/parse-glob/node_modules/is-glob/index.js");
+var isGlob = __webpack_require__(/*! is-glob */ "./node_modules/is-glob/index.js");
 var findBase = __webpack_require__(/*! glob-base */ "./node_modules/glob-base/index.js");
 var extglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
 var dotfile = __webpack_require__(/*! is-dotfile */ "./node_modules/is-dotfile/index.js");
@@ -12969,30 +17242,6 @@ function unescape(str) {
   return str;
 }
 
-
-/***/ }),
-
-/***/ "./node_modules/parse-glob/node_modules/is-glob/index.js":
-/*!***************************************************************!*\
-  !*** ./node_modules/parse-glob/node_modules/is-glob/index.js ***!
-  \***************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-/*!
- * is-glob <https://github.com/jonschlinkert/is-glob>
- *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
- */
-
-var isExtglob = __webpack_require__(/*! is-extglob */ "./node_modules/is-extglob/index.js");
-
-module.exports = function isGlob(str) {
-  return typeof str === 'string'
-    && (/[*!?{}(|)[\]]/.test(str)
-     || isExtglob(str));
-};
 
 /***/ }),
 
@@ -13269,27 +17518,19 @@ process.umask = function() { return 0; };
 var replace = String.prototype.replace;
 var percentTwenties = /%20/g;
 
-var util = __webpack_require__(/*! ./utils */ "./node_modules/qs/lib/utils.js");
-
-var Format = {
+module.exports = {
+    'default': 'RFC3986',
+    formatters: {
+        RFC1738: function (value) {
+            return replace.call(value, percentTwenties, '+');
+        },
+        RFC3986: function (value) {
+            return value;
+        }
+    },
     RFC1738: 'RFC1738',
     RFC3986: 'RFC3986'
 };
-
-module.exports = util.assign(
-    {
-        'default': Format.RFC3986,
-        formatters: {
-            RFC1738: function (value) {
-                return replace.call(value, percentTwenties, '+');
-            },
-            RFC3986: function (value) {
-                return String(value);
-            }
-        }
-    },
-    Format
-);
 
 
 /***/ }),
@@ -13399,11 +17640,11 @@ var parseValues = function parseQueryStringValues(str, options) {
 
         var key, val;
         if (pos === -1) {
-            key = options.decoder(part, defaults.decoder, charset, 'key');
+            key = options.decoder(part, defaults.decoder, charset);
             val = options.strictNullHandling ? null : '';
         } else {
-            key = options.decoder(part.slice(0, pos), defaults.decoder, charset, 'key');
-            val = options.decoder(part.slice(pos + 1), defaults.decoder, charset, 'value');
+            key = options.decoder(part.slice(0, pos), defaults.decoder, charset);
+            val = options.decoder(part.slice(pos + 1), defaults.decoder, charset);
         }
 
         if (val && options.interpretNumericEntities && charset === 'iso-8859-1') {
@@ -13474,7 +17715,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
 
     // Get the parent
 
-    var segment = options.depth > 0 && brackets.exec(key);
+    var segment = brackets.exec(key);
     var parent = segment ? key.slice(0, segment.index) : key;
 
     // Stash the parent if it exists
@@ -13494,7 +17735,7 @@ var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
     // Loop through children appending to the array until we hit depth
 
     var i = 0;
-    while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
+    while ((segment = child.exec(key)) !== null && i < options.depth) {
         i += 1;
         if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
             if (!options.allowPrototypes) {
@@ -13536,8 +17777,7 @@ var normalizeParseOptions = function normalizeParseOptions(opts) {
         comma: typeof opts.comma === 'boolean' ? opts.comma : defaults.comma,
         decoder: typeof opts.decoder === 'function' ? opts.decoder : defaults.decoder,
         delimiter: typeof opts.delimiter === 'string' || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
-        // eslint-disable-next-line no-implicit-coercion, no-extra-parens
-        depth: (typeof opts.depth === 'number' || opts.depth === false) ? +opts.depth : defaults.depth,
+        depth: typeof opts.depth === 'number' ? opts.depth : defaults.depth,
         ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
         interpretNumericEntities: typeof opts.interpretNumericEntities === 'boolean' ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
         parameterLimit: typeof opts.parameterLimit === 'number' ? opts.parameterLimit : defaults.parameterLimit,
@@ -13587,14 +17827,14 @@ var formats = __webpack_require__(/*! ./formats */ "./node_modules/qs/lib/format
 var has = Object.prototype.hasOwnProperty;
 
 var arrayPrefixGenerators = {
-    brackets: function brackets(prefix) {
+    brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
         return prefix + '[]';
     },
     comma: 'comma',
-    indices: function indices(prefix, key) {
+    indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
         return prefix + '[' + key + ']';
     },
-    repeat: function repeat(prefix) {
+    repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
         return prefix;
     }
 };
@@ -13607,7 +17847,6 @@ var pushToArray = function (arr, valueOrArray) {
 
 var toISO = Date.prototype.toISOString;
 
-var defaultFormat = formats['default'];
 var defaults = {
     addQueryPrefix: false,
     allowDots: false,
@@ -13617,26 +17856,17 @@ var defaults = {
     encode: true,
     encoder: utils.encode,
     encodeValuesOnly: false,
-    format: defaultFormat,
-    formatter: formats.formatters[defaultFormat],
+    formatter: formats.formatters[formats['default']],
     // deprecated
     indices: false,
-    serializeDate: function serializeDate(date) {
+    serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
         return toISO.call(date);
     },
     skipNulls: false,
     strictNullHandling: false
 };
 
-var isNonNullishPrimitive = function isNonNullishPrimitive(v) {
-    return typeof v === 'string'
-        || typeof v === 'number'
-        || typeof v === 'boolean'
-        || typeof v === 'symbol'
-        || typeof v === 'bigint';
-};
-
-var stringify = function stringify(
+var stringify = function stringify( // eslint-disable-line func-name-matching
     object,
     prefix,
     generateArrayPrefix,
@@ -13662,16 +17892,16 @@ var stringify = function stringify(
 
     if (obj === null) {
         if (strictNullHandling) {
-            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, 'key') : prefix;
+            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset) : prefix;
         }
 
         obj = '';
     }
 
-    if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
+    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || utils.isBuffer(obj)) {
         if (encoder) {
-            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, 'key');
-            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset, 'value'))];
+            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset);
+            return [formatter(keyValue) + '=' + formatter(encoder(obj, defaults.encoder, charset))];
         }
         return [formatter(prefix) + '=' + formatter(String(obj))];
     }
@@ -13999,12 +18229,7 @@ var encode = function encode(str, defaultEncoder, charset) {
         return str;
     }
 
-    var string = str;
-    if (typeof str === 'symbol') {
-        string = Symbol.prototype.toString.call(str);
-    } else if (typeof str !== 'string') {
-        string = String(str);
-    }
+    var string = typeof str === 'string' ? str : String(str);
 
     if (charset === 'iso-8859-1') {
         return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
@@ -14128,7 +18353,7 @@ module.exports = {
 
 
 var isNumber = __webpack_require__(/*! is-number */ "./node_modules/randomatic/node_modules/is-number/index.js");
-var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/kind-of/index.js");
+var typeOf = __webpack_require__(/*! kind-of */ "./node_modules/randomatic/node_modules/kind-of/index.js");
 var mathRandom = __webpack_require__(/*! math-random */ "./node_modules/math-random/browser.js");
 
 /**
@@ -14250,6 +18475,146 @@ module.exports = function isNumber(num) {
 
 /***/ }),
 
+/***/ "./node_modules/randomatic/node_modules/kind-of/index.js":
+/*!***************************************************************!*\
+  !*** ./node_modules/randomatic/node_modules/kind-of/index.js ***!
+  \***************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+var toString = Object.prototype.toString;
+
+module.exports = function kindOf(val) {
+  if (val === void 0) return 'undefined';
+  if (val === null) return 'null';
+
+  var type = typeof val;
+  if (type === 'boolean') return 'boolean';
+  if (type === 'string') return 'string';
+  if (type === 'number') return 'number';
+  if (type === 'symbol') return 'symbol';
+  if (type === 'function') {
+    return isGeneratorFn(val) ? 'generatorfunction' : 'function';
+  }
+
+  if (isArray(val)) return 'array';
+  if (isBuffer(val)) return 'buffer';
+  if (isArguments(val)) return 'arguments';
+  if (isDate(val)) return 'date';
+  if (isError(val)) return 'error';
+  if (isRegexp(val)) return 'regexp';
+
+  switch (ctorName(val)) {
+    case 'Symbol': return 'symbol';
+    case 'Promise': return 'promise';
+
+    // Set, Map, WeakSet, WeakMap
+    case 'WeakMap': return 'weakmap';
+    case 'WeakSet': return 'weakset';
+    case 'Map': return 'map';
+    case 'Set': return 'set';
+
+    // 8-bit typed arrays
+    case 'Int8Array': return 'int8array';
+    case 'Uint8Array': return 'uint8array';
+    case 'Uint8ClampedArray': return 'uint8clampedarray';
+
+    // 16-bit typed arrays
+    case 'Int16Array': return 'int16array';
+    case 'Uint16Array': return 'uint16array';
+
+    // 32-bit typed arrays
+    case 'Int32Array': return 'int32array';
+    case 'Uint32Array': return 'uint32array';
+    case 'Float32Array': return 'float32array';
+    case 'Float64Array': return 'float64array';
+  }
+
+  if (isGeneratorObj(val)) {
+    return 'generator';
+  }
+
+  // Non-plain objects
+  type = toString.call(val);
+  switch (type) {
+    case '[object Object]': return 'object';
+    // iterators
+    case '[object Map Iterator]': return 'mapiterator';
+    case '[object Set Iterator]': return 'setiterator';
+    case '[object String Iterator]': return 'stringiterator';
+    case '[object Array Iterator]': return 'arrayiterator';
+  }
+
+  // other
+  return type.slice(8, -1).toLowerCase().replace(/\s/g, '');
+};
+
+function ctorName(val) {
+  return val.constructor ? val.constructor.name : null;
+}
+
+function isArray(val) {
+  if (Array.isArray) return Array.isArray(val);
+  return val instanceof Array;
+}
+
+function isError(val) {
+  return val instanceof Error || (typeof val.message === 'string' && val.constructor && typeof val.constructor.stackTraceLimit === 'number');
+}
+
+function isDate(val) {
+  if (val instanceof Date) return true;
+  return typeof val.toDateString === 'function'
+    && typeof val.getDate === 'function'
+    && typeof val.setDate === 'function';
+}
+
+function isRegexp(val) {
+  if (val instanceof RegExp) return true;
+  return typeof val.flags === 'string'
+    && typeof val.ignoreCase === 'boolean'
+    && typeof val.multiline === 'boolean'
+    && typeof val.global === 'boolean';
+}
+
+function isGeneratorFn(name, val) {
+  return ctorName(name) === 'GeneratorFunction';
+}
+
+function isGeneratorObj(val) {
+  return typeof val.throw === 'function'
+    && typeof val.return === 'function'
+    && typeof val.next === 'function';
+}
+
+function isArguments(val) {
+  try {
+    if (typeof val.length === 'number' && typeof val.callee === 'function') {
+      return true;
+    }
+  } catch (err) {
+    if (err.message.indexOf('callee') !== -1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * If you need to support Safari 5-7 (8-10 yr-old browser),
+ * take a look at https://github.com/feross/is-buffer
+ */
+
+function isBuffer(val) {
+  if (val.constructor && typeof val.constructor.isBuffer === 'function') {
+    return val.constructor.isBuffer(val);
+  }
+  return false;
+}
+
+
+/***/ }),
+
 /***/ "./node_modules/regex-cache/index.js":
 /*!*******************************************!*\
   !*** ./node_modules/regex-cache/index.js ***!
@@ -14326,147 +18691,6 @@ function memo(key, opts, regex) {
 
 module.exports.cache = cache;
 module.exports.basic = basic;
-
-
-/***/ }),
-
-/***/ "./node_modules/regexp.prototype.flags/implementation.js":
-/*!***************************************************************!*\
-  !*** ./node_modules/regexp.prototype.flags/implementation.js ***!
-  \***************************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var toObject = Object;
-var TypeErr = TypeError;
-
-module.exports = function flags() {
-	if (this != null && this !== toObject(this)) {
-		throw new TypeErr('RegExp.prototype.flags getter called on non-object');
-	}
-	var result = '';
-	if (this.global) {
-		result += 'g';
-	}
-	if (this.ignoreCase) {
-		result += 'i';
-	}
-	if (this.multiline) {
-		result += 'm';
-	}
-	if (this.dotAll) {
-		result += 's';
-	}
-	if (this.unicode) {
-		result += 'u';
-	}
-	if (this.sticky) {
-		result += 'y';
-	}
-	return result;
-};
-
-
-/***/ }),
-
-/***/ "./node_modules/regexp.prototype.flags/index.js":
-/*!******************************************************!*\
-  !*** ./node_modules/regexp.prototype.flags/index.js ***!
-  \******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var define = __webpack_require__(/*! define-properties */ "./node_modules/define-properties/index.js");
-
-var implementation = __webpack_require__(/*! ./implementation */ "./node_modules/regexp.prototype.flags/implementation.js");
-var getPolyfill = __webpack_require__(/*! ./polyfill */ "./node_modules/regexp.prototype.flags/polyfill.js");
-var shim = __webpack_require__(/*! ./shim */ "./node_modules/regexp.prototype.flags/shim.js");
-
-var flagsBound = Function.call.bind(implementation);
-
-define(flagsBound, {
-	getPolyfill: getPolyfill,
-	implementation: implementation,
-	shim: shim
-});
-
-module.exports = flagsBound;
-
-
-/***/ }),
-
-/***/ "./node_modules/regexp.prototype.flags/polyfill.js":
-/*!*********************************************************!*\
-  !*** ./node_modules/regexp.prototype.flags/polyfill.js ***!
-  \*********************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var implementation = __webpack_require__(/*! ./implementation */ "./node_modules/regexp.prototype.flags/implementation.js");
-
-var supportsDescriptors = __webpack_require__(/*! define-properties */ "./node_modules/define-properties/index.js").supportsDescriptors;
-var gOPD = Object.getOwnPropertyDescriptor;
-var TypeErr = TypeError;
-
-module.exports = function getPolyfill() {
-	if (!supportsDescriptors) {
-		throw new TypeErr('RegExp.prototype.flags requires a true ES5 environment that supports property descriptors');
-	}
-	if (/a/mig.flags === 'gim') {
-		var descriptor = gOPD(RegExp.prototype, 'flags');
-		if (descriptor && typeof descriptor.get === 'function' && typeof (/a/).dotAll === 'boolean') {
-			return descriptor.get;
-		}
-	}
-	return implementation;
-};
-
-
-/***/ }),
-
-/***/ "./node_modules/regexp.prototype.flags/shim.js":
-/*!*****************************************************!*\
-  !*** ./node_modules/regexp.prototype.flags/shim.js ***!
-  \*****************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var supportsDescriptors = __webpack_require__(/*! define-properties */ "./node_modules/define-properties/index.js").supportsDescriptors;
-var getPolyfill = __webpack_require__(/*! ./polyfill */ "./node_modules/regexp.prototype.flags/polyfill.js");
-var gOPD = Object.getOwnPropertyDescriptor;
-var defineProperty = Object.defineProperty;
-var TypeErr = TypeError;
-var getProto = Object.getPrototypeOf;
-var regex = /a/;
-
-module.exports = function shimFlags() {
-	if (!supportsDescriptors || !getProto) {
-		throw new TypeErr('RegExp.prototype.flags requires a true ES5 environment that supports property descriptors');
-	}
-	var polyfill = getPolyfill();
-	var proto = getProto(regex);
-	var descriptor = gOPD(proto, 'flags');
-	if (!descriptor || descriptor.get !== polyfill) {
-		defineProperty(proto, 'flags', {
-			configurable: true,
-			enumerable: false,
-			get: polyfill
-		});
-	}
-	return polyfill;
-};
 
 
 /***/ }),
@@ -14781,7 +19005,7 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! @sfx/core */ "./packages/@sfx/core/dist/index.js"));
+__export(__webpack_require__(/*! @sfx/core */ "./packages/@sfx/core/src/index.ts"));
 
 
 /***/ }),
@@ -14799,11 +19023,11 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-__export(__webpack_require__(/*! @sfx/dom-events-plugin */ "./packages/@sfx/dom-events-plugin/dist/index.js"));
-__export(__webpack_require__(/*! @sfx/sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/dist/index.js"));
-__export(__webpack_require__(/*! @sfx/sayt-plugin */ "./packages/@sfx/sayt-plugin/dist/index.js"));
-__export(__webpack_require__(/*! @sfx/search-driver-plugin */ "./packages/@sfx/search-driver-plugin/dist/index.js"));
-__export(__webpack_require__(/*! @sfx/search-plugin */ "./packages/@sfx/search-plugin/dist/index.js"));
+__export(__webpack_require__(/*! @sfx/dom-events-plugin */ "./packages/@sfx/dom-events-plugin/src/index.ts"));
+__export(__webpack_require__(/*! @sfx/sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/src/index.ts"));
+__export(__webpack_require__(/*! @sfx/sayt-plugin */ "./packages/@sfx/sayt-plugin/src/index.ts"));
+__export(__webpack_require__(/*! @sfx/search-plugin */ "./packages/@sfx/search-plugin/src/index.ts"));
+__export(__webpack_require__(/*! @sfx/search-driver-plugin */ "./packages/@sfx/search-driver-plugin/src/index.ts"));
 
 
 /***/ }),
@@ -14839,18 +19063,17 @@ module.exports = g;
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/dist/core.js":
-/*!*****************************************!*\
-  !*** ./packages/@sfx/core/dist/core.js ***!
-  \*****************************************/
+/***/ "./packages/@sfx/core/src/core.ts":
+/*!****************************************!*\
+  !*** ./packages/@sfx/core/src/core.ts ***!
+  \****************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var core_1 = __webpack_require__(/*! ./utils/core */ "./packages/@sfx/core/dist/utils/core.js");
-var dependencies_1 = __webpack_require__(/*! ./utils/dependencies */ "./packages/@sfx/core/dist/utils/dependencies.js");
+var core_1 = __webpack_require__(/*! ./utils/core */ "./packages/@sfx/core/src/utils/core.ts");
 /**
  * The core of the SF-X plugin system. This entity is responsible for
  * managing plugins and provides a mechanism for plugins to communicate
@@ -14874,12 +19097,6 @@ var Core = /** @class */ (function () {
          * Plugins do not have access to this directory.
          */
         this.directory = Object.create(null);
-        /**
-         * An object with plugin names mapped to the names of the plugins that
-         * depend on it. This dependency graph is represented as an adjacency
-         * list.
-         */
-        this.dependencyGraph = dependencies_1.createDependencyGraph();
     }
     /**
      * Register one or more plugins with Core.
@@ -14909,76 +19126,53 @@ var Core = /** @class */ (function () {
     Core.prototype.register = function (plugins) {
         var missingDependencies = core_1.calculateMissingDependencies(plugins, this.registry);
         if (missingDependencies.length) {
-            throw new Error("Missing dependencies: " + missingDependencies.join(', '));
+            throw new Error('Missing dependencies: ' + missingDependencies.join(', '));
         }
         core_1.registerPlugins(plugins, this.registry, this.directory);
-        this.dependencyGraph = dependencies_1.mergeDependencyGraphs(this.dependencyGraph, dependencies_1.createDependencyGraph(plugins));
         core_1.initPlugins(plugins);
         core_1.readyPlugins(plugins);
     };
     /**
-     * Unregisters the given plugins. The plugin registry, directory and
-     * dependency graph are all updated. The optional `unregister`
-     * function of each plugin is called when the plugin is unregistered.
-     * The order in which the plugins are unregistered is unspecified.
-     *
-     * @param plugins The names of the plugins to unregister.
-     * @throws If unregistering a plugin will break a dependency.
-     */
-    Core.prototype.unregister = function (plugins) {
-        var updatedGraph = dependencies_1.removeFromDependencyGraph(this.dependencyGraph, plugins);
-        core_1.unregisterPlugins(plugins, this.registry, this.directory);
-        this.dependencyGraph = updatedGraph;
-    };
-    /**
-     * Unregisters all plugins. The plugin registry, directory and
-     * dependency graph are all cleared. The optional `unregister`
-     * function of each plugin is called when the plugin is unregistered.
-     * The order in which the plugins are unregistered is unspecified.
+     * Unregisters all plugins. The plugin registry and directory are both
+     * cleared. The optional `unregister` function of each plugin is
+     * called when the plugin is unregistered. The order in which the
+     * plugins are unregistered is unspecified.
      */
     Core.prototype.unregisterAll = function () {
         core_1.unregisterPlugins(Object.keys(this.directory), this.registry, this.directory);
-        this.dependencyGraph = dependencies_1.createDependencyGraph();
     };
     return Core;
 }());
 exports.default = Core;
-//# sourceMappingURL=core.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/dist/index.js":
-/*!******************************************!*\
-  !*** ./packages/@sfx/core/dist/index.js ***!
-  \******************************************/
+/***/ "./packages/@sfx/core/src/index.ts":
+/*!*****************************************!*\
+  !*** ./packages/@sfx/core/src/index.ts ***!
+  \*****************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var core_1 = __webpack_require__(/*! ./core */ "./packages/@sfx/core/dist/core.js");
+var core_1 = __webpack_require__(/*! ./core */ "./packages/@sfx/core/src/core.ts");
 exports.Core = core_1.default;
-//# sourceMappingURL=index.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/dist/utils/core.js":
-/*!***********************************************!*\
-  !*** ./packages/@sfx/core/dist/utils/core.js ***!
-  \***********************************************/
+/***/ "./packages/@sfx/core/src/utils/core.ts":
+/*!**********************************************!*\
+  !*** ./packages/@sfx/core/src/utils/core.ts ***!
+  \**********************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var __spreadArrays = (this && this.__spreadArrays) || function () {
-    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
-    for (var r = Array(s), k = 0, i = 0; i < il; i++)
-        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
-            r[k] = a[j];
-    return r;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * Calculates the missing dependencies of the given plugins. The given
@@ -14990,11 +19184,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * @returns An array of names of missing plugins.
  */
 function calculateMissingDependencies(plugins, registry) {
-    var available = __spreadArrays(Object.keys(registry), plugins.map(function (_a) {
+    var available = Object.keys(registry).concat(plugins.map(function (_a) {
         var name = _a.metadata.name;
         return name;
     }));
-    var required = plugins.reduce(function (memo, plugin) { return __spreadArrays(memo, plugin.metadata.depends); }, []);
+    var required = plugins.reduce(function (memo, plugin) {
+        return memo.concat(plugin.metadata.depends);
+    }, []);
     var availableSet = new Set(available);
     var requiredSet = new Set(required);
     var difference = new Set(Array.from(requiredSet).filter(function (p) { return !availableSet.has(p); }));
@@ -15053,8 +19249,7 @@ function readyPlugins(plugins) {
 exports.readyPlugins = readyPlugins;
 /**
  * Unregisters the plugins with the given names from the given registry
- * and directory. It is safe to attempt to unregister a plugin that is
- * not registered.
+ * and directory.
  *
  * @param names The names of the plugins to unregister.
  * @param registry The registry from which to unregister the plugin's
@@ -15064,7 +19259,7 @@ exports.readyPlugins = readyPlugins;
 function unregisterPlugins(names, registry, directory) {
     names.forEach(function (name) {
         var plugin = directory[name];
-        if (plugin && typeof plugin.unregister === 'function') {
+        if (typeof plugin.unregister === 'function') {
             plugin.unregister();
         }
     });
@@ -15074,110 +19269,14 @@ function unregisterPlugins(names, registry, directory) {
     });
 }
 exports.unregisterPlugins = unregisterPlugins;
-//# sourceMappingURL=core.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/core/dist/utils/dependencies.js":
-/*!*******************************************************!*\
-  !*** ./packages/@sfx/core/dist/utils/dependencies.js ***!
-  \*******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * Creates an empty dependency graph.
- *
- * @returns An empty dependency graph.
- * @hidden
- */
-function createEmptyGraph() {
-    return Object.create(null);
-}
-/**
- * Builds a dependency graph from the given plugins.
- *
- * @param plugins The plugins from which to build the graph.
- * @returns The completed dependency graph.
- */
-function createDependencyGraph(plugins) {
-    if (plugins === void 0) { plugins = []; }
-    var dependencyGraph = createEmptyGraph();
-    plugins.forEach(function (_a) {
-        var _b = _a.metadata, name = _b.name, depends = _b.depends;
-        if (!dependencyGraph[name])
-            dependencyGraph[name] = [];
-        depends.forEach(function (dependency) {
-            if (!dependencyGraph[dependency])
-                dependencyGraph[dependency] = [];
-            dependencyGraph[dependency].push(name);
-        });
-    });
-    return dependencyGraph;
-}
-exports.createDependencyGraph = createDependencyGraph;
-/**
- * Deeply merges the given dependency graphs without modifying the
- * original graphs. When a property exists in more than one graph, the
- * corresponding arrays are concatenated.
- *
- * @param graphs The dependency graphs to merge.
- * @returns The merged dependency graph.
- */
-function mergeDependencyGraphs() {
-    var graphs = [];
-    for (var _i = 0; _i < arguments.length; _i++) {
-        graphs[_i] = arguments[_i];
-    }
-    return graphs.reduce(function (merged, graph) {
-        Object.keys(graph).forEach(function (key) {
-            var _a;
-            if (!merged[key])
-                merged[key] = [];
-            (_a = merged[key]).push.apply(_a, graph[key]);
-        });
-        return merged;
-    }, createEmptyGraph());
-}
-exports.mergeDependencyGraphs = mergeDependencyGraphs;
-/**
- * Removes the specified names from the given dependency graph. The
- * corresponding properties are deleted and the dependency lists are
- * updated. The original graph is not modified. It is safe to attempt to
- * remove a name that is not in the graph.
- *
- * @param graph The graph to remove plugins from.
- * @param names The names of the plugins to remove from the graph.
- * @returns The resulting graph with the given names removed.
- * @throws If one or more names cannot be removed from the graph without
- *         breaking a dependency.
- */
-function removeFromDependencyGraph(graph, names) {
-    var namesSet = new Set(names);
-    var newGraph = Object.keys(graph).reduce(function (clone, plugin) {
-        clone[plugin] = graph[plugin].filter(function (depender) { return !namesSet.has(depender); });
-        return clone;
-    }, createEmptyGraph());
-    var errors = names
-        .filter(function (name) { return newGraph[name] && newGraph[name].length > 0; })
-        .map(function (name) { return name + " is required by: " + newGraph[name].join(', ') + "."; });
-    if (errors.length > 0)
-        throw new Error("Failed to remove dependencies.\n" + errors.join('\n'));
-    names.forEach(function (name) { delete newGraph[name]; });
-    return newGraph;
-}
-exports.removeFromDependencyGraph = removeFromDependencyGraph;
-//# sourceMappingURL=dependencies.js.map
-
-/***/ }),
-
-/***/ "./packages/@sfx/dom-events-plugin/dist/dom-events-plugin.js":
-/*!*******************************************************************!*\
-  !*** ./packages/@sfx/dom-events-plugin/dist/dom-events-plugin.js ***!
-  \*******************************************************************/
+/***/ "./packages/@sfx/dom-events-plugin/src/dom-events-plugin.ts":
+/*!******************************************************************!*\
+  !*** ./packages/@sfx/dom-events-plugin/src/dom-events-plugin.ts ***!
+  \******************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -15220,7 +19319,7 @@ var DomEventsPlugin = /** @class */ (function () {
             window: typeof window !== 'undefined' ? window : undefined,
             CustomEvent: typeof CustomEvent !== 'undefined' ? CustomEvent : undefined,
         };
-        this.options = __assign(__assign({}, this.options), options);
+        this.options = __assign({}, this.options, options);
         this.window = this.options.window;
         this.CustomEvent = this.options.CustomEvent;
         if (!this.window) {
@@ -15275,7 +19374,6 @@ var DomEventsPlugin = /** @class */ (function () {
     /**
      * @see [[DomEventsPluginExposedValue.dispatchEvent]]
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     DomEventsPlugin.prototype.dispatchEvent = function (eventName, payload) {
         var eventToDispatch = new this.CustomEvent(eventName, { detail: payload });
         this.window.dispatchEvent(eventToDispatch);
@@ -15283,13 +19381,29 @@ var DomEventsPlugin = /** @class */ (function () {
     return DomEventsPlugin;
 }());
 exports.default = DomEventsPlugin;
-//# sourceMappingURL=dom-events-plugin.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/dom-events-plugin/dist/index.js":
+/***/ "./packages/@sfx/dom-events-plugin/src/index.ts":
+/*!******************************************************!*\
+  !*** ./packages/@sfx/dom-events-plugin/src/index.ts ***!
+  \******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+var dom_events_plugin_1 = __webpack_require__(/*! ./dom-events-plugin */ "./packages/@sfx/dom-events-plugin/src/dom-events-plugin.ts");
+exports.DomEventsPlugin = dom_events_plugin_1.default;
+
+
+/***/ }),
+
+/***/ "./packages/@sfx/sayt-driver-plugin/src/index.ts":
 /*!*******************************************************!*\
-  !*** ./packages/@sfx/dom-events-plugin/dist/index.js ***!
+  !*** ./packages/@sfx/sayt-driver-plugin/src/index.ts ***!
   \*******************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
@@ -15297,51 +19411,33 @@ exports.default = DomEventsPlugin;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-var dom_events_plugin_1 = __webpack_require__(/*! ./dom-events-plugin */ "./packages/@sfx/dom-events-plugin/dist/dom-events-plugin.js");
-exports.DomEventsPlugin = dom_events_plugin_1.default;
-//# sourceMappingURL=index.js.map
-
-/***/ }),
-
-/***/ "./packages/@sfx/sayt-driver-plugin/dist/index.js":
-/*!********************************************************!*\
-  !*** ./packages/@sfx/sayt-driver-plugin/dist/index.js ***!
-  \********************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-// eslint-disable-next-line import/prefer-default-export
-var sayt_driver_plugin_1 = __webpack_require__(/*! ./sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/dist/sayt-driver-plugin.js");
+var sayt_driver_plugin_1 = __webpack_require__(/*! ./sayt-driver-plugin */ "./packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts");
 exports.SaytDriverPlugin = sayt_driver_plugin_1.default;
-//# sourceMappingURL=index.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-driver-plugin/dist/sayt-driver-plugin.js":
-/*!*********************************************************************!*\
-  !*** ./packages/@sfx/sayt-driver-plugin/dist/sayt-driver-plugin.js ***!
-  \*********************************************************************/
+/***/ "./packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts":
+/*!********************************************************************!*\
+  !*** ./packages/@sfx/sayt-driver-plugin/src/sayt-driver-plugin.ts ***!
+  \********************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
         }
-        return t;
-    };
-    return __assign.apply(this, arguments);
+    return t;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-var events_1 = __webpack_require__(/*! @sfx/events */ "../sfx-events/dist/index.js");
 /**
  * Driver plugin that serves as the link between the Sayt data source
  * and the View layer. This plugin is responsible for listening to events,
@@ -15349,35 +19445,25 @@ var events_1 = __webpack_require__(/*! @sfx/events */ "../sfx-events/dist/index.
  * and then emitting the API response back in an event.
  */
 var SaytDriverPlugin = /** @class */ (function () {
-    /**
-     * Binds relevant functions. Sets transformProduct property if a
-     * product transformer function is passed.
-     */
-    function SaytDriverPlugin(options) {
+    function SaytDriverPlugin() {
         /**
          * Name of the events plugin.
          */
         this.eventsPluginName = 'dom_events';
         /**
-         * Provide default configuration for SAYT product searches.
+         * Event name to listen for Sayt autocomplete requests.
          */
-        this.defaultSearchConfig = {
-            fields: ['*'],
-        };
+        this.saytDataEvent = 'sfx::autocomplete_fetch_data';
         /**
-         * Default product transformer identity function.
-         * Intended to be overwritten by passing a custom product transformer.
-         *
-         * @param product The product to be returned as-is.
+         * Event name for sending Sayt autocomplete responses.
          */
-        this.transformProduct = (function (product) { return product; });
-        this.fetchAutocompleteTerms = this.fetchAutocompleteTerms.bind(this);
-        this.fetchProductData = this.fetchProductData.bind(this);
+        this.saytResponseEvent = 'sfx::autocomplete_received_results';
+        /**
+         * Event name to listen for Sayt autocomplete errors.
+         */
+        this.saytErrorEvent = 'sfx::autocomplete_sayt_error';
+        this.fetchSaytData = this.fetchSaytData.bind(this);
         this.autocompleteCallback = this.autocompleteCallback.bind(this);
-        this.searchCallback = this.searchCallback.bind(this);
-        if (options && options.productTransformer) {
-            this.transformProduct = options.productTransformer;
-        }
     }
     Object.defineProperty(SaytDriverPlugin.prototype, "metadata", {
         get: function () {
@@ -15386,7 +19472,6 @@ var SaytDriverPlugin = /** @class */ (function () {
                 depends: [
                     this.eventsPluginName,
                     'sayt',
-                    'search',
                 ],
             };
         },
@@ -15404,84 +19489,49 @@ var SaytDriverPlugin = /** @class */ (function () {
     };
     /**
      * Lifecycle event where the plugin can first safely interact with the registry.
-     * The method will register an event listener for Sayt and product data requests.
+     * The method will register an event listener for listening to Sayt data requests
+     * and trigger its callback for making search requests.
      */
     SaytDriverPlugin.prototype.ready = function () {
-        this.core[this.eventsPluginName].registerListener(events_1.AUTOCOMPLETE_REQUEST, this.fetchAutocompleteTerms);
-        this.core[this.eventsPluginName].registerListener(events_1.SAYT_PRODUCTS_REQUEST, this.fetchProductData);
+        this.core[this.eventsPluginName].registerListener(this.saytDataEvent, this.fetchSaytData);
     };
     /**
      * Lifecycle event where the plugin will unregister all event listeners.
      */
     SaytDriverPlugin.prototype.unregister = function () {
-        this.core[this.eventsPluginName].unregisterListener(events_1.AUTOCOMPLETE_REQUEST, this.fetchAutocompleteTerms);
-        this.core[this.eventsPluginName].unregisterListener(events_1.SAYT_PRODUCTS_REQUEST, this.fetchProductData);
+        this.core[this.eventsPluginName].unregisterListener(this.saytDataEvent, this.fetchSaytData);
     };
     /**
-     * Sends a request to the Sayt API for autocomplete terms and dispatches
-     * events on success and failure.
+     * Dispatches an event with the response from the sayt data plugin.
+     * Callback for the Sayt data request event listener.
      *
      * @param event Event that contains the Sayt API request payload.
      */
-    SaytDriverPlugin.prototype.fetchAutocompleteTerms = function (event) {
+    SaytDriverPlugin.prototype.fetchSaytData = function (event) {
         var _this = this;
-        var _a = event.detail, query = _a.query, group = _a.group, config = _a.config;
-        this.sendAutocompleteApiRequest(query, config)
-            .then(function (results) {
-            var payload = { results: results, group: group };
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.AUTOCOMPLETE_RESPONSE, payload);
+        this.sendSaytApiRequest(event.detail)
+            .then(function (data) {
+            _this.core[_this.eventsPluginName].dispatchEvent(_this.saytResponseEvent, data);
         })
-            .catch(function (error) {
-            var payload = { error: error, group: group };
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.AUTOCOMPLETE_ERROR, payload);
-        });
-    };
-    /**
-     * Sends a request to the Search API for product data and dispatches
-     * events on success and failure.
-     *
-     * @param event Event that contains the Search API request payload.
-     */
-    SaytDriverPlugin.prototype.fetchProductData = function (event) {
-        var _this = this;
-        var _a = event.detail, query = _a.query, group = _a.group, config = _a.config;
-        this.sendSearchApiRequest(query, config)
-            .then(function (results) {
-            var payload = __assign(__assign({}, results), { group: group });
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SAYT_PRODUCTS_RESPONSE, payload);
-        })
-            .catch(function (error) {
-            var payload = { error: error, group: group };
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SAYT_PRODUCTS_ERROR, payload);
+            .catch(function (e) {
+            _this.core[_this.eventsPluginName].dispatchEvent(_this.saytErrorEvent, e);
         });
     };
     /**
      * Sends a request to the SAYT API with the given query and config object.
      *
-     * @param query The search term to send.
-     * @param config Extra query-time configuration to customize the SAYT request.
+     * @param saytDataQuery Request object received from the event listener.
      * @returns A promise from the Sayt API that has been reformatted
      * with the passed callback.
      */
-    SaytDriverPlugin.prototype.sendAutocompleteApiRequest = function (query, config) {
+    SaytDriverPlugin.prototype.sendSaytApiRequest = function (_a) {
+        var query = _a.query, config = __rest(_a, ["query"]);
         return this.core.sayt.autocomplete(query, config).then(this.autocompleteCallback);
-    };
-    /**
-     * Sends a request to the Search API with the given query and config object.
-     *
-     * @param query The search term to send.
-     * @param config Extra query-time configuration to customize the Search request.
-     * @returns A promise from the Search API that has been reformatted
-     * with the passed callback.
-     */
-    SaytDriverPlugin.prototype.sendSearchApiRequest = function (query, config) {
-        return this.core.search.search(__assign(__assign(__assign({}, this.defaultSearchConfig), { query: query }), config))
-            .then(this.searchCallback);
     };
     /**
      * Extracts search terms from the given response.
      *
-     * @param response An array of search term strings.
+     * @param response An array search term strings.
      * @returns An array of search term strings.
      */
     SaytDriverPlugin.prototype.autocompleteCallback = function (response) {
@@ -15494,24 +19544,6 @@ var SaytDriverPlugin = /** @class */ (function () {
         return [searchTerms];
     };
     /**
-     * Extracts query and products from the given response.
-     * Calls `this.transformProduct` on each product found in the response.
-     * Filters out any products that map to a falsy value.
-     *
-     * @param response An object containing the original search response.
-     * @returns An object containing an array of valid simplified products and the original response.
-     */
-    SaytDriverPlugin.prototype.searchCallback = function (searchResponse) {
-        var records = searchResponse.records;
-        var mappedRecords = records
-            .map(this.transformProduct)
-            .filter(Boolean);
-        return {
-            products: mappedRecords,
-            originalResponse: searchResponse,
-        };
-    };
-    /**
      * Formats a given list of search terms.
      *
      * @param terms An array of search terms.
@@ -15519,19 +19551,21 @@ var SaytDriverPlugin = /** @class */ (function () {
      */
     SaytDriverPlugin.prototype.constructSearchTerms = function (terms) {
         return terms.filter(function (term) { return term.value; })
-            .map(function (term) { return ({ label: term.value }); });
+            .map(function (term) {
+            return { label: term.value };
+        });
     };
     return SaytDriverPlugin;
 }());
 exports.default = SaytDriverPlugin;
-//# sourceMappingURL=sayt-driver-plugin.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-plugin/dist/index.js":
-/*!*************************************************!*\
-  !*** ./packages/@sfx/sayt-plugin/dist/index.js ***!
-  \*************************************************/
+/***/ "./packages/@sfx/sayt-plugin/src/index.ts":
+/*!************************************************!*\
+  !*** ./packages/@sfx/sayt-plugin/src/index.ts ***!
+  \************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -15541,17 +19575,17 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-var sayt_plugin_1 = __webpack_require__(/*! ./sayt-plugin */ "./packages/@sfx/sayt-plugin/dist/sayt-plugin.js");
+var sayt_plugin_1 = __webpack_require__(/*! ./sayt-plugin */ "./packages/@sfx/sayt-plugin/src/sayt-plugin.ts");
 exports.SaytPlugin = sayt_plugin_1.default;
 __export(__webpack_require__(/*! sayt */ "./node_modules/sayt/index.js"));
-//# sourceMappingURL=index.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/sayt-plugin/dist/sayt-plugin.js":
-/*!*******************************************************!*\
-  !*** ./packages/@sfx/sayt-plugin/dist/sayt-plugin.js ***!
-  \*******************************************************/
+/***/ "./packages/@sfx/sayt-plugin/src/sayt-plugin.ts":
+/*!******************************************************!*\
+  !*** ./packages/@sfx/sayt-plugin/src/sayt-plugin.ts ***!
+  \******************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -15592,13 +19626,13 @@ var SaytPlugin = /** @class */ (function () {
     return SaytPlugin;
 }());
 exports.default = SaytPlugin;
-//# sourceMappingURL=sayt-plugin.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-driver-plugin/dist/index.js":
+/***/ "./packages/@sfx/search-driver-plugin/src/events.ts":
 /*!**********************************************************!*\
-  !*** ./packages/@sfx/search-driver-plugin/dist/index.js ***!
+  !*** ./packages/@sfx/search-driver-plugin/src/events.ts ***!
   \**********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
@@ -15606,35 +19640,50 @@ exports.default = SaytPlugin;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-// eslint-disable-next-line import/prefer-default-export
-var search_driver_plugin_1 = __webpack_require__(/*! ./search-driver-plugin */ "./packages/@sfx/search-driver-plugin/dist/search-driver-plugin.js");
-exports.SearchDriverPlugin = search_driver_plugin_1.default;
-//# sourceMappingURL=index.js.map
+/**
+ * Fired to request a search. Its payload is the search term to use.
+ */
+exports.SEARCH_REQUEST_EVENT = 'sfx::search_request';
+/**
+ * Fired when a search response has been received from the server.
+ * The payload is the search response.
+ */
+exports.SEARCH_RESPONSE_EVENT = 'sfx::search_response';
+/**
+ * Fired when an error has occurred during a search request.
+ */
+exports.SEARCH_ERROR_EVENT = 'sfx::search_error';
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-driver-plugin/dist/search-driver-plugin.js":
-/*!*************************************************************************!*\
-  !*** ./packages/@sfx/search-driver-plugin/dist/search-driver-plugin.js ***!
-  \*************************************************************************/
+/***/ "./packages/@sfx/search-driver-plugin/src/index.ts":
+/*!*********************************************************!*\
+  !*** ./packages/@sfx/search-driver-plugin/src/index.ts ***!
+  \*********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var events_1 = __webpack_require__(/*! @sfx/events */ "../sfx-events/dist/index.js");
+var search_driver_plugin_1 = __webpack_require__(/*! ./search-driver-plugin */ "./packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts");
+exports.SearchDriverPlugin = search_driver_plugin_1.default;
+
+
+/***/ }),
+
+/***/ "./packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts":
+/*!************************************************************************!*\
+  !*** ./packages/@sfx/search-driver-plugin/src/search-driver-plugin.ts ***!
+  \************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+var events_1 = __webpack_require__(/*! ./events */ "./packages/@sfx/search-driver-plugin/src/events.ts");
 /**
  * This plugin is responsible for exposing events that allow
  * for interacting with GroupBy's Search API.
@@ -15644,29 +19693,12 @@ var SearchDriverPlugin = /** @class */ (function () {
      * Constructs a new instance of the plugin and binds the necessary
      * callbacks.
      */
-    function SearchDriverPlugin(options) {
+    function SearchDriverPlugin() {
         /**
          * Name of the events plugin.
          */
         this.eventsPluginName = 'dom_events';
-        /**
-         * Default configuration for all searches.
-         */
-        this.defaultSearchConfig = {
-            fields: ['*'],
-        };
-        /**
-         * Default product transformer identity function.
-         * Intended to be overwritten by passing a custom product transformer.
-         *
-         * @param product The product to be returned as-is.
-         */
-        this.transformProduct = (function (product) { return product; });
         this.fetchSearchData = this.fetchSearchData.bind(this);
-        this.searchCallback = this.searchCallback.bind(this);
-        if (options && options.productTransformer) {
-            this.transformProduct = options.productTransformer;
-        }
     }
     Object.defineProperty(SearchDriverPlugin.prototype, "metadata", {
         get: function () {
@@ -15690,36 +19722,34 @@ var SearchDriverPlugin = /** @class */ (function () {
     /**
      * Registers event listeners. The following events are listened for:
      *
-     * - [[SEARCH_REQUEST]]
+     * - [[SEARCH_REQUEST_EVENT]]
      */
     SearchDriverPlugin.prototype.ready = function () {
-        this.core[this.eventsPluginName].registerListener(events_1.SEARCH_REQUEST, this.fetchSearchData);
+        this.core[this.eventsPluginName].registerListener(events_1.SEARCH_REQUEST_EVENT, this.fetchSearchData);
     };
     /**
      * Unregisters event listeners.
      */
     SearchDriverPlugin.prototype.unregister = function () {
-        this.core[this.eventsPluginName].unregisterListener(events_1.SEARCH_REQUEST, this.fetchSearchData);
+        this.core[this.eventsPluginName].unregisterListener(events_1.SEARCH_REQUEST_EVENT, this.fetchSearchData);
     };
     /**
      * Performs a search with the given search term and emits the result
      * through an event. The result is emitted in a
-     * [[SEARCH_RESPONSE]] event. If the search fails for any
-     * reason, a [[SEARCH_ERROR]] is dispatched with the error.
+     * [[SEARCH_RESPONSE_EVENT]] event. If the search fails for any
+     * reason, a [[SEARCH_ERROR_EVENT]] is dispatched with the error.
      *
      * @param event the event whose payload is the search term.
      */
     SearchDriverPlugin.prototype.fetchSearchData = function (event) {
         var _this = this;
-        var _a = event.detail, query = _a.query, group = _a.group;
-        this.sendSearchApiRequest(query)
+        var searchTerm = event.detail;
+        this.sendSearchApiRequest(searchTerm)
             .then(function (results) {
-            var payload = { results: results, group: group };
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_RESPONSE, payload);
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_RESPONSE_EVENT, results);
         })
-            .catch(function (error) {
-            var payload = { error: error, group: group };
-            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_ERROR, payload);
+            .catch(function (e) {
+            _this.core[_this.eventsPluginName].dispatchEvent(events_1.SEARCH_ERROR_EVENT, e);
         });
     };
     /**
@@ -15728,39 +19758,19 @@ var SearchDriverPlugin = /** @class */ (function () {
      * @param query the query to send.
      */
     SearchDriverPlugin.prototype.sendSearchApiRequest = function (query) {
-        var fullQuery = __assign(__assign({}, this.defaultSearchConfig), { query: query });
-        return this.core.search.search(fullQuery)
-            .then(this.searchCallback);
-    };
-    /**
-     * Extracts query and products from the given response.
-     * Calls `this.transformProduct` on each product found in the response.
-     * Filters out any products that map to a falsy value.
-     *
-     * @param response An object containing the original query and product records.
-     * @returns An object containing the query and an array of valid simplified products.
-     */
-    SearchDriverPlugin.prototype.searchCallback = function (response) {
-        var records = response.records;
-        var mappedRecords = records
-            .map(this.transformProduct)
-            .filter(Boolean);
-        return {
-            originalResponse: response,
-            products: mappedRecords,
-        };
+        return this.core.search.search(query);
     };
     return SearchDriverPlugin;
 }());
 exports.default = SearchDriverPlugin;
-//# sourceMappingURL=search-driver-plugin.js.map
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-plugin/dist/index.js":
-/*!***************************************************!*\
-  !*** ./packages/@sfx/search-plugin/dist/index.js ***!
-  \***************************************************/
+/***/ "./packages/@sfx/search-plugin/src/index.ts":
+/*!**************************************************!*\
+  !*** ./packages/@sfx/search-plugin/src/index.ts ***!
+  \**************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -15770,17 +19780,17 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-var search_plugin_1 = __webpack_require__(/*! ./search-plugin */ "./packages/@sfx/search-plugin/dist/search-plugin.js");
+var search_plugin_1 = __webpack_require__(/*! ./search-plugin */ "./packages/@sfx/search-plugin/src/search-plugin.ts");
 exports.SearchPlugin = search_plugin_1.default;
-__export(__webpack_require__(/*! groupby-api */ "./node_modules/groupby-api/dist/index.js"));
-//# sourceMappingURL=index.js.map
+__export(__webpack_require__(/*! groupby-api */ "../../api-javascript/dist/index.js"));
+
 
 /***/ }),
 
-/***/ "./packages/@sfx/search-plugin/dist/search-plugin.js":
-/*!***********************************************************!*\
-  !*** ./packages/@sfx/search-plugin/dist/search-plugin.js ***!
-  \***********************************************************/
+/***/ "./packages/@sfx/search-plugin/src/search-plugin.ts":
+/*!**********************************************************!*\
+  !*** ./packages/@sfx/search-plugin/src/search-plugin.ts ***!
+  \**********************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -15798,7 +19808,7 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-var groupby_api_1 = __webpack_require__(/*! groupby-api */ "./node_modules/groupby-api/dist/index.js");
+var groupby_api_1 = __webpack_require__(/*! groupby-api */ "../../api-javascript/dist/index.js");
 /**
  * This plugin exposes an instance of the GroupBy search client.
  */
@@ -15836,7 +19846,7 @@ var SearchPlugin = /** @class */ (function () {
     return SearchPlugin;
 }());
 exports.default = SearchPlugin;
-//# sourceMappingURL=search-plugin.js.map
+
 
 /***/ }),
 

--- a/packages/web-components/@sfx/autocomplete/package.json
+++ b/packages/web-components/@sfx/autocomplete/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@sfx/events": "groupby/sfx-events#6cc0210443a350182313f97e5d6862e551a4c26d",
+    "@sfx/events": "groupby/sfx-events#c4a4853a424992db9c170fea6990dc2a52c3061e",
     "lit-element": "^2.2.0"
   }
 }

--- a/packages/web-components/@sfx/product/package.json
+++ b/packages/web-components/@sfx/product/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@sfx/events": "groupby/sfx-events#6cc0210443a350182313f97e5d6862e551a4c26d",
+    "@sfx/events": "groupby/sfx-events#c4a4853a424992db9c170fea6990dc2a52c3061e",
     "lit-element": "^2.2.0"
   }
 }

--- a/packages/web-components/@sfx/product/src/product.ts
+++ b/packages/web-components/@sfx/product/src/product.ts
@@ -2,10 +2,10 @@ import {
   customElement,
   property,
   html,
+  LitElement,
   TemplateResult,
 } from 'lit-element';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-import { Base } from '@sfx/base';
 import {
   Product as ProductModel,
   ProductVariant,

--- a/packages/web-components/@sfx/product/src/product.ts
+++ b/packages/web-components/@sfx/product/src/product.ts
@@ -16,7 +16,7 @@ import { toLowerCaseKebab } from './utils';
  * A product component that consumes product data to display.
  */
 @customElement('sfx-product')
-export default class Product extends Base {
+export default class Product extends LitElement {
   /** The product data. */
   @property({ type: Object }) product: ProductModel = {};
 
@@ -117,5 +117,9 @@ export default class Product extends Base {
       </slot>
       ${this.additionalInfo()}
     `;
+  }
+
+  createRenderRoot() {
+    return this;
   }
 }

--- a/packages/web-components/@sfx/product/src/product.ts
+++ b/packages/web-components/@sfx/product/src/product.ts
@@ -119,7 +119,7 @@ export default class Product extends LitElement {
     `;
   }
 
-  createRenderRoot() {
+  createRenderRoot(): Element|ShadowRoot {
     return this;
   }
 }

--- a/packages/web-components/@sfx/product/test/unit/product.test.ts
+++ b/packages/web-components/@sfx/product/test/unit/product.test.ts
@@ -14,10 +14,6 @@ describe('Product Component', () => {
   });
 
   describe('constructor', () => {
-    it('should extend the Base class', () => {
-      expect(component).to.be.an.instanceof(Base);
-    });
-
     describe('product property', () => {
       it('should have a default empty product object', () => {
         expect(component.product).to.deep.equal({});

--- a/packages/web-components/@sfx/products/package.json
+++ b/packages/web-components/@sfx/products/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@sfx/events": "groupby/sfx-events#6cc0210443a350182313f97e5d6862e551a4c26d",
+    "@sfx/events": "groupby/sfx-events#c4a4853a424992db9c170fea6990dc2a52c3061e",
     "lit-element": "^2.2.0"
   }
 }

--- a/packages/web-components/@sfx/products/src/products-sayt.ts
+++ b/packages/web-components/@sfx/products/src/products-sayt.ts
@@ -1,6 +1,7 @@
 import { css, CSSResult, customElement } from 'lit-element';
 import {
   SAYT_PRODUCTS_RESPONSE,
+  Product,
   SaytProductsResponsePayload,
 } from '@sfx/events';
 import { ProductsBase } from '.';
@@ -46,7 +47,7 @@ export default class ProductsSayt extends ProductsBase {
    *
    * @param event An event containing a search result with product data.
    */
-  setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload<any>>): void {
+  setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload<Product>>): void {
     const eventGroup = event.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup === componentGroup) {

--- a/packages/web-components/@sfx/products/src/products-sayt.ts
+++ b/packages/web-components/@sfx/products/src/products-sayt.ts
@@ -46,7 +46,7 @@ export default class ProductsSayt extends ProductsBase {
    *
    * @param event An event containing a search result with product data.
    */
-  setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload>): void {
+  setProductsFromEvent(event: CustomEvent<SaytProductsResponsePayload<any>>): void {
     const eventGroup = event.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup === componentGroup) {

--- a/packages/web-components/@sfx/products/src/products-search.ts
+++ b/packages/web-components/@sfx/products/src/products-search.ts
@@ -28,7 +28,6 @@ export default class ProductsSearch extends ProductsBase {
    */
   connectedCallback(): void {
     super.connectedCallback();
-
     window.addEventListener(SEARCH_RESPONSE, this.setProductsFromEvent);
   }
 
@@ -46,11 +45,11 @@ export default class ProductsSearch extends ProductsBase {
    *
    * @param event An event containing a search result with product data.
    */
-  setProductsFromEvent(event: CustomEvent<SearchResponsePayload>): void {
+  setProductsFromEvent(event: CustomEvent<SearchResponsePayload<any>>): void {
     const eventGroup = event.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup === componentGroup) {
-      this.products = event.detail.results.records || [];
+      this.products = event.detail.results.products || [];
     }
   }
 

--- a/packages/web-components/@sfx/products/src/products-search.ts
+++ b/packages/web-components/@sfx/products/src/products-search.ts
@@ -1,6 +1,7 @@
 import { css, CSSResult, customElement } from 'lit-element';
 import {
   SEARCH_RESPONSE,
+  Product,
   SearchResponsePayload,
 } from '@sfx/events';
 import { ProductsBase } from '.';
@@ -45,7 +46,7 @@ export default class ProductsSearch extends ProductsBase {
    *
    * @param event An event containing a search result with product data.
    */
-  setProductsFromEvent(event: CustomEvent<SearchResponsePayload<any>>): void {
+  setProductsFromEvent(event: CustomEvent<SearchResponsePayload<Product>>): void {
     const eventGroup = event.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup === componentGroup) {

--- a/packages/web-components/@sfx/products/test/unit/products.test.ts
+++ b/packages/web-components/@sfx/products/test/unit/products.test.ts
@@ -193,11 +193,11 @@ describe('Products Search Component', () => {
   });
 
   describe('setProductsFromEvent', () => {
-    let records;
+    let products;
     let group;
 
     beforeEach(() => {
-      records = [1, 2, 3];
+      products = [1, 2, 3];
       group = 'group';
     });
 
@@ -209,16 +209,16 @@ describe('Products Search Component', () => {
     });
 
     it('should set products when the event matches the group in the component', () => {
-      const event = { detail: { results: { records }, group } };
+      const event = { detail: { results: { products }, group } };
       component.group = group;
 
       component.setProductsFromEvent(event);
 
-      expect(component.products).to.equal(records);
+      expect(component.products).to.equal(products);
     });
 
     it('should not set products when the group in the component and event do not match', () => {
-      const event = { detail: { results: { records }, group } };
+      const event = { detail: { results: { products }, group } };
 
       component.setProductsFromEvent(event);
 
@@ -226,20 +226,20 @@ describe('Products Search Component', () => {
     });
 
     it('should default the group in the event to an empty string if it is falsey', () => {
-      const event = { detail: { results: { records } } };
+      const event = { detail: { results: { products } } };
 
       component.setProductsFromEvent(event);
 
-      expect(component.products).to.equal(records);
+      expect(component.products).to.equal(products);
     });
 
     it('should default the group in the component to an empty string if it is falsey', () => {
       component.group = undefined;
-      const event = { detail: { results: { records } } };
+      const event = { detail: { results: { products } } };
 
       component.setProductsFromEvent(event);
 
-      expect(component.products).to.equal(records);
+      expect(component.products).to.equal(products);
     });
   });
 });

--- a/packages/web-components/@sfx/sayt/package.json
+++ b/packages/web-components/@sfx/sayt/package.json
@@ -28,7 +28,7 @@
     "html-entities": "^1.2.1"
   },
   "dependencies": {
-    "@sfx/events": "groupby/sfx-events#6cc0210443a350182313f97e5d6862e551a4c26d",
+    "@sfx/events": "groupby/sfx-events#c4a4853a424992db9c170fea6990dc2a52c3061e",
     "@types/debounce": "^1.2.0",
     "debounce": "^1.2.0",
     "lit-element": "^2.2.0"

--- a/packages/web-components/@sfx/search-box/package.json
+++ b/packages/web-components/@sfx/search-box/package.json
@@ -28,7 +28,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@sfx/events": "groupby/sfx-events#6cc0210443a350182313f97e5d6862e551a4c26d",
+    "@sfx/events": "groupby/sfx-events#c4a4853a424992db9c170fea6990dc2a52c3061e",
     "lit-element": "^2.2.0"
   }
 }

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -1,6 +1,7 @@
 import {
   customElement,
   html,
+  LitElement,
   property,
   TemplateResult,
 } from 'lit-element';
@@ -25,7 +26,7 @@ import {
  * The entity also listens for events, and updates data accordingly.
  */
 @customElement('sfx-search-box')
-export default class SearchBox extends Base {
+export default class SearchBox extends LitElement {
   /**
    * Text used as placeholder in search box.
    */
@@ -231,5 +232,9 @@ export default class SearchBox extends Base {
           `
     : ''}
     `;
+  }
+
+  createRenderRoot() {
+    return this;
   }
 }

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -6,7 +6,6 @@ import {
   TemplateResult,
 } from 'lit-element';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-import { Base } from '@sfx/base';
 import {
   SEARCHBOX_CLEAR,
   SEARCHBOX_CLICK,

--- a/packages/web-components/@sfx/search-box/src/search-box.ts
+++ b/packages/web-components/@sfx/search-box/src/search-box.ts
@@ -233,7 +233,7 @@ export default class SearchBox extends LitElement {
     `;
   }
 
-  createRenderRoot() {
+  createRenderRoot(): Element|ShadowRoot {
     return this;
   }
 }

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -25,10 +25,6 @@ describe('SearchBox Component', () => {
   });
 
   describe('Constructor', () => {
-    it('should extend Base', () => {
-      expect(searchbox).to.be.an.instanceof(Base);
-    });
-
     describe('placeholder property', () => {
       it('should have default value `Type your search`', () => {
         expect(searchbox.placeholder).to.equal('Type your search');

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -1,6 +1,5 @@
 import { TemplateResult } from 'lit-element';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-import { Base } from '@sfx/base';
 import {
   SEARCHBOX_CLEAR,
   SEARCHBOX_CLICK,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5688,7 +5688,7 @@ http-errors@~1.7.2:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
   integrity sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
 
-http-proxy-middleware@0.19.1:
+http-proxy-middleware@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
   integrity sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
@@ -8611,6 +8611,13 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+raf@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
@@ -8779,7 +8786,7 @@ react-hotkeys@2.0.0-pre4:
   dependencies:
     prop-types "^15.6.1"
 
-react-input-autosize@^2.2.2:
+react-input-autosize@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
   integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,9 +781,9 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@sfx/events@groupby/sfx-events#6cc0210443a350182313f97e5d6862e551a4c26d":
+"@sfx/events@groupby/sfx-events#c4a4853a424992db9c170fea6990dc2a52c3061e":
   version "0.0.0"
-  resolved "https://codeload.github.com/groupby/sfx-events/tar.gz/6cc0210443a350182313f97e5d6862e551a4c26d"
+  resolved "https://codeload.github.com/groupby/sfx-events/tar.gz/c4a4853a424992db9c170fea6990dc2a52c3061e"
   dependencies:
     groupby-api "^2.6.2"
     sayt "^0.1.9"


### PR DESCRIPTION
This PR primarily updates the demo to define functions for transforming the product for Search and Sayt, much as the client would have to do. The transformer for Apparel, previously hardcoded in the Logic Layer, is now defined in `demo.html`.

Note that the product transformer for Search is intentionally simple. It will display only product titles.

Additionally:
* Update Product and Searchbox components to extend `LitElement` instead of `Base`. This removes issues with multiple renders/updates of components (artifacts from previous renders remain in the DOM).
* Add event listeners for events in the demo file. This is intentional. It is easier to demonstrate functionality, and to debug issues, if we can see events being logged to the console.