### PR TITLE
SFX-378: Accept area and collection in SAYT component

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -3,8 +3,8 @@
   <head>
     <title>Demo of Logic and View Integration</title>
     <script src="../dist/components.js"></script>
-    <!-- <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script> -->
-    <script src="./temp/sfx-all-plugins-bundle.js"></script>
+    <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script>
+    <!-- <script src="./temp/sfx-all-plugins-bundle.js"></script> -->
   </head>
 
   <body>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -42,7 +42,7 @@
 
         return {
           title: data.title,
-          price: nonvisualVariants[0].originalPrice,
+          price: nonvisualVariants[0].retailPrice,
           imageSrc: firstVariant.productImage,
           imageAlt: data.title,
           productUrl: firstVariant.productImage,

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -3,13 +3,13 @@
   <head>
     <title>Demo of Logic and View Integration</title>
     <script src="../dist/components.js"></script>
-    <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script>
-    <!-- <script src="./temp/sfx-all-plugins-bundle.js"></script> -->
+    <!-- <script src="https://cdn.groupbycloud.com/sfx-all-plugins-bundle.js"></script> -->
+    <script src="./temp/sfx-all-plugins-bundle.js"></script>
   </head>
 
   <body>
     <sfx-search-box id="main-search" placeholder="search" clearbutton searchbutton></sfx-search-box>
-    <sfx-sayt searchbox="main-search"></sfx-sayt>
+    <sfx-sayt searchbox="main-search" area="DemoMaster" collection="products"></sfx-sayt>
 
     <sfx-search-box id="secondary-search" group="secondary" placeholder="search" clearbutton searchbutton></sfx-search-box>
     <sfx-sayt searchbox="secondary-search" group="secondary"></sfx-sayt>

--- a/packages/web-components/@sfx/sayt/README.md
+++ b/packages/web-components/@sfx/sayt/README.md
@@ -62,6 +62,8 @@ particular customizations:
 - `minSearchLength`: The minimum length of the search term required before a SAYT request will be made with it.
 - `searchbox`: Optional ID of the searchbox paired with this component.
 - `group`: Optional attribute to add the `sayt` component to a grouping of related search components. The component will only act on events if they contain the same group name as the component.
+- `area`: The area to use in product searches.
+- `collection`: The collection to use in autocomplete and product searches.
 
 ## Testing
 

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -76,12 +76,12 @@ export default class Sayt extends LitElement {
   @property({ type: Number, reflect: true }) debounce = 300;
 
   /**
-   * Determines the area used for products searches.
+   * The area to use in product searches.
    */
   @property({ type: String, reflect: true }) area: string = '';
 
   /**
-   * Determines the collection used for products and autocomplete searches.
+   * The collection to use for autocomplete and product searches.
    */
   @property({ type: String, reflect: true }) collection: string = '';
 

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -76,6 +76,16 @@ export default class Sayt extends LitElement {
   @property({ type: Number, reflect: true }) debounce = 300;
 
   /**
+   * Determines the area used for products searches.
+   */
+  @property({ type: String, reflect: true }) area: string = '';
+
+  /**
+   * Determines the collection used for products and autocomplete searches.
+   */
+  @property({ type: String, reflect: true }) collection: string = '';
+
+  /**
    * A debounced version of [[requestSaytProducts]].
    * The delay is configured through the [[debounce]] property.
    */
@@ -263,7 +273,14 @@ export default class Sayt extends LitElement {
    */
   dispatchRequestEvent(eventType: string, query: string): void {
     const requestEvent = new CustomEvent(eventType, {
-      detail: { query, group: this.group },
+      detail: {
+        query,
+        group: this.group,
+        config: {
+          area: this.area,
+          collection: this.collection,
+        },
+      },
       bubbles: true,
     });
     this.dispatchEvent(requestEvent);

--- a/packages/web-components/@sfx/sayt/src/sayt.ts
+++ b/packages/web-components/@sfx/sayt/src/sayt.ts
@@ -81,7 +81,7 @@ export default class Sayt extends LitElement {
   @property({ type: String, reflect: true }) area: string = '';
 
   /**
-   * The collection to use for autocomplete and product searches.
+   * The collection to use in autocomplete and product searches.
    */
   @property({ type: String, reflect: true }) collection: string = '';
 

--- a/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
@@ -50,9 +50,45 @@ describe('Sayt Component', () => {
       });
     });
 
+    describe('visible property', () => {
+      it('should have default value of false', () => {
+        expect(sayt.visible).to.be.false;
+      });
+    });
+
+    describe('searchbox property', () => {
+      it('should have default value of an empty string', () => {
+        expect(sayt.searchbox).to.equal('');
+      });
+    });
+
     describe('group property', () => {
       it('should have default value of an empty string', () => {
         expect(sayt.group).to.equal('');
+      });
+    });
+
+    describe('closeText property', () => {
+      it('should have default value of Close', () => {
+        expect(sayt.closeText).to.equal('Close');
+      });
+    });
+
+    describe('showCloseButton property', () => {
+      it('should have default value of false', () => {
+        expect(sayt.showCloseButton).to.be.false;
+      });
+    });
+
+    describe('minSearchLength property', () => {
+      it('should have default value of 3', () => {
+        expect(sayt.minSearchLength).to.equal(3);
+      });
+    });
+
+    describe('debounce property', () => {
+      it('should have default value of 300', () => {
+        expect(sayt.debounce).to.equal(300);
       });
     });
 

--- a/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@sfx/sayt/test/unit/sayt.test.ts
@@ -55,6 +55,18 @@ describe('Sayt Component', () => {
         expect(sayt.group).to.equal('');
       });
     });
+
+    describe('area property', () => {
+      it('should have default value of an empty string', () => {
+        expect(sayt.area).to.equal('');
+      });
+    });
+
+    describe('collection property', () => {
+      it('should have default value of an empty string', () => {
+        expect(sayt.collection).to.equal('');
+      });
+    });
   });
 
   describe('connectedCallback()', () => {
@@ -372,9 +384,11 @@ describe('Sayt Component', () => {
   });
 
   describe('dispatchRequestEvent()', () => {
-    it('should dispatch an event with a payload that includes the query and the group property', () => {
+    it('should dispatch an event with a payload that includes the query, the group property, and config', () => {
       const eventName = 'some-event-name';
       const group = sayt.group = 'some-group-name';
+      const area = sayt.area = 'some-area';
+      const collection = sayt.collection = 'some-collection';
       const query = 'some-query';
       const eventObj = { a: 'a' };
       const customEvent = stub(window, 'CustomEvent').returns(eventObj);
@@ -383,7 +397,14 @@ describe('Sayt Component', () => {
       sayt.dispatchRequestEvent(eventName, query);
 
       expect(customEvent).to.be.calledWith(eventName, {
-        detail: { query, group },
+        detail: {
+          query,
+          group,
+          config: {
+            area,
+            collection,
+          },
+        },
         bubbles: true,
       });
       expect(dispatchEvent).to.be.calledWith(eventObj);

--- a/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@sfx/search-box/test/unit/search-box.test.ts
@@ -48,6 +48,18 @@ describe('SearchBox Component', () => {
       });
     });
 
+    describe('area property', () => {
+      it('should have default value of an empty string', () => {
+        expect(searchbox.area).to.equal('');
+      });
+    });
+
+    describe('collection property', () => {
+      it('should have default value of an empty string', () => {
+        expect(searchbox.collection).to.equal('');
+      });
+    });
+
     describe('group property', () => {
       it('should have default value of an empty string', () => {
         expect(searchbox.group).to.equal('');


### PR DESCRIPTION
`area` and `collection` are now configurable as properties on the SAYT component. Their values are sent with autocomplete and products requests when they are made.