### PR TITLE
SFX-426: Clear SAYT requests for products if SAYT is hidden

### DIFF
--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -207,7 +207,7 @@ export default class Sayt extends LitElement {
   }
 
   /**
-   * Changes the `visible` property to `false`.
+   * Changes the [[visible]] property to `false`.
    * This will clear debounced calls for SAYT products. 
    */
   hideSayt(): void {

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -208,7 +208,7 @@ export default class Sayt extends LitElement {
 
   /**
    * Changes the [[visible]] property to `false`.
-   * This will clear debounced calls for SAYT products. 
+   * This will also clear pending calls for SAYT products.
    */
   hideSayt(): void {
     this.visible = false;

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -211,6 +211,8 @@ export default class Sayt extends LitElement {
    */
   hideSayt(): void {
     this.visible = false;
+    this.debouncedRequestSaytProducts.clear();
+    this.visible = false;
   }
 
   /**

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -188,7 +188,7 @@ export default class Sayt extends LitElement {
   }
 
   /**
-   * Changes the `visible` property to `true`.
+   * Changes the [[visible]] property to `true`.
    */
   showSayt(): void {
     this.visible = true;

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -208,11 +208,11 @@ export default class Sayt extends LitElement {
 
   /**
    * Changes the `visible` property to `false`.
+   * This will clear debounced calls for SAYT products. 
    */
   hideSayt(): void {
     this.visible = false;
     this.debouncedRequestSaytProducts.clear();
-    this.visible = false;
   }
 
   /**

--- a/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
@@ -254,6 +254,14 @@ describe('Sayt Component', () => {
 
       expect(sayt.visible).to.be.false;
     });
+
+    it('should clear all requests for SAYT products', () => {
+      const debouncedRequestSaytProductsClear = stub(sayt.debouncedRequestSaytProducts, 'clear');
+
+      sayt.hideSayt();
+
+      expect(debouncedRequestSaytProductsClear).to.be.called;
+    });
   });
 
   describe('hideCorrectSayt()', () => {


### PR DESCRIPTION
`debouncedRequestSaytProducts()` should be cleared after a user wilfully exits/hides the SAYT window. 