### PR TITLE
Add eslintrc to test directories

### DIFF
--- a/packages/web-components/@sfx/autocomplete/test/.eslintrc.js
+++ b/packages/web-components/@sfx/autocomplete/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/web-components/@sfx/base/test/.eslintrc.js
+++ b/packages/web-components/@sfx/base/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/web-components/@sfx/product/test/.eslintrc.js
+++ b/packages/web-components/@sfx/product/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/web-components/@sfx/products/test/.eslintrc.js
+++ b/packages/web-components/@sfx/products/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/web-components/@sfx/sayt/test/.eslintrc.js
+++ b/packages/web-components/@sfx/sayt/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/web-components/@sfx/search-box/test/.eslintrc.js
+++ b/packages/web-components/@sfx/search-box/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;

--- a/packages/web-components/@sfx/ui/test/.eslintrc.js
+++ b/packages/web-components/@sfx/ui/test/.eslintrc.js
@@ -1,0 +1,3 @@
+const eslint = require('../../../../../scripts/config/eslint/test/.eslintrc.js');
+
+module.exports = eslint;


### PR DESCRIPTION
This makes local tools use the test-specific eslint settings while working with the tests.